### PR TITLE
Bug in pam which needs defended against

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -76,7 +76,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.32.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.2" }
+kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.3" }
 kanidm_utils_users = { path = "./src/users" }
 walkdir = "2"
 csv = "1.2.2"


### PR DESCRIPTION
See related:
https://github.com/kanidm/kanidm/pull/2960

It seems that a pam or sudo update triggered
this behaviour, which appears to be an external
bug that we need to defend against.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
