### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following packages are required on openSUSE to build and test this package.
 
 Or on Debian based systems:
 
-    sudo apt-get install libpam0g-dev libudev-dev libssl-dev pkg-config tpm-udev libtss2-dev libcap-dev libtalloc-dev libtevent-dev libldb-dev libdhash-dev libkrb5-dev libpcre2-dev libclang-18-dev autoconf gettext libsqlite3-dev
+    sudo apt-get install libpam0g-dev libudev-dev libssl-dev pkg-config tpm-udev libtss2-dev libcap-dev libtalloc-dev libtevent-dev libldb-dev libdhash-dev libkrb5-dev libpcre2-dev libclang-18-dev autoconf gettext libsqlite3-dev build-essentials libdbus-1-dev
     
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     source "$HOME/.cargo/env"


### PR DESCRIPTION
Included build-essentials and libdbus-1-dev into the apt-get install list, as they are both required for Debian builds.

Fixes #
add packages that are needed when you try and run make for Debian systems 

Checklist

- [ x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
