### PR TITLE
Revert "Speed up nss requests w/out auth attempt"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-libhimmelblau = { version = "0.3.3" }
+libhimmelblau = { version = "0.3.2" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"
 reqwest = { version = "^0.12.2", features = ["json"] }


### PR DESCRIPTION
This reverts commit 2fb9f6a11dc123678515cd3b5558bc645ae39fdc. This method may speed up nss, but it also breaks
group memberships.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
