### PR TITLE
Improve the user experience for users installing Himmelblau

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	git submodule init; git submodule update
-	cargo build
+	cargo build --release
 
 build-tests:
 	$(MAKE) -C tests
@@ -11,3 +11,44 @@ test: build-tests
 clean:
 	cargo clean
 	$(MAKE) -C tests clean
+
+PLATFORM := $(shell grep '^ID=' /etc/os-release | awk -F= '{ print $$2 }' | tr -d '"')
+
+install-opensuse:
+	install -D -d -m 0755 /etc/himmelblau
+	install -m 0644 ./src/config/himmelblau.conf.example /etc/himmelblau/himmelblau.conf
+	install -m 0755 ./target/release/libnss_himmelblau.so /usr/lib64/libnss_himmelblau.so.2
+	install -m 0755 ./target/release/libpam_himmelblau.so /usr/lib64/security
+	install -m 0755 ./target/release/himmelblaud /usr/sbin
+	install -m 0755 ./target/release/himmelblaud_tasks /usr/sbin
+	install -m 0755 ./target/release/broker /usr/sbin
+	install -m 0755 ./target/release/aad-tool /usr/bin
+	install -m 0644 ./platform/opensuse/himmelblaud.service /usr/lib/systemd/system
+	install -m 0644 ./platform/opensuse/himmelblaud-tasks.service /usr/lib/systemd/system
+	install -m 0644 ./platform/opensuse/com.microsoft.identity.broker1.service /usr/share/dbus-1/services
+	install -m 0644 ./platform/opensuse/org.samba.himmelblau.conf /usr/share/dbus-1/system.d
+
+install-debian:
+	install -D -d -m 0755 /etc/himmelblau
+	install -m 0644 ./src/config/himmelblau.conf.example /etc/himmelblau/himmelblau.conf
+	install -m 0755 ./target/release/libnss_himmelblau.so /usr/lib/x86_64-linux-gnu/libnss_himmelblau.so.2
+	install -m 0755 ./target/release/libpam_himmelblau.so /usr/lib/x86_64-linux-gnu
+	install -m 0755 ./target/release/himmelblaud /usr/sbin
+	install -m 0755 ./target/release/himmelblaud_tasks /usr/sbin
+	install -m 0755 ./target/release/broker /usr/sbin
+	install -m 0755 ./target/release/aad-tool /usr/bin
+	install -m 0644 ./platform/debian/himmelblaud.service /usr/lib/systemd/system
+	install -m 0644 ./platform/debian/himmelblaud-tasks.service /usr/lib/systemd/system
+	install -m 0644 ./platform/debian/com.microsoft.identity.broker1.service /usr/share/dbus-1/services
+	install -m 0644 ./platform/debian/org.samba.himmelblau.conf /usr/share/dbus-1/system.d
+
+install:
+ifeq ($(PLATFORM), debian)
+	$(MAKE) install-debian
+else ifeq ($(PLATFORM), ubuntu)
+	$(MAKE) install-ubuntu
+else ifneq (,$(findstring opensuse,$(PLATFORM)))
+	$(MAKE) install-opensuse
+else
+	$(error "Unsupported platform: $(PLATFORM)")
+endif

--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ The following packages are required on openSUSE to build and test this package.
 
 Or on Debian based systems:
 
-    sudo apt-get install libpam0g-dev libudev-dev libssl-dev pkg-config tpm-udev libtss2-dev libcap-dev libtalloc-dev libtevent-dev libldb-dev libdhash-dev libkrb5-dev libpcre2-dev libclang-dev autoconf gettext cargo libsqlite3-dev
+    sudo apt-get install libpam0g-dev libudev-dev libssl-dev pkg-config tpm-udev libtss2-dev libcap-dev libtalloc-dev libtevent-dev libldb-dev libdhash-dev libkrb5-dev libpcre2-dev libclang-18-dev autoconf gettext libsqlite3-dev
+    
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    source "$HOME/.cargo/env"
+    rustup default stable
+
+On Debian systems, rust must be installed using [rustup](https://rustup.rs), because the version of Rust shipped with Debian is very old.
 
 You can build the components with
 

--- a/README.md
+++ b/README.md
@@ -84,20 +84,15 @@ You can build the components with
 
     cd himmelblau; make
 
-To test debug builds you can use these directly out of the build directory, but you must
-link the libraries to the correct locations
+Install the binaries
 
 > **WARNING** you should only do this on a disposable machine or a machine you are willing to
 > recover with single user mode.
 
-    # You must use the full paths!
-    ln -s /root/himmelblau/target/debug/libpam_himmelblau.so /usr/lib64/security/pam_himmelblau.so
-    ln -s /root/himmelblau/target/debug/libnss_himmelblau.so /usr/lib64/libnss_himmelblau.so.2
+    sudo make install
 
 Configure your instance
 
-    mkdir /etc/himmelblau/
-    cp src/config/himmelblau.conf.example /etc/himmelblau/himmelblau.conf
     vim /etc/himmelblau/himmelblau.conf
 
 It's essential that you configure the `domains` and `pam_allow_groups` options, otherwise
@@ -106,8 +101,7 @@ or groups which are allowed access to the host.
 
 Run the daemon with:
 
-    cargo run --bin=himmelblaud -- -d -c ./src/config/himmelblau.conf.example &
-    sudo cargo run --bin=himmelblaud_tasks -- &
+    sudo systemctl start himmelblaud himmelblaud-tasks
 
 Check systemd journal for errors.
 
@@ -126,15 +120,15 @@ Setup NSS
     group:      compat systemd himmelblau
     shadow:     compat systemd himmelblau
 
-> **WARNING** It's essential that the systemd nss module be added before the himmelblau nss
-> module, otherwise you will encounter deadlocks in himmelblau (nss recursion caused by systemd
-> skipping compat/files).
-
 Check that you can resolve a user with
 
     getent passwd <name>
 
 Setup PAM
+
+> **WARNING** only modify your PAM configuration if you are confident you understand
+> the syntax. The following setup is meant as an example. Removing PAM modules from
+> your stack may prevent you from authenticating to the host. Proceed with caution!
 
     old /etc/pam.d/{common-account,common-auth,common-password,common-session}
     cp /etc/pam.d/common-password-pc /etc/pam.d/common-password


### PR DESCRIPTION
Installation instructions need improvements, and we need a `make install` command.

Fixes #186

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
