### PR TITLE
Rework the poll logic

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -7,14 +7,10 @@ use crate::config::HimmelblauConfig;
 use crate::config::IdAttr;
 use crate::db::KeyStoreTxn;
 use crate::idprovider::interface::tpm;
-use crate::unix_proto::{DeviceAuthorizationResponse, PamAuthRequest};
+use crate::unix_proto::PamAuthRequest;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use himmelblau::auth::{
-    BrokerClientApplication, ClientInfo,
-    DeviceAuthorizationResponse as msal_DeviceAuthorizationResponse, IdToken, MFAAuthContinue,
-    UserToken as UnixUserToken,
-};
+use himmelblau::auth::{BrokerClientApplication, UserToken as UnixUserToken};
 use himmelblau::discovery::EnrollAttrs;
 use himmelblau::error::{ErrorResponse, MsalError, AUTH_PENDING, DEVICE_AUTH_FAIL, REQUIRES_MFA};
 use himmelblau::graph::{DirectoryObject, Graph};
@@ -416,34 +412,6 @@ impl HimmelblauProvider {
     }
 }
 
-impl From<msal_DeviceAuthorizationResponse> for DeviceAuthorizationResponse {
-    fn from(src: msal_DeviceAuthorizationResponse) -> Self {
-        Self {
-            device_code: src.device_code.clone(),
-            user_code: src.user_code.clone(),
-            verification_uri: src.verification_uri.clone(),
-            verification_uri_complete: src.verification_uri_complete.clone(),
-            expires_in: src.expires_in,
-            interval: src.interval,
-            message: src.message.clone(),
-        }
-    }
-}
-
-impl From<DeviceAuthorizationResponse> for msal_DeviceAuthorizationResponse {
-    fn from(src: DeviceAuthorizationResponse) -> Self {
-        Self {
-            device_code: src.device_code,
-            user_code: src.user_code,
-            verification_uri: src.verification_uri,
-            verification_uri_complete: src.verification_uri_complete,
-            expires_in: src.expires_in,
-            interval: src.interval,
-            message: src.message,
-        }
-    }
-}
-
 #[async_trait]
 impl IdProvider for HimmelblauProvider {
     async fn provider_authenticate(&self, _tpm: &mut tpm::BoxedDynTpm) -> Result<(), IdpError> {
@@ -653,9 +621,9 @@ impl IdProvider for HimmelblauProvider {
         // Skip Hello authentication if it is disabled by config
         let hello_enabled = self.config.read().await.get_enable_hello();
         if !self.is_domain_joined(keystore).await || hello_key.is_none() || !hello_enabled {
-            Ok((AuthRequest::Password, AuthCredHandler::Password))
+            Ok((AuthRequest::Password, AuthCredHandler::None))
         } else {
-            Ok((AuthRequest::Pin, AuthCredHandler::Pin))
+            Ok((AuthRequest::Pin, AuthCredHandler::None))
         }
     }
 
@@ -667,7 +635,7 @@ impl IdProvider for HimmelblauProvider {
         keystore: &mut D,
         tpm: &mut tpm::BoxedDynTpm,
         machine_key: &tpm::MachineKey,
-        shutdown_rx: &broadcast::Receiver<()>,
+        _shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError> {
         macro_rules! enroll_and_obtain_enrolled_token {
             ($token:ident) => {{
@@ -773,31 +741,15 @@ impl IdProvider for HimmelblauProvider {
                 }
             }};
         }
-        let mut shutdown_rx_cl = shutdown_rx.resubscribe();
-        match (&cred_handler, pam_next_req) {
-            (AuthCredHandler::MFA { data }, PamAuthRequest::SetupPin { pin }) => {
+        match (&mut *cred_handler, pam_next_req) {
+            (AuthCredHandler::SetupPin { token }, PamAuthRequest::SetupPin { pin }) => {
                 let hello_tag = self.fetch_hello_key_tag(account_id);
-                let token: Token = serde_json::from_str(data).map_err(|e| {
-                    error!("{:?}", e);
-                    IdpError::BadRequest
-                })?;
-                let token = UnixUserToken {
-                    token_type: "".to_string(),
-                    scope: None,
-                    expires_in: 0,
-                    ext_expires_in: 0,
-                    access_token: token.0,
-                    refresh_token: token.1,
-                    id_token: IdToken::default(),
-                    client_info: ClientInfo::default(),
-                    prt: None,
-                };
 
                 let hello_key = match self
                     .client
                     .write()
                     .await
-                    .provision_hello_for_business_key(&token, tpm, machine_key, &pin)
+                    .provision_hello_for_business_key(token, tpm, machine_key, &pin)
                     .await
                 {
                     Ok(hello_key) => hello_key,
@@ -822,7 +774,7 @@ impl IdProvider for HimmelblauProvider {
 
                 auth_and_validate_hello_key!(hello_key, pin)
             }
-            (AuthCredHandler::Pin, PamAuthRequest::Pin { cred }) => {
+            (_, PamAuthRequest::Pin { cred }) => {
                 let hello_tag = self.fetch_hello_key_tag(account_id);
                 let hello_key = keystore
                     .get_tagged_hsm_key(&hello_tag)
@@ -837,7 +789,7 @@ impl IdProvider for HimmelblauProvider {
 
                 auth_and_validate_hello_key!(hello_key, cred)
             }
-            (AuthCredHandler::Password, PamAuthRequest::Password { cred }) => {
+            (_, PamAuthRequest::Password { cred }) => {
                 // Always attempt to force MFA when enrolling the device, otherwise
                 // the device object will not have the MFA claim. If we are already
                 // enrolled but creating a new Hello Pin, we follow the same process,
@@ -905,12 +857,24 @@ impl IdProvider for HimmelblauProvider {
                                                     error!("{:?}", e);
                                                     IdpError::BadRequest
                                                 })?;
-                                            return Ok((
-                                                AuthResult::Next(
-                                                    AuthRequest::DeviceAuthorizationGrant {
-                                                        data: resp.into(),
-                                                    },
+                                            let msg = match &resp.message {
+                                                Some(msg) => msg.to_string(),
+                                                None => format!(
+                                                    "Using a browser on another \
+                                        device, visit:\n{}\nAnd enter the code:\n{}",
+                                                    resp.verification_uri, resp.user_code
                                                 ),
+                                            };
+                                            let polling_interval = resp.interval.unwrap_or(5);
+                                            *cred_handler =
+                                                AuthCredHandler::DeviceAuthorizationGrant {
+                                                    flow: resp,
+                                                };
+                                            return Ok((
+                                                AuthResult::Next(AuthRequest::MFAPoll {
+                                                    msg,
+                                                    polling_interval,
+                                                }),
                                                 /* An MFA auth cannot cache the password. This would
                                                  * lead to a potential downgrade to SFA attack (where
                                                  * the attacker auths with a stolen password, then
@@ -943,12 +907,7 @@ impl IdProvider for HimmelblauProvider {
                 match resp.mfa_method.as_str() {
                     "PhoneAppOTP" | "OneWaySMS" | "ConsolidatedTelephony" => {
                         let msg = resp.msg.clone();
-                        *cred_handler = AuthCredHandler::MFA {
-                            data: serde_json::to_string(&resp).map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::BadRequest
-                            })?,
-                        };
+                        *cred_handler = AuthCredHandler::MFA { flow: resp };
                         return Ok((
                             AuthResult::Next(AuthRequest::MFACode { msg }),
                             /* An MFA auth cannot cache the password. This would
@@ -964,12 +923,7 @@ impl IdProvider for HimmelblauProvider {
                             error!("Invalid response from the server");
                             IdpError::BadRequest
                         })?;
-                        *cred_handler = AuthCredHandler::MFA {
-                            data: serde_json::to_string(&resp).map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::BadRequest
-                            })?,
-                        };
+                        *cred_handler = AuthCredHandler::MFA { flow: resp };
                         return Ok((
                             AuthResult::Next(AuthRequest::MFAPoll {
                                 msg,
@@ -986,35 +940,35 @@ impl IdProvider for HimmelblauProvider {
                     }
                 }
             }
-            (_, PamAuthRequest::DeviceAuthorizationGrant { data }) => {
-                let sleep_interval: u64 = match data.interval.as_ref() {
-                    Some(val) => *val as u64,
-                    None => 5,
-                };
-                let mut mtoken = self
+            (
+                AuthCredHandler::DeviceAuthorizationGrant { flow },
+                PamAuthRequest::MFAPoll { .. },
+            ) => {
+                let token = match self
                     .client
                     .write()
                     .await
-                    .acquire_token_by_device_flow(data.clone().into())
-                    .await;
-                while let Err(MsalError::AcquireTokenFailed(ref resp)) = mtoken {
-                    if resp.error_codes.contains(&AUTH_PENDING) {
-                        debug!("Polling for acquire_token_by_device_flow");
-                        sleep(Duration::from_secs(sleep_interval));
-                        mtoken = self
-                            .client
-                            .write()
-                            .await
-                            .acquire_token_by_device_flow(data.clone().into())
-                            .await;
-                    } else {
-                        break;
+                    .acquire_token_by_device_flow(flow.clone())
+                    .await
+                {
+                    Err(MsalError::AcquireTokenFailed(ref resp)) => {
+                        if resp.error_codes.contains(&AUTH_PENDING) {
+                            debug!("Polling for acquire_token_by_device_flow");
+                            return Ok((
+                                AuthResult::Next(AuthRequest::MFAPollWait),
+                                AuthCacheAction::None,
+                            ));
+                        } else {
+                            error!("{}", resp.error_description);
+                            return Err(IdpError::BadRequest);
+                        }
                     }
-                }
-                let token = mtoken.map_err(|e| {
-                    error!("{:?}", e);
-                    IdpError::NotFound
-                })?;
+                    Err(e) => {
+                        error!("{:?}", e);
+                        return Err(IdpError::BadRequest);
+                    }
+                    Ok(token) => token,
+                };
                 let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
                     Ok(AuthResult::Success { token: token3 }) => {
@@ -1027,7 +981,10 @@ impl IdProvider for HimmelblauProvider {
                         // attempt here.
                         let sfa_enabled = self.config.read().await.get_enable_sfa_fallback();
                         if !mfa && !sfa_enabled {
-                            info!("A DAG produced an SFA token, yet SFA fallback is disabled by configuration");
+                            info!(
+                                "A DAG produced an SFA token, yet SFA \
+                                fallback is disabled by configuration"
+                            );
                             return Ok((AuthResult::Denied, AuthCacheAction::None));
                         }
                         // STOP! If the DAG doesn't hold an MFA amr, then we
@@ -1037,9 +994,15 @@ impl IdProvider for HimmelblauProvider {
                         let hello_enabled = self.config.read().await.get_enable_hello();
                         if !mfa || !hello_enabled {
                             if !mfa {
-                                info!("Skipping Hello enrollment because the token doesn't contain an MFA amr");
+                                info!(
+                                    "Skipping Hello enrollment because \
+                                    the token doesn't contain an MFA amr"
+                                );
                             } else if !hello_enabled {
-                                info!("Skipping Hello enrollment because it is disabled");
+                                info!(
+                                    "Skipping Hello enrollment \
+                                    because it is disabled"
+                                );
                             }
                             return Ok((
                                 AuthResult::Success { token: token3 },
@@ -1048,16 +1011,7 @@ impl IdProvider for HimmelblauProvider {
                         }
 
                         // Setup Windows Hello
-                        *cred_handler = AuthCredHandler::MFA {
-                            data: serde_json::to_string(&Token(
-                                token.access_token.clone(),
-                                token.refresh_token.to_string(),
-                            ))
-                            .map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::BadRequest
-                            })?,
-                        };
+                        *cred_handler = AuthCredHandler::SetupPin { token };
                         return Ok((
                             AuthResult::Next(AuthRequest::SetupPin {
                                 msg: format!(
@@ -1073,16 +1027,12 @@ impl IdProvider for HimmelblauProvider {
                     Err(e) => Err(e),
                 }
             }
-            (AuthCredHandler::MFA { data }, PamAuthRequest::MFACode { cred }) => {
-                let mut flow: MFAAuthContinue = serde_json::from_str(data).map_err(|e| {
-                    error!("{:?}", e);
-                    IdpError::BadRequest
-                })?;
+            (AuthCredHandler::MFA { ref mut flow }, PamAuthRequest::MFACode { cred }) => {
                 let token = self
                     .client
                     .write()
                     .await
-                    .acquire_token_by_mfa_flow(account_id, Some(&cred), None, &mut flow)
+                    .acquire_token_by_mfa_flow(account_id, Some(&cred), None, flow)
                     .await
                     .map_err(|e| {
                         error!("{:?}", e);
@@ -1102,16 +1052,7 @@ impl IdProvider for HimmelblauProvider {
                         }
 
                         // Setup Windows Hello
-                        *cred_handler = AuthCredHandler::MFA {
-                            data: serde_json::to_string(&Token(
-                                token.access_token.clone(),
-                                token.refresh_token.to_string(),
-                            ))
-                            .map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::BadRequest
-                            })?,
-                        };
+                        *cred_handler = AuthCredHandler::SetupPin { token };
                         return Ok((
                             AuthResult::Next(AuthRequest::SetupPin {
                                 msg: format!(
@@ -1127,49 +1068,35 @@ impl IdProvider for HimmelblauProvider {
                     Err(e) => Err(e),
                 }
             }
-            (AuthCredHandler::MFA { data }, PamAuthRequest::MFAPoll) => {
-                let mut flow: MFAAuthContinue = serde_json::from_str(data).map_err(|e| {
-                    error!("{:?}", e);
-                    IdpError::BadRequest
-                })?;
+            (AuthCredHandler::MFA { ref mut flow }, PamAuthRequest::MFAPoll { poll_attempt }) => {
                 let max_poll_attempts = flow.max_poll_attempts.ok_or_else(|| {
                     error!("Invalid response from the server");
                     IdpError::BadRequest
                 })?;
-                let polling_interval = flow.polling_interval.ok_or_else(|| {
-                    error!("Invalid response from the server");
-                    IdpError::BadRequest
-                })?;
-                let mut poll_attempt = 1;
-                let token = loop {
-                    if poll_attempt > max_poll_attempts {
-                        error!("MFA polling timed out");
-                        return Err(IdpError::BadRequest);
-                    }
-                    if shutdown_rx_cl.try_recv().ok().is_some() {
-                        debug!("Received a signal to shutdown, bailing MFA poll");
-                        return Err(IdpError::BadRequest);
-                    }
-                    sleep(Duration::from_millis(polling_interval.into()));
-                    match self
-                        .client
-                        .write()
-                        .await
-                        .acquire_token_by_mfa_flow(account_id, None, Some(poll_attempt), &mut flow)
-                        .await
-                    {
-                        Ok(token) => break token,
-                        Err(e) => match e {
-                            MsalError::MFAPollContinue => {
-                                poll_attempt += 1;
-                                continue;
-                            }
-                            e => {
-                                error!("{:?}", e);
-                                return Err(IdpError::NotFound);
-                            }
-                        },
-                    }
+                if poll_attempt > max_poll_attempts {
+                    error!("MFA polling timed out");
+                    return Err(IdpError::BadRequest);
+                }
+                let token = match self
+                    .client
+                    .write()
+                    .await
+                    .acquire_token_by_mfa_flow(account_id, None, Some(poll_attempt), flow)
+                    .await
+                {
+                    Ok(token) => token,
+                    Err(e) => match e {
+                        MsalError::MFAPollContinue => {
+                            return Ok((
+                                AuthResult::Next(AuthRequest::MFAPollWait),
+                                AuthCacheAction::None,
+                            ));
+                        }
+                        e => {
+                            error!("{:?}", e);
+                            return Err(IdpError::NotFound);
+                        }
+                    },
                 };
                 let token2 = enroll_and_obtain_enrolled_token!(token);
                 match self.token_validate(account_id, &token2).await {
@@ -1185,16 +1112,7 @@ impl IdProvider for HimmelblauProvider {
                         }
 
                         // Setup Windows Hello
-                        *cred_handler = AuthCredHandler::MFA {
-                            data: serde_json::to_string(&Token(
-                                token.access_token.clone(),
-                                token.refresh_token.to_string(),
-                            ))
-                            .map_err(|e| {
-                                error!("{:?}", e);
-                                IdpError::BadRequest
-                            })?,
-                        };
+                        *cred_handler = AuthCredHandler::SetupPin { token };
                         return Ok((
                             AuthResult::Next(AuthRequest::SetupPin {
                                 msg: format!(
@@ -1230,9 +1148,9 @@ impl IdProvider for HimmelblauProvider {
                 IdpError::BadRequest
             })?;
         if !self.is_domain_joined(keystore).await || hello_key.is_none() {
-            Ok((AuthRequest::Password, AuthCredHandler::Password))
+            Ok((AuthRequest::Password, AuthCredHandler::None))
         } else {
-            Ok((AuthRequest::Pin, AuthCredHandler::Pin))
+            Ok((AuthRequest::Pin, AuthCredHandler::None))
         }
     }
 
@@ -1248,7 +1166,7 @@ impl IdProvider for HimmelblauProvider {
         _online_at_init: bool,
     ) -> Result<AuthResult, IdpError> {
         match (&cred_handler, pam_next_req) {
-            (AuthCredHandler::Pin, PamAuthRequest::Pin { cred }) => {
+            (_, PamAuthRequest::Pin { cred }) => {
                 let hello_tag = self.fetch_hello_key_tag(account_id);
                 let hello_key: LoadableIdentityKey = keystore
                     .get_tagged_hsm_key(&hello_tag)

--- a/src/common/src/idprovider/interface.rs
+++ b/src/common/src/idprovider/interface.rs
@@ -5,10 +5,11 @@
  */
 
 use crate::db::KeyStoreTxn;
-use crate::unix_proto::{DeviceAuthorizationResponse, PamAuthRequest, PamAuthResponse};
+use crate::unix_proto::{PamAuthRequest, PamAuthResponse};
 use async_trait::async_trait;
-use himmelblau::auth::UserToken as UnixUserToken;
+use himmelblau::{DeviceAuthorizationResponse, MFAAuthContinue, UserToken as UnixUserToken};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
@@ -66,31 +67,28 @@ pub struct UserToken {
     pub valid: bool,
 }
 
-#[derive(Debug)]
 pub enum AuthCredHandler {
-    Password,
-    DeviceAuthorizationGrant,
-    /// Additional data required by the provider to complete the
-    /// authentication, but not required by PAM
-    ///
-    /// Sadly due to how this is passed around we can't make this a
-    /// generic associated type, else it would have to leak up to the
-    /// daemon.
-    ///
-    /// ⚠️  TODO: Optimally this should actually be a tokio oneshot receiver
-    /// with the decision from a task that is spawned.
-    MFA {
-        data: String,
-    },
-    SetupPin,
-    Pin,
+    MFA { flow: MFAAuthContinue },
+    DeviceAuthorizationGrant { flow: DeviceAuthorizationResponse },
+    SetupPin { token: UnixUserToken },
+    None,
+}
+
+impl fmt::Debug for AuthCredHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthCredHandler::MFA { .. } => f.write_str("MFA { .. }"),
+            AuthCredHandler::DeviceAuthorizationGrant { .. } => {
+                f.write_str("DeviceAuthorizationGrant { .. }")
+            }
+            AuthCredHandler::SetupPin { .. } => f.write_str("SetupPin { .. }"),
+            AuthCredHandler::None => f.write_str("None"),
+        }
+    }
 }
 
 pub enum AuthRequest {
     Password,
-    DeviceAuthorizationGrant {
-        data: DeviceAuthorizationResponse,
-    },
     MFACode {
         msg: String,
     },
@@ -113,9 +111,6 @@ impl Into<PamAuthResponse> for AuthRequest {
     fn into(self) -> PamAuthResponse {
         match self {
             AuthRequest::Password => PamAuthResponse::Password,
-            AuthRequest::DeviceAuthorizationGrant { data } => {
-                PamAuthResponse::DeviceAuthorizationGrant { data }
-            }
             AuthRequest::MFACode { msg } => PamAuthResponse::MFACode { msg },
             AuthRequest::MFAPoll {
                 msg,

--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -48,6 +48,7 @@ enum CacheState {
     OfflineNextCheck(SystemTime),
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum AuthSession {
     InProgress {
         account_id: String,
@@ -1098,7 +1099,7 @@ where
                 // contained to the resolver so that it has generic offline-paths
                 // that are possible?
                 match (&cred_handler, &pam_next_req) {
-                    (AuthCredHandler::Password, PamAuthRequest::Password { cred }) => {
+                    (_, PamAuthRequest::Password { cred }) => {
                         match self.check_cache_userpassword(token.uuid, cred).await {
                             Ok(true) => Ok(AuthResult::Success {
                                 token: *token.clone(),
@@ -1110,11 +1111,7 @@ where
                             }
                         }
                     }
-                    (AuthCredHandler::Password, _) => {
-                        // AuthCredHandler::Password is only valid with a cred provided
-                        return Err(());
-                    }
-                    (AuthCredHandler::DeviceAuthorizationGrant, _) => {
+                    (AuthCredHandler::DeviceAuthorizationGrant { .. }, _) => {
                         // AuthCredHandler::DeviceAuthorizationGrant is invalid for offline auth
                         return Err(());
                     }
@@ -1122,11 +1119,11 @@ where
                         // AuthCredHandler::MFA is invalid for offline auth
                         return Err(());
                     }
-                    (AuthCredHandler::SetupPin, _) => {
+                    (AuthCredHandler::SetupPin { .. }, _) => {
                         // AuthCredHandler::SetupPin is invalid for offline auth
                         return Err(());
                     }
-                    (AuthCredHandler::Pin, PamAuthRequest::Pin { .. }) => {
+                    (_, PamAuthRequest::Pin { .. }) => {
                         // The Pin acts as a single device password, and can be
                         // used to unlock the TPM to validate the authentication.
                         let mut hsm_lock = self.hsm.lock().await;
@@ -1151,8 +1148,16 @@ where
 
                         auth_result
                     }
-                    (AuthCredHandler::Pin, _) => {
-                        // AuthCredHandler::Pin is only valid with a cred provided
+                    (AuthCredHandler::None, PamAuthRequest::MFACode { .. }) => {
+                        // AuthCredHandler::None is invalid with MFACode
+                        return Err(());
+                    }
+                    (AuthCredHandler::None, PamAuthRequest::MFAPoll { .. }) => {
+                        // AuthCredHandler::None is invalid with MFAPoll
+                        return Err(());
+                    }
+                    (AuthCredHandler::None, PamAuthRequest::SetupPin { .. }) => {
+                        // AuthCredHandler::None is invalid with SetupPin
                         return Err(());
                     }
                 }
@@ -1215,10 +1220,6 @@ where
             .await?
         {
             (auth_session, PamAuthResponse::Password) => {
-                // Can continue!
-                auth_session
-            }
-            (auth_session, PamAuthResponse::DeviceAuthorizationGrant { .. }) => {
                 // Can continue!
                 auth_session
             }

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -22,29 +22,12 @@ pub struct NssGroup {
     pub members: Vec<String>,
 }
 
-/* RFC8628: 3.2. Device Authorization Response */
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct DeviceAuthorizationResponse {
-    pub device_code: String,
-    pub user_code: String,
-    pub verification_uri: String,
-    pub verification_uri_complete: Option<String>,
-    pub expires_in: u32,
-    pub interval: Option<u32>,
-    /* The message is not part of RFC8628, but an add-on from MS. Listed
-     * optional here to support all implementations. */
-    pub message: Option<String>,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthResponse {
     Unknown,
     Success,
     Denied,
     Password,
-    DeviceAuthorizationGrant {
-        data: DeviceAuthorizationResponse,
-    },
     /// PAM must prompt for an authentication code
     MFACode {
         msg: String,
@@ -68,9 +51,8 @@ pub enum PamAuthResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PamAuthRequest {
     Password { cred: String },
-    DeviceAuthorizationGrant { data: DeviceAuthorizationResponse },
     MFACode { cred: String },
-    MFAPoll,
+    MFAPoll { poll_attempt: u32 },
     SetupPin { pin: String },
     Pin { cred: String },
 }

--- a/src/idmap/src/lib.rs
+++ b/src/idmap/src/lib.rs
@@ -129,8 +129,7 @@ fn object_id_to_sid(object_id: &Uuid) -> Result<AadSid, IdmapError> {
 }
 
 fn rid_from_sid(sid: &AadSid) -> Result<u32, IdmapError> {
-    Ok(sid.sub_auths
-        [usize::try_from(sid.num_auths).map_err(|_| IDMAP_SID_INVALID)? - 1])
+    Ok(sid.sub_auths[usize::try_from(sid.num_auths).map_err(|_| IDMAP_SID_INVALID)? - 1])
 }
 
 pub const DEFAULT_IDMAP_RANGE: (u32, u32) = (200000, 2000200000);

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -19,6 +19,7 @@ libc = { workspace = true }
 kanidm_unix_common = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+himmelblau_unix_common.workspace = true
 
 [build-dependencies]
 pkg-config.workspace = true


### PR DESCRIPTION
Fixes #219

This is meant to address the issues in #219. Unfortunately, it appears that SSHD is not terminating the auth attempt when the ssh session times out. There isn't really anything we can do about that. We can however, handle this a little better in the communication between the daemon and the pam module. Now the daemon will do nothing unless prompted by the pam module (when polling). I also added code to honor the DAG timeout specified by Microsoft at init time.

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
