### PR TITLE
Add a debug option to the config

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -388,6 +388,13 @@ impl HimmelblauConfig {
             DEFAULT_SFA_FALLBACK_ENABLED,
         )
     }
+
+    pub fn get_debug(&self) -> bool {
+        match_bool(
+            self.config.get("global", "debug"),
+            false,
+        )
+    }
 }
 
 impl fmt::Debug for HimmelblauConfig {

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -6,6 +6,9 @@
 # domains =
 #
 ### Optional global values
+# Configure whether the logger will output debug messages to the journal.
+# debug = false
+#
 # pam_allow_groups SHOULD be defined or else all users will be authorized by
 # pam account. The option should be set to a comma seperated list of Users and
 # Groups which are allowed access to the system. Groups MUST be specified by

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -590,6 +590,10 @@ async fn main() -> ExitCode {
                 }
             };
 
+            if cfg.get_debug() {
+                std::env::set_var("RUST_LOG", "debug");
+            }
+
             if clap_args.get_flag("configtest") {
                 eprintln!("###################################");
                 eprintln!("Dumping configs:\n###################################");


### PR DESCRIPTION
This allows debug to be enabled in the
configuration file.

Fixes #152

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
