### PR TITLE
Allow disabling Hello PIN auth for enrolled users

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -544,7 +544,9 @@ impl IdProvider for HimmelblauProvider {
                 error!("Failed fetching hello key from keystore: {:?}", e);
                 IdpError::BadRequest
             })?;
-        if !self.is_domain_joined(keystore).await || hello_key.is_none() {
+        // Skip Hello authentication if it is disabled by config
+        let hello_enabled = self.config.read().await.get_enable_hello();
+        if !self.is_domain_joined(keystore).await || hello_key.is_none() || !hello_enabled {
             Ok((AuthRequest::Password, AuthCredHandler::Password))
         } else {
             Ok((AuthRequest::Pin, AuthCredHandler::Pin))


### PR DESCRIPTION
It's possible Hello PIN auth could be disabled
after a user has completed Hello PIN enrollment.
This ensures authentication with that enrolled
PIN will be disallowed.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
