### PR TITLE
Update required packages for tumbleweed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ sudo zypper ref && sudo zypper in himmelblau nss-himmelblau pam-himmelblau
 
 The following packages are required on openSUSE to build and test this package.
 
-    sudo zypper in cargo git gcc sqlite3-devel libopenssl-3-devel pam-devel libcap-devel libtalloc-devel libtevent-devel libldb-devel libdhash-devel krb5-devel pcre2-devel libclang13 autoconf
+    sudo zypper in cargo git gcc sqlite3-devel libopenssl-3-devel pam-devel libcap-devel libtalloc-devel libtevent-devel libldb-devel libdhash-devel krb5-devel pcre2-devel libclang13 autoconf make automake  gettext-tools clang
+
 
 Or on Ubuntu:
 


### PR DESCRIPTION
As of 14-06-2024 this set of packages provides the requirements to build himmelblau on a fresh (gnome) install of tumbleweed

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
