### PR TITLE
Update the base64urlsafedata version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ zeroize = "^1.7.0"
 argon2 = { version = "0.5.2", features = ["alloc"] }
 base32 = "^0.4.0"
 base64 = "^0.22.0"
-base64urlsafedata = "0.1.3"
+base64urlsafedata = "0.5.0"
 hex = "^0.4.3"
 num_enum = "^0.7.2"
 scim_proto = "^0.2.1"


### PR DESCRIPTION
This requires updating Kanidm also, to match
the new dependency version.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
