### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install-ubuntu:
 	install -m 0644 ./src/config/himmelblau.conf.example /etc/himmelblau/himmelblau.conf
 	install -m 0755 ./target/release/libnss_himmelblau.so /usr/lib/x86_64-linux-gnu/libnss_himmelblau.so.2
 	install -m 0755 ./target/release/libpam_himmelblau.so /usr/lib/x86_64-linux-gnu/security/pam_himmelblau.so
+	install -m 0755 ./target/release/libpam_himmelblau.so /usr/lib/security/pam_himmelblau.so
 	install -m 0644 ./platform/debian/pam-config /usr/share/pam-configs/himmelblau
 	install -m 0755 ./target/release/himmelblaud /usr/sbin
 	install -m 0755 ./target/release/himmelblaud_tasks /usr/sbin


### PR DESCRIPTION
Updated make file install-ubuntu now copies libpam_himmelblau.so to /usr/lib/security/pam_himmelblau.so

Fixes #251

Checklist

- [x] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [x] make test has been run and passes
