### PR TITLE
Authorize all users when pam_allow_groups is empty

### DIFF
--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -171,7 +171,7 @@ where
         dbtxn.commit().map_err(|_| ())?;
 
         if pam_allow_groups.is_empty() {
-            warn!("Will not be able to authorise user logins, pam_allow_groups config is not configured.");
+            warn!("pam_allow_groups config is not configured, all users will be authorized!");
         }
 
         // We assume we are offline at start up, and we mark the next "online check" as
@@ -852,9 +852,8 @@ where
         let token = self.get_usertoken(Id::Name(account_id.to_string())).await?;
 
         if self.pam_allow_groups.is_empty() {
-            // can't allow anything if the group list is zero...
-            eprintln!("Cannot authenticate users, no allowed groups in configuration!");
-            Ok(Some(false))
+            // An empty allow list permits all users
+            Ok(Some(true))
         } else {
             Ok(token.map(|tok| {
                 let user_set: BTreeSet<_> = tok

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -5,14 +5,14 @@
 # this would be the primary user of the device.
 # domains =
 #
-# REQUIRED: pam_allow_groups MUST be defined or all users will be rejected by
+### Optional global values
+# pam_allow_groups SHOULD be defined or else all users will be authorized by
 # pam account. The option should be set to a comma seperated list of Users and
 # Groups which are allowed access to the system. Groups MUST be specified by
 # Object ID, not by UPN. This is because Azure does not permit regular users
 # the right to read group names, only the Object IDs which they belong to.
 # pam_allow_groups =
 #
-### Optional global values
 # Specify whether to map uid/gid based on the object name or the object uuid.
 # By object uuid mapping is the old default, but can cause authentication
 # issues over SSH. Mapping by name is recommeneded.


### PR DESCRIPTION
This flips the default behavior to permit all
users in the configured domains, rather than
to default to prohibit all users. I believe the
prohibit all default is excessive (and comes from
a Kanidm default).

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
