### PR TITLE
Ignore broker scopes requests for now

### DIFF
--- a/src/daemon/src/broker.rs
+++ b/src/daemon/src/broker.rs
@@ -89,7 +89,7 @@ impl HimmelblauBroker for Broker {
         if request.account.username.to_lowercase() != user.spn.to_lowercase() {
             return Err("Invalid request for user!".into());
         }
-        let scopes = request.auth_parameters.requested_scopes;
+        let scopes = vec![];
         let token = self
             .cachelayer
             .get_user_accesstoken(Id::Name(user.spn), scopes)

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -1,5 +1,5 @@
 /*
-   MIT License 
+   MIT License
 
    Copyright (c) 2015 TOZNY
    Copyright (c) 2020 William Brown <william@blackhats.net.au>


### PR DESCRIPTION
This will require a PRTv3. Meanwhile ignore the
scopes request, otherwise the request will fail.

Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
