### PR TITLE
Fix user dropping from NSS

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -480,7 +480,15 @@ impl IdProvider for HimmelblauProvider {
     ) -> Result<UserToken, IdpError> {
         /* Use the prt mem cache to refresh the user token */
         let account_id = id.to_string().clone();
-        let prt = self.refresh_cache.refresh_token(&account_id).await?;
+        let prt = match self.refresh_cache.refresh_token(&account_id).await {
+            Ok(prt) => prt,
+            Err(_) => {
+                debug!("Unable to refresh user via PRT cache");
+                // Never return IdpError::NotFound. This deletes the existing
+                // user from the cache.
+                return Err(IdpError::BadRequest);
+            }
+        };
         let scopes = vec!["GroupMember.Read.All"];
         let token = match self
             .client
@@ -506,13 +514,25 @@ impl IdProvider for HimmelblauProvider {
                         .await
                     {
                         Ok(token) => token,
-                        Err(_e) => return Err(IdpError::NotFound),
+                        Err(e) => {
+                            error!("{:?}", e);
+                            // Never return IdpError::NotFound. This deletes
+                            // the existing user from the cache.
+                            return Err(IdpError::BadRequest);
+                        }
                     }
                 } else {
-                    return Err(IdpError::NotFound);
+                    // Never return IdpError::NotFound. This deletes the
+                    // existing user from the cache.
+                    return Err(IdpError::BadRequest);
                 }
             }
-            Err(_e) => return Err(IdpError::NotFound),
+            Err(e) => {
+                error!("{:?}", e);
+                // Never return IdpError::NotFound. This deletes the existing
+                // user from the cache.
+                return Err(IdpError::BadRequest);
+            }
         };
         match self.token_validate(&account_id, &token).await {
             Ok(AuthResult::Success { mut token }) => {
@@ -524,8 +544,10 @@ impl IdProvider for HimmelblauProvider {
                 }
                 Ok(token)
             }
-            Ok(AuthResult::Denied) | Ok(AuthResult::Next(_)) => Err(IdpError::NotFound),
-            Err(e) => Err(e),
+            // Never return IdpError::NotFound. This deletes the existing
+            // user from the cache.
+            Ok(AuthResult::Denied) | Ok(AuthResult::Next(_)) => Err(IdpError::BadRequest),
+            Err(_) => Err(IdpError::BadRequest),
         }
     }
 


### PR DESCRIPTION
This was caused by the provider failing to
refresh the user token, and getting a 'NotFound'
response. Only ever return 'BadRequest' for this
request.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
