### PR TITLE
Fix Ubuntu PAM fallback to password prompt

### DIFF
--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -3,7 +3,7 @@ Default: yes
 Priority: 512
 Auth-Type: Primary
 Auth:
-	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user
+	[success=end default=die]    pam_himmelblau.so ignore_unknown_user
 Account-Type: Primary
 Account:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user


### PR DESCRIPTION
Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
