### PR TITLE
When faking a uuid for NSS, use a random uuid

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -554,7 +554,7 @@ impl IdProvider for HimmelblauProvider {
                             return Ok(UserToken {
                                 name: account_id.clone(),
                                 spn: account_id.clone(),
-                                uuid: Uuid::max(),
+                                uuid: Uuid::new_v4(),
                                 gidnumber,
                                 displayname: "".to_string(),
                                 shell: Some(config.get_shell(Some(&self.domain))),


### PR DESCRIPTION
This prevents potential clashing of users in the
cache.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
