### PR TITLE
Add an option for disabling Windows Hello

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -7,10 +7,10 @@ use tracing::{debug, error};
 
 use crate::constants::{
     DEFAULT_AUTHORITY_HOST, DEFAULT_CACHE_TIMEOUT, DEFAULT_CONFIG_PATH, DEFAULT_CONN_TIMEOUT,
-    DEFAULT_DB_PATH, DEFAULT_GRAPH, DEFAULT_HOME_ALIAS, DEFAULT_HOME_ATTR, DEFAULT_HOME_PREFIX,
-    DEFAULT_HSM_PIN_PATH, DEFAULT_IDMAP_RANGE, DEFAULT_ODC_PROVIDER, DEFAULT_SELINUX,
-    DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH, DEFAULT_USE_ETC_SKEL,
-    SERVER_CONFIG_PATH,
+    DEFAULT_DB_PATH, DEFAULT_GRAPH, DEFAULT_HELLO_ENABLED, DEFAULT_HOME_ALIAS, DEFAULT_HOME_ATTR,
+    DEFAULT_HOME_PREFIX, DEFAULT_HSM_PIN_PATH, DEFAULT_IDMAP_RANGE, DEFAULT_ODC_PROVIDER,
+    DEFAULT_SELINUX, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
+    DEFAULT_USE_ETC_SKEL, SERVER_CONFIG_PATH,
 };
 use crate::unix_config::{HomeAttr, HsmType};
 use graph::constants::BROKER_APP_ID;
@@ -448,6 +448,13 @@ impl HimmelblauConfig {
 
     pub fn get_config_file(&self) -> String {
         self.filename.clone()
+    }
+
+    pub fn get_enable_hello(&self) -> bool {
+        match_bool(
+            self.config.get("global", "enable_hello"),
+            DEFAULT_HELLO_ENABLED,
+        )
     }
 }
 

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -20,3 +20,4 @@ pub const DEFAULT_CONN_TIMEOUT: u64 = 30;
 pub const DEFAULT_CACHE_TIMEOUT: u64 = 15;
 pub const DEFAULT_SELINUX: bool = true;
 pub const DEFAULT_HSM_PIN_PATH: &str = "/var/lib/himmelblaud/hsm-pin";
+pub const DEFAULT_HELLO_ENABLED: bool = true;

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -877,8 +877,16 @@ impl IdProvider for HimmelblauProvider {
                             error!("{:?}", e);
                             IdpError::NotFound
                         })?;
-                        if !mfa {
-                            info!("Skipping MFA enrollment because the token doesn't contain an MFA amr");
+                        // Also skip Hello enrollment if it is disabled by config
+                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        if !mfa || !hello_enabled {
+                            if !mfa {
+                                info!("Skipping MFA enrollment because the token doesn't contain an MFA amr");
+                            } else if !hello_enabled {
+                                info!(
+                                    "Skipping MFA enrollment because Hello enrollment is disabled"
+                                );
+                            }
                             return Ok((
                                 AuthResult::Success { token: token3 },
                                 AuthCacheAction::None,
@@ -922,7 +930,17 @@ impl IdProvider for HimmelblauProvider {
                     })?;
                 let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
-                    Ok(AuthResult::Success { .. }) => {
+                    Ok(AuthResult::Success { token: token3 }) => {
+                        // Skip Hello enrollment if it is disabled by config
+                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        if !hello_enabled {
+                            info!("Skipping MFA enrollment because Hello enrollment is disabled");
+                            return Ok((
+                                AuthResult::Success { token: token3 },
+                                AuthCacheAction::None,
+                            ));
+                        }
+
                         // Setup Windows Hello
                         *cred_handler = AuthCredHandler::MFA {
                             data: UnixUserTokenI(token).into(),
@@ -990,7 +1008,17 @@ impl IdProvider for HimmelblauProvider {
                 };
                 let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
-                    Ok(AuthResult::Success { .. }) => {
+                    Ok(AuthResult::Success { token: token3 }) => {
+                        // Skip Hello enrollment if it is disabled by config
+                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        if !hello_enabled {
+                            info!("Skipping MFA enrollment because Hello enrollment is disabled");
+                            return Ok((
+                                AuthResult::Success { token: token3 },
+                                AuthCacheAction::None,
+                            ));
+                        }
+
                         // Setup Windows Hello
                         *cred_handler = AuthCredHandler::MFA {
                             data: UnixUserTokenI(token).into(),

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -18,6 +18,11 @@
 # be specified.
 # odc_provider = odc.officeapps.live.com
 #
+# Whether to enroll users in Hello authentication. If disabled, MFA may be
+# required during each login. Disabling Hello authentication is recommeneded
+# when the host is public facing (such as via SSH).
+# enable_hello = true
+#
 # authority_host = login.microsoftonline.com
 #
 # The location of the cache database


### PR DESCRIPTION
This makes sense in public facing situations,
such as when the host has a public facing IP.
Otherwise a Hello PIN could be brute forced.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
