### PR TITLE
Never return the Pam result from get_user()

### DIFF
--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -254,7 +254,7 @@ impl PamHooks for PamKanidm {
             Ok(aid) => aid,
             Err(e) => {
                 error!(err = ?e, "get_user");
-                return e;
+                return PamResultCode::PAM_SERVICE_ERR;
             }
         };
 
@@ -323,7 +323,7 @@ impl PamHooks for PamKanidm {
             Ok(aid) => aid,
             Err(e) => {
                 error!(err = ?e, "get_user");
-                return e;
+                return PamResultCode::PAM_SERVICE_ERR;
             }
         };
 
@@ -545,7 +545,7 @@ impl PamHooks for PamKanidm {
             Ok(aid) => aid,
             Err(err) => {
                 error!(?err, "get_user");
-                return err;
+                return PamResultCode::PAM_SERVICE_ERR;
             }
         };
 


### PR DESCRIPTION
This could be an invalid response.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
