### PR TITLE
Add a version check script

### DIFF
--- a/.github/workflows/build_debian_source_package.yml
+++ b/.github/workflows/build_debian_source_package.yml
@@ -1,9 +1,10 @@
 name: Build Himmelblau Debian source package
 
 on:
-  push:
-    branches:
-      - stable-0.5.x
+  workflow_run:
+    workflows: ["Rust Version Tagging (Post-Merge)"]
+    types:
+      - completed
 
 env:
   SCCACHE_GHA_ENABLED: "true"
@@ -12,6 +13,7 @@ env:
 jobs:
   build-source-package:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: "[general] - Checkout repository"

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,30 @@
+name: Rust Version Tagging (Post-Merge)
+
+on:
+  push:
+    branches:
+      - stable-0.5.x
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Git for tagging
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "action@github.com"
+
+    - name: Extract version from Cargo.toml
+      id: get-version
+      run: |
+        VERSION=$(grep '^version =' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Create and push a new tag
+      run: |
+        git tag "$VERSION"
+        git push origin "$VERSION"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,36 @@
+name: Rust Version Check (Pre-Merge)
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Extract version from Cargo.toml
+      id: get-version
+      run: |
+        VERSION=$(grep '^version =' Cargo.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "Package version: $VERSION"
+
+    - name: Check if tag exists for the version
+      run: |
+        git fetch --tags
+        if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          echo "Git tag for version $VERSION already exists!"
+          exit 1
+        else
+          echo "No existing tag found for version $VERSION."
+        fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -75,7 +75,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.32.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.5.1" }
+kanidm_lib_crypto = { path = "./src/kanidm/libs/crypto", version = "0.5.2" }
 kanidm_utils_users = { path = "./src/kanidm/libs/users" }
 walkdir = "2"
 csv = "1.2.2"


### PR DESCRIPTION
This github action is to ensure that the version
number is always incremented in the Cargo.toml
when submitting an MR. Without it, the Debian
build will fail.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
