### PR TITLE
PAM should be placed first in the stack

### DIFF
--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -1,9 +1,9 @@
 Name: Azure authentication
 Default: yes
-Priority: 192
+Priority: 512
 Auth-Type: Primary
 Auth:
-	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user use_first_pass
+	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user
 Account-Type: Primary
 Account:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user


### PR DESCRIPTION
This allows us to provide a PIN prompt prior to
pam-unix taking over and sending a password
prompt. pam-unix still works as expected, because
pam-himmelblau skips local users.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
