### PR TITLE
Only remove cached user if it doesn't exist

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -486,53 +486,58 @@ impl IdProvider for HimmelblauProvider {
             Some(token) => token.spn.clone(),
             None => id.to_string().clone(),
         };
-        let prt = match self.refresh_cache.refresh_token(&account_id).await {
-            Ok(prt) => prt,
-            Err(_) => match old_token {
-                // If we have an existing token, just keep it
-                Some(token) => return Ok(token.clone()),
-                // Otherwise, see if we should fake it
-                None => {
-                    // Check if the user exists
-                    let exists = self
-                        .client
-                        .write()
-                        .await
-                        .check_user_exists(&account_id)
-                        .await
-                        .map_err(|e| {
-                            error!("Failed checking if the user exists: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
-                    if exists {
-                        // Generate a UserToken, with invalid uuid and gid. We can
-                        // only fetch these from an authenticated token. We have to
-                        // provide something, or SSH will fail.
-                        let groups = vec![GroupToken {
-                            name: account_id.clone(),
-                            spn: account_id.clone(),
-                            uuid: Uuid::max(),
-                            gidnumber: i32::MAX as u32,
-                        }];
-                        let config = self.config.read().await;
-                        return Ok(UserToken {
-                            name: account_id.clone(),
-                            spn: account_id.clone(),
-                            uuid: Uuid::max(),
-                            gidnumber: i32::MAX as u32,
-                            displayname: "".to_string(),
-                            shell: Some(config.get_shell(Some(&self.domain))),
-                            groups,
-                            sshkeys: vec![],
-                            valid: true,
-                        });
-                    } else {
-                        // This is the one time we really should return
-                        // IdpError::NotFound, because this user doesn't exist.
-                        return Err(IdpError::NotFound);
+        macro_rules! fake_user {
+            () => {
+                match old_token {
+                    // If we have an existing token, just keep it
+                    Some(token) => return Ok(token.clone()),
+                    // Otherwise, see if we should fake it
+                    None => {
+                        // Check if the user exists
+                        let exists = self
+                            .client
+                            .write()
+                            .await
+                            .check_user_exists(&account_id)
+                            .await
+                            .map_err(|e| {
+                                error!("Failed checking if the user exists: {:?}", e);
+                                IdpError::BadRequest
+                            })?;
+                        if exists {
+                            // Generate a UserToken, with invalid uuid and gid. We can
+                            // only fetch these from an authenticated token. We have to
+                            // provide something, or SSH will fail.
+                            let groups = vec![GroupToken {
+                                name: account_id.clone(),
+                                spn: account_id.clone(),
+                                uuid: Uuid::max(),
+                                gidnumber: i32::MAX as u32,
+                            }];
+                            let config = self.config.read().await;
+                            return Ok(UserToken {
+                                name: account_id.clone(),
+                                spn: account_id.clone(),
+                                uuid: Uuid::max(),
+                                gidnumber: i32::MAX as u32,
+                                displayname: "".to_string(),
+                                shell: Some(config.get_shell(Some(&self.domain))),
+                                groups,
+                                sshkeys: vec![],
+                                valid: true,
+                            });
+                        } else {
+                            // This is the one time we really should return
+                            // IdpError::NotFound, because this user doesn't exist.
+                            return Err(IdpError::NotFound);
+                        }
                     }
                 }
-            },
+            };
+        }
+        let prt = match self.refresh_cache.refresh_token(&account_id).await {
+            Ok(prt) => prt,
+            Err(_) => fake_user!(),
         };
         let scopes = vec!["GroupMember.Read.All"];
         let token = match self
@@ -563,20 +568,20 @@ impl IdProvider for HimmelblauProvider {
                             error!("{:?}", e);
                             // Never return IdpError::NotFound. This deletes
                             // the existing user from the cache.
-                            return Err(IdpError::BadRequest);
+                            fake_user!()
                         }
                     }
                 } else {
                     // Never return IdpError::NotFound. This deletes the
                     // existing user from the cache.
-                    return Err(IdpError::BadRequest);
+                    fake_user!()
                 }
             }
             Err(e) => {
                 error!("{:?}", e);
                 // Never return IdpError::NotFound. This deletes the existing
                 // user from the cache.
-                return Err(IdpError::BadRequest);
+                fake_user!()
             }
         };
         match self.token_validate(&account_id, &token).await {
@@ -591,8 +596,8 @@ impl IdProvider for HimmelblauProvider {
             }
             // Never return IdpError::NotFound. This deletes the existing
             // user from the cache.
-            Ok(AuthResult::Denied) | Ok(AuthResult::Next(_)) => Err(IdpError::BadRequest),
-            Err(_) => Err(IdpError::BadRequest),
+            Ok(AuthResult::Denied) | Ok(AuthResult::Next(_)) => fake_user!(),
+            Err(_) => fake_user!(),
         }
     }
 


### PR DESCRIPTION
The ONLY time we should delete a user from the
cache is if we have a confirmed response from
Azure that the user does not exist. Otherwise it
should remain cached.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
