### PR TITLE
Fallback to SFA first if MFA fails Browse files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-msal = { version = "0.1.18" }
+msal = { version = "0.1.19" }
 graph = { path = "src/graph" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"


### PR DESCRIPTION
If MFA fails, first check to see if this is
because the user doesn't require MFA. Then
continue to fallback to DAG if necessary.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
