### PR TITLE
Add cargo deb build

### DIFF
--- a/images/ubuntu/Dockerfile.22.04
+++ b/images/ubuntu/Dockerfile.22.04
@@ -1,0 +1,51 @@
+# Use the official Ubuntu 22.04 image as the base
+FROM ubuntu:22.04
+
+# Set environment variables for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install essential build dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    libssl-dev \
+    libsss-idmap-dev \
+    libdbus-1-dev \
+    libtool \
+    pkg-config \
+    autoconf \
+    libpam0g-dev \
+    libudev-dev \
+    libssl-dev \
+    tpm-udev \
+    libtss2-dev \
+    libcap-dev \
+    libtalloc-dev \
+    libtevent-dev \
+    libldb-dev \
+    libdhash-dev \
+    libkrb5-dev \
+    libpcre2-dev \
+    libclang-dev \
+    gettext \
+    cargo \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (latest stable)
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set environment for Rust
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+VOLUME /himmelblau
+
+# Change directory to the repository
+WORKDIR /himmelblau
+
+# Install the cargo-deb tool
+RUN cargo install cargo-deb
+
+# Build the project and create the .deb package
+CMD cargo deb --deb-revision=ubuntu22.04 -p himmelblaud && cargo deb --deb-revision=ubuntu22.04 -p nss_himmelblau && cargo deb --deb-revision=ubuntu22.04 -p pam_himmelblau

--- a/images/ubuntu/Dockerfile.24.04
+++ b/images/ubuntu/Dockerfile.24.04
@@ -1,0 +1,51 @@
+# Use the official Ubuntu 24.04 image as the base
+FROM ubuntu:24.04
+
+# Set environment variables for non-interactive installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install essential build dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    libssl-dev \
+    libsss-idmap-dev \
+    libdbus-1-dev \
+    libtool \
+    pkg-config \
+    autoconf \
+    libpam0g-dev \
+    libudev-dev \
+    libssl-dev \
+    tpm-udev \
+    libtss2-dev \
+    libcap-dev \
+    libtalloc-dev \
+    libtevent-dev \
+    libldb-dev \
+    libdhash-dev \
+    libkrb5-dev \
+    libpcre2-dev \
+    libclang-dev \
+    gettext \
+    cargo \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (latest stable)
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set environment for Rust
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+VOLUME /himmelblau
+
+# Change directory to the repository
+WORKDIR /himmelblau
+
+# Install the cargo-deb tool
+RUN cargo install cargo-deb
+
+# Build the project and create the .deb package
+CMD cargo deb --deb-revision=ubuntu24.04 -p himmelblaud && cargo deb --deb-revision=ubuntu24.04 -p nss_himmelblau && cargo deb --deb-revision=ubuntu24.04 -p pam_himmelblau

--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -38,3 +38,18 @@ kanidm_utils_users = { workspace = true }
 csv = { workspace = true }
 notify-debouncer-full = { workspace = true }
 kanidm-hsm-crypto = { workspace = true }
+
+[package.metadata.deb]
+name = "himmelblau"
+maintainer = "David Mulder <dmulder@suse.com>"
+depends = ["libssl3", "libsqlite3-0"]
+recommends = ["nss-himmelblau", "pam-himmelblau"]
+assets = [
+  ["../../src/config/himmelblau.conf.example", "etc/himmelblau/himmelblau.conf", "644"],
+  ["target/release/aad-tool", "usr/bin/", "755"],
+  ["../../platform/debian/himmelblaud-tasks.service", "etc/systemd/system/", "644"],
+  ["../../platform/debian/himmelblaud.service", "etc/systemd/system/", "644"],
+  ["target/release/himmelblaud", "usr/sbin/", "755"],
+  ["target/release/himmelblaud_tasks", "usr/sbin/", "755"],
+  ["../../README.md", "usr/share/doc/himmelblau/README", "644"],
+]

--- a/src/nss/Cargo.toml
+++ b/src/nss/Cargo.toml
@@ -22,3 +22,9 @@ libc = { workspace = true }
 paste = { workspace = true }
 lazy_static = { workspace = true }
 
+[package.metadata.deb]
+name = "nss-himmelblau"
+maintainer = "David Mulder <dmulder@suse.com>"
+assets = [
+  ["target/release/libnss_himmelblau.so", "usr/lib/x86_64-linux-gnu/libnss_himmelblau.so.2", "755"],
+]

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -23,3 +23,10 @@ tracing = { workspace = true }
 
 [build-dependencies]
 pkg-config.workspace = true
+
+[package.metadata.deb]
+name = "pam-himmelblau"
+maintainer = "David Mulder <dmulder@suse.com>"
+assets = [
+  ["target/release/libpam_himmelblau.so", "usr/lib/x86_64-linux-gnu/", "755"],
+]


### PR DESCRIPTION
This is a simple solution to the Ubuntu packaging
needs. `make deb` now generates Ubuntu 22.04 and
24.04 packages.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
