### PR TITLE
Fix fallback DAG deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -37,7 +37,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-msal = { version = "0.1.16" }
+msal = { version = "0.1.18" }
 graph = { path = "src/graph" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"
@@ -77,7 +77,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.31.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.3.0" }
+kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.3.1" }
 kanidm_utils_users = { path = "./src/kanidm/libs/users" }
 walkdir = "2"
 csv = "1.2.2"


### PR DESCRIPTION
The DAG request isn't polling properly, and needs
patches to Kanidm. Disable DAG for now until this
is fixed.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
