### PR TITLE
Always force MFA when enrolling the device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-msal = { version = "0.1.12", features = ["tpm"] }
+msal = { version = "0.1.13", features = ["tpm"] }
 graph = { path = "src/graph" }
 clap = { version = "^3.2", features = ["derive", "env"] }
 clap_complete = "^4.4.1"


### PR DESCRIPTION
Otherwise the device will not hold an MFA claim.
Also attempt MFA later if username/password
fails with MFA request.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
