### PR TITLE
Correct the debug messages for Hello skip

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -881,11 +881,9 @@ impl IdProvider for HimmelblauProvider {
                         let hello_enabled = self.config.read().await.get_enable_hello();
                         if !mfa || !hello_enabled {
                             if !mfa {
-                                info!("Skipping MFA enrollment because the token doesn't contain an MFA amr");
+                                info!("Skipping Hello enrollment because the token doesn't contain an MFA amr");
                             } else if !hello_enabled {
-                                info!(
-                                    "Skipping MFA enrollment because Hello enrollment is disabled"
-                                );
+                                info!("Skipping Hello enrollment because it is disabled");
                             }
                             return Ok((
                                 AuthResult::Success { token: token3 },
@@ -934,7 +932,7 @@ impl IdProvider for HimmelblauProvider {
                         // Skip Hello enrollment if it is disabled by config
                         let hello_enabled = self.config.read().await.get_enable_hello();
                         if !hello_enabled {
-                            info!("Skipping MFA enrollment because Hello enrollment is disabled");
+                            info!("Skipping Hello enrollment because it is disabled");
                             return Ok((
                                 AuthResult::Success { token: token3 },
                                 AuthCacheAction::None,
@@ -1012,7 +1010,7 @@ impl IdProvider for HimmelblauProvider {
                         // Skip Hello enrollment if it is disabled by config
                         let hello_enabled = self.config.read().await.get_enable_hello();
                         if !hello_enabled {
-                            info!("Skipping MFA enrollment because Hello enrollment is disabled");
+                            info!("Skipping Hello enrollment because it is disabled");
                             return Ok((
                                 AuthResult::Success { token: token3 },
                                 AuthCacheAction::None,


### PR DESCRIPTION
The messages incorrectly indicate that we're
skipping MFA. What I meant was we're skipping
Hello enrollment.

Checklist

- [x] This pr contains no AI generated code
- [x] cargo fmt has been run
- [x] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
