### PR TITLE
stable 0.1.x Correct the cargo version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -34,16 +34,16 @@ serde = { version = "^1.0.180", features = ["derive"] }
 serde_json = "^1.0.96"
 tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
-himmelblau_unix_common = { version = "^0.1.0", path = "src/common" }
-kanidm_unix_common = { version = "^0.1.0", path = "src/glue" }
-msal = { version = "^0.1.0", path = "src/msal" }
+himmelblau_unix_common = { path = "src/common" }
+kanidm_unix_common = { path = "src/glue" }
+msal = { path = "src/msal" }
 clap = { version = "^3.2", features = ["derive", "env"] }
 reqwest = { version = "^0.11.18", features = ["json"] }
 anyhow = "^1.0.71"
 tokio = { version = "^1.28.1", features = ["rt", "macros", "sync", "time", "net", "io-util", "signal"] }
 tokio-util = { version = "^0.7.8", features = ["codec"] }
 async-trait = "^0.1.72"
-himmelblau_policies = { version = "^0.1.0", path = "src/policies" }
+himmelblau_policies = { path = "src/policies" }
 
 # Kanidm deps
 argon2 = { version = "0.5.1", features = ["alloc"] }
@@ -59,7 +59,7 @@ url = "^2.4.0"
 urlencoding = "2.1.3"
 uuid = "^1.4.1"
 webauthn-rs-proto = "0.4.8"
-kanidm_proto = { path = "./src/proto", version = "^0.1.0" }
+kanidm_proto = { path = "./src/proto" }
 openssl-sys = "^0.9"
 openssl = "^0.10.55"
 rand = "^0.8.5"

--- a/src/nss/src/lib.rs
+++ b/src/nss/src/lib.rs
@@ -19,6 +19,3 @@ extern crate lazy_static;
 
 #[cfg(target_family = "unix")]
 mod implementation;
-
-#[cfg(target_family = "unix")]
-pub use implementation::*;


### PR DESCRIPTION
This corrects the version number in the cargo.toml.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
