### PR TITLE
Fix Bug #113

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-msal = { version = "0.1.20" }
+msal = { version = "0.1.21" }
 graph = { path = "src/graph" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -18,7 +18,9 @@ use msal::auth::{
     DeviceAuthorizationResponse as msal_DeviceAuthorizationResponse, EnrollAttrs, IdToken,
     MFAAuthContinue, UserToken as UnixUserToken,
 };
-use msal::error::{MsalError, AUTH_PENDING, NO_CONSENT, NO_GROUP_CONSENT, REQUIRES_MFA};
+use msal::error::{
+    MsalError, AUTH_PENDING, DEVICE_AUTH_FAIL, NO_CONSENT, NO_GROUP_CONSENT, REQUIRES_MFA,
+};
 use reqwest;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -559,6 +561,67 @@ impl IdProvider for HimmelblauProvider {
         machine_key: &tpm::MachineKey,
         shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError> {
+        macro_rules! enroll_and_obtain_enrolled_token {
+            ($token:ident) => {{
+                if !self.is_domain_joined(keystore).await {
+                    debug!("Device is not enrolled. Enrolling now.");
+                    self.join_domain(tpm, &$token, keystore, machine_key)
+                        .await
+                        .map_err(|e| {
+                            error!("Failed to join domain: {:?}", e);
+                            IdpError::BadRequest
+                        })?;
+                }
+                let mtoken2 = self
+                    .client
+                    .write()
+                    .await
+                    .acquire_token_by_refresh_token(
+                        &$token.refresh_token,
+                        vec![],
+                        None,
+                        tpm,
+                        machine_key,
+                    )
+                    .await;
+                match mtoken2 {
+                    Ok(token) => token,
+                    Err(e) => {
+                        error!("{:?}", e);
+                        match e {
+                            MsalError::AcquireTokenFailed(err_resp) => {
+                                if err_resp.error_codes.contains(&DEVICE_AUTH_FAIL) {
+                                    /* A device authentication failure may happen
+                                     * if Azure hasn't finished replicating the new
+                                     * device object. Wait 5 seconds and try again. */
+                                    info!("Azure hasn't finished replicating the device...");
+                                    info!("Retrying in 5 seconds");
+                                    sleep(Duration::from_secs(5));
+                                    self.client
+                                        .write()
+                                        .await
+                                        .acquire_token_by_refresh_token(
+                                            &$token.refresh_token,
+                                            vec![],
+                                            None,
+                                            tpm,
+                                            machine_key,
+                                        )
+                                        .await
+                                        .map_err(|e| {
+                                            error!("{:?}", e);
+                                            IdpError::NotFound
+                                        })?
+                                } else {
+                                    return Err(IdpError::NotFound);
+                                }
+                            }
+                            _ => return Err(IdpError::NotFound),
+                        }
+                    }
+                }
+            }};
+        }
         let mut shutdown_rx_cl = shutdown_rx.resubscribe();
         match (&cred_handler, pam_next_req) {
             (AuthCredHandler::MFA { data }, PamAuthRequest::SetupPin { pin }) => {
@@ -753,31 +816,7 @@ impl IdProvider for HimmelblauProvider {
                                 }
                             }
                         };
-                        if !self.is_domain_joined(keystore).await {
-                            debug!("Device is not enrolled for {}. Enrolling now.", account_id);
-                            self.join_domain(tpm, &token, keystore, machine_key)
-                                .await
-                                .map_err(|e| {
-                                    error!("Failed to join domain: {:?}", e);
-                                    IdpError::BadRequest
-                                })?;
-                        }
-                        let token2 = self
-                            .client
-                            .write()
-                            .await
-                            .acquire_token_by_refresh_token(
-                                &token.refresh_token,
-                                vec![],
-                                None,
-                                tpm,
-                                machine_key,
-                            )
-                            .await
-                            .map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::NotFound
-                            })?;
+                        let token2 = enroll_and_obtain_enrolled_token!(token);
                         return match self.token_validate(account_id, &token2).await {
                             Ok(AuthResult::Success { token }) => {
                                 // STOP! If we just enrolled with an SFA token, then we
@@ -860,31 +899,7 @@ impl IdProvider for HimmelblauProvider {
                     error!("{:?}", e);
                     IdpError::NotFound
                 })?;
-                if !self.is_domain_joined(keystore).await {
-                    debug!("Device is not enrolled for {}. Enrolling now.", account_id);
-                    self.join_domain(tpm, &token, keystore, machine_key)
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to join domain: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
-                }
-                let token2 = self
-                    .client
-                    .write()
-                    .await
-                    .acquire_token_by_refresh_token(
-                        &token.refresh_token,
-                        vec![],
-                        None,
-                        tpm,
-                        machine_key,
-                    )
-                    .await
-                    .map_err(|e| {
-                        error!("{:?}", e);
-                        IdpError::NotFound
-                    })?;
+                let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
                     Ok(AuthResult::Success { token: token3 }) => {
                         // STOP! If the DAG doesn't hold an MFA amr, then we
@@ -937,31 +952,7 @@ impl IdProvider for HimmelblauProvider {
                         error!("{:?}", e);
                         IdpError::NotFound
                     })?;
-                if !self.is_domain_joined(keystore).await {
-                    debug!("Device is not enrolled for {}. Enrolling now.", account_id);
-                    self.join_domain(tpm, &token, keystore, machine_key)
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to join domain: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
-                }
-                let token2 = self
-                    .client
-                    .write()
-                    .await
-                    .acquire_token_by_refresh_token(
-                        &token.refresh_token,
-                        vec![],
-                        None,
-                        tpm,
-                        machine_key,
-                    )
-                    .await
-                    .map_err(|e| {
-                        error!("{:?}", e);
-                        IdpError::NotFound
-                    })?;
+                let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
                     Ok(AuthResult::Success { .. }) => {
                         // Setup Windows Hello
@@ -1029,31 +1020,7 @@ impl IdProvider for HimmelblauProvider {
                         },
                     }
                 };
-                if !self.is_domain_joined(keystore).await {
-                    debug!("Device is not enrolled for {}. Enrolling now.", account_id);
-                    self.join_domain(tpm, &token, keystore, machine_key)
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to join domain: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
-                }
-                let token2 = self
-                    .client
-                    .write()
-                    .await
-                    .acquire_token_by_refresh_token(
-                        &token.refresh_token,
-                        vec![],
-                        None,
-                        tpm,
-                        machine_key,
-                    )
-                    .await
-                    .map_err(|e| {
-                        error!("{:?}", e);
-                        IdpError::NotFound
-                    })?;
+                let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
                     Ok(AuthResult::Success { .. }) => {
                         // Setup Windows Hello


### PR DESCRIPTION
Fixes #113. "AADSTS50155: Device authentication failed" when authenticating too quickly after enrollment

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
