### PR TITLE
Windows Hello PIN implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-msal = { version = "0.1.15" }
+msal = { version = "0.1.16" }
 graph = { path = "src/graph" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"
@@ -101,5 +101,5 @@ opentelemetry-stdout = { version = "0.1.0", features = [
 ] }
 tonic = "0.11.0"
 tracing-opentelemetry = "0.21.0"
-compact_jwt = { version = "0.3.5", features = ["hsm-crypto", "msextensions"] }
-kanidm-hsm-crypto = { version = "^0.1.6", features = ["msextensions"] }
+compact_jwt = { version = "0.4.0-dev", features = ["hsm-crypto", "msextensions"] }
+kanidm-hsm-crypto = { version = "^0.2.0", features = ["msextensions"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -77,7 +77,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.31.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.2.0" }
+kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.3.0" }
 kanidm_utils_users = { path = "./src/kanidm/libs/users" }
 walkdir = "2"
 csv = "1.2.2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,8 +6,8 @@
 #
 ########################################################################
 
-# default is 7, 8's ok. https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
-too-many-arguments-threshold = 8
+# default is 7, 9's ok. https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
+too-many-arguments-threshold = 9
 
 # default's 250
 type-complexity-threshold = 300

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -632,13 +632,23 @@ impl IdProvider for HimmelblauProvider {
 
                 match self.token_validate(account_id, &token).await {
                     Ok(AuthResult::Success { token }) => {
+                        debug!("Returning user token from successful Hello PIN setup and authentication.");
                         Ok((AuthResult::Success { token }, AuthCacheAction::None))
                     }
                     /* This should never happen. It doesn't make sense to
                      * continue from a Pin auth. */
-                    Ok(AuthResult::Next(_)) => Err(IdpError::BadRequest),
-                    Ok(auth_result) => Ok((auth_result, AuthCacheAction::None)),
-                    Err(e) => Err(e),
+                    Ok(AuthResult::Next(_)) => {
+                        debug!("Invalid additional authentication requested with Hello auth.");
+                        Err(IdpError::BadRequest)
+                    }
+                    Ok(auth_result) => {
+                        debug!("Hello auth failed.");
+                        Ok((auth_result, AuthCacheAction::None))
+                    }
+                    Err(e) => {
+                        error!("Error encountered during Hello auth: {:?}", e);
+                        Err(e)
+                    }
                 }
             }
             (AuthCredHandler::Pin, PamAuthRequest::Pin { cred }) => {
@@ -674,13 +684,23 @@ impl IdProvider for HimmelblauProvider {
 
                 match self.token_validate(account_id, &token).await {
                     Ok(AuthResult::Success { token }) => {
+                        debug!("Returning user token from successful Hello PIN authentication.");
                         Ok((AuthResult::Success { token }, AuthCacheAction::None))
                     }
                     /* This should never happen. It doesn't make sense to
                      * continue from a Pin auth. */
-                    Ok(AuthResult::Next(_)) => Err(IdpError::BadRequest),
-                    Ok(auth_result) => Ok((auth_result, AuthCacheAction::None)),
-                    Err(e) => Err(e),
+                    Ok(AuthResult::Next(_)) => {
+                        debug!("Invalid additional authentication requested with Hello auth.");
+                        Err(IdpError::BadRequest)
+                    }
+                    Ok(auth_result) => {
+                        debug!("Hello auth failed.");
+                        Ok((auth_result, AuthCacheAction::None))
+                    }
+                    Err(e) => {
+                        error!("Error encountered during Hello auth: {:?}", e);
+                        Err(e)
+                    }
                 }
             }
             (AuthCredHandler::Password, PamAuthRequest::Password { cred }) => {
@@ -988,7 +1008,10 @@ impl IdProvider for HimmelblauProvider {
                     Err(e) => Err(e),
                 }
             }
-            _ => Err(IdpError::NotFound),
+            _ => {
+                error!("Unexpected AuthCredHandler and PamAuthRequest pairing");
+                Err(IdpError::NotFound)
+            }
         }
     }
 

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -1,1 +1,35 @@
-../kanidm/proto/Cargo.toml
+[package]
+name = "kanidm_proto"
+description = "Kanidm Protocol Bindings for serde"
+documentation = "https://docs.rs/kanidm_proto/latest/kanidm_proto/"
+
+version = { workspace = true }
+authors = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+test = true
+doctest = true
+
+[features]
+wasm = ["webauthn-rs-proto/wasm"]
+
+[dependencies]
+base32 = { workspace = true }
+base64urlsafedata = { workspace = true }
+num_enum = { workspace = true }
+scim_proto = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+time = { workspace = true, features = ["serde", "std"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+urlencoding = { workspace = true }
+utoipa = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }
+webauthn-rs-proto = { workspace = true }


### PR DESCRIPTION
This causes Himmelblau to enroll the
authenticating user in Windows Hello for Pin
authentication. It uses the msal rust library
to associate the user chosen Pin with a rsa key,
which is then enrolled in Windows Hello.
This eliminates the problem with MFA prompts at
the lock screen (which didn't work). The user now
treats the Pin code as a local password.

Fixes #

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
