### PR TITLE
Disable the SFA fallback by default

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -8,8 +8,8 @@ use crate::constants::{
     BROKER_APP_ID, DEFAULT_CACHE_TIMEOUT, DEFAULT_CONFIG_PATH, DEFAULT_CONN_TIMEOUT,
     DEFAULT_DB_PATH, DEFAULT_HELLO_ENABLED, DEFAULT_HOME_ALIAS, DEFAULT_HOME_ATTR,
     DEFAULT_HOME_PREFIX, DEFAULT_HSM_PIN_PATH, DEFAULT_ID_ATTR_MAP, DEFAULT_ODC_PROVIDER,
-    DEFAULT_SELINUX, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
-    DEFAULT_USE_ETC_SKEL, SERVER_CONFIG_PATH,
+    DEFAULT_SELINUX, DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL, DEFAULT_SOCK_PATH,
+    DEFAULT_TASK_SOCK_PATH, DEFAULT_USE_ETC_SKEL, SERVER_CONFIG_PATH,
 };
 use crate::unix_config::{HomeAttr, HsmType};
 use idmap::DEFAULT_IDMAP_RANGE;
@@ -380,6 +380,13 @@ impl HimmelblauConfig {
             },
             None => DEFAULT_ID_ATTR_MAP,
         }
+    }
+
+    pub fn get_enable_sfa_fallback(&self) -> bool {
+        match_bool(
+            self.config.get("global", "enable_sfa_fallback"),
+            DEFAULT_SFA_FALLBACK_ENABLED,
+        )
     }
 }
 

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_CACHE_TIMEOUT: u64 = 15;
 pub const DEFAULT_SELINUX: bool = true;
 pub const DEFAULT_HSM_PIN_PATH: &str = "/var/lib/himmelblaud/hsm-pin";
 pub const DEFAULT_HELLO_ENABLED: bool = true;
+pub const DEFAULT_SFA_FALLBACK_ENABLED: bool = false;
 pub const DEFAULT_ID_ATTR_MAP: IdAttr = IdAttr::Name;
 pub const BROKER_APP_ID: &str = "29d9ed98-a469-4536-ade2-f981bc1d605e";
 pub const BROKER_CLIENT_IDENT: &str = "38aa3b87-a06d-4817-b275-7a316988d93b";

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -29,6 +29,11 @@
 # when the host is public facing (such as via SSH).
 # enable_hello = true
 #
+# Whether to permit attempting a SFA (password only) authentication when MFA
+# methods are unavailable. Sometimes this is possible when MFA has yet to be
+# configured. This is disabled by default.
+# enable_sfa_fallback = false
+#
 # authority_host = login.microsoftonline.com
 #
 # The location of the cache database


### PR DESCRIPTION
Just because an SFA fallback is permitted by
Azure, doesn't mean we should attempt it by
default. This disables SFA unless explicitly
enabled via configuration.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
