### PR TITLE
Normalize idmap inputs

### DIFF
--- a/src/idmap/src/lib.rs
+++ b/src/idmap/src/lib.rs
@@ -193,7 +193,8 @@ impl SssIdmap {
         })?;
         let tenant_id_cstr =
             CString::new(tenant_id).map_err(|_| IdmapError::IDMAP_OUT_OF_MEMORY)?;
-        let input_cstr = CString::new(input).map_err(|_| IdmapError::IDMAP_OUT_OF_MEMORY)?;
+        let input_cstr =
+            CString::new(input.to_lowercase()).map_err(|_| IdmapError::IDMAP_OUT_OF_MEMORY)?;
         unsafe {
             let mut id: u32 = 0;
             match map_err(ffi::sss_idmap_gen_to_unix(


### PR DESCRIPTION
Otherwise 'Administrator@contoso.samba.org' will get a different uid than 'administrator@contoso.samba.org'.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
