### PR TITLE
Fix CVE-2024-11738: rustls network-reachable panic in `Acceptor::accept`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.15"
+version = "0.6.16"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]
@@ -78,7 +78,7 @@ tracing-forest = "^0.1.6"
 rusqlite = "^0.32.0"
 hashbrown = { version = "0.14.0", features = ["serde", "inline-more", "ahash"] }
 lru = "^0.12.3"
-kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.15" }
+kanidm_lib_crypto = { path = "./src/crypto", version = "0.6.16" }
 kanidm_utils_users = { path = "./src/users" }
 walkdir = "2"
 csv = "1.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ os-release = "^0.1.0"
 jsonwebtoken = "^9.2.0"
 zeroize = "^1.7.0"
 idmap = { path = "src/idmap" }
+rustls = ">=0.23.19" # CVE-2024-11738
 
 # Kanidm deps
 argon2 = { version = "0.5.2", features = ["alloc"] }


### PR DESCRIPTION
Fixes #

Checklist

- [ ] This pr contains no AI generated code
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes
