### PR TITLE
Rework the poll logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -76,7 +76,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.32.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.6" }
+kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.7" }
 kanidm_utils_users = { path = "./src/users" }
 walkdir = "2"
 csv = "1.2.2"

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -829,8 +829,15 @@ impl IdProvider for HimmelblauProvider {
             }
             (
                 AuthCredHandler::DeviceAuthorizationGrant { flow },
-                PamAuthRequest::MFAPoll { .. },
+                PamAuthRequest::MFAPoll { poll_attempt },
             ) => {
+                let polling_interval = flow.interval.unwrap_or(5);
+                // Convert `expires_in` (a lifetime in seconds) to max_poll_attempts
+                let max_poll_attempts = flow.expires_in / polling_interval;
+                if poll_attempt > max_poll_attempts {
+                    error!("MFA DAG polling timed out");
+                    return Err(IdpError::BadRequest);
+                }
                 let token = match self
                     .client
                     .write()

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -22,29 +22,12 @@ pub struct NssGroup {
     pub members: Vec<String>,
 }
 
-/* RFC8628: 3.2. Device Authorization Response */
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct DeviceAuthorizationResponse {
-    pub device_code: String,
-    pub user_code: String,
-    pub verification_uri: String,
-    pub verification_uri_complete: Option<String>,
-    pub expires_in: u32,
-    pub interval: Option<u32>,
-    /* The message is not part of RFC8628, but an add-on from MS. Listed
-     * optional here to support all implementations. */
-    pub message: Option<String>,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthResponse {
     Unknown,
     Success,
     Denied,
     Password,
-    DeviceAuthorizationGrant {
-        data: DeviceAuthorizationResponse,
-    },
     /// PAM must prompt for an authentication code
     MFACode {
         msg: String,
@@ -68,9 +51,8 @@ pub enum PamAuthResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
     Password { cred: String },
-    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
     MFACode { cred: String },
-    MFAPoll,
+    MFAPoll { poll_attempt: u32 },
     SetupPin { pin: String },
     Pin { cred: String },
 }

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -19,6 +19,7 @@ libc = { workspace = true }
 kanidm_unix_common = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+himmelblau_unix_common.workspace = true
 
 [build-dependencies]
 pkg-config.workspace = true


### PR DESCRIPTION
Fixes #219

This is meant to address the issues in #219. Unfortunately, it appears that SSHD is not terminating the auth attempt when the ssh session times out. There isn't really anything we can do about that. We can however, handle this a little better in the communication between the daemon and the pam module. Now the daemon will do nothing unless prompted by the pam module (when polling). I also added code to honor the DAG timeout specified by Microsoft at init time.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
