### PR TITLE
Disable SELinux labeling on build container volume mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ deb:
 	for v in 22.04 24.04; do \
 		echo "Building Ubuntu $$v packages"; \
 		$(DOCKER) build -t himmelblau-ubuntu$$v-build -f images/ubuntu/Dockerfile.$$v .; \
-		$(DOCKER) run --rm -it -v ./:/himmelblau himmelblau-ubuntu$$v-build; \
+		$(DOCKER) run --rm --security-opt label=disable -it -v ./:/himmelblau himmelblau-ubuntu$$v-build; \
 		mv ./target/debian/*.deb ./packaging/; \
 	done
 
@@ -72,7 +72,7 @@ rpm:
 	for v in rocky8 rocky9 sle15sp6 tumbleweed rawhide fedora41; do \
 		echo "Building $$v RPM packages"; \
 		$(DOCKER) build -t himmelblau-$$v-build -f images/rpm/Dockerfile.$$v .; \
-		$(DOCKER) run --rm -it -v ./:/himmelblau himmelblau-$$v-build; \
+		$(DOCKER) run --rm --security-opt label=disable -it -v ./:/himmelblau himmelblau-$$v-build; \
 		for file in ./target/generate-rpm/*.rpm; do \
 			mv "$$file" "$${file%.rpm}-$$v.rpm"; \
 		done; \


### PR DESCRIPTION
At least with rootless podman on SELinux-enabled RedHat-based distributions, access to volume mounts breaks due to a default of enabling SELinux labeling from inside the container on those mounts. This prevents building of RPMs and DEBs.

Enable option --security-opt label=disable for calls to docker/podman run to disable SELinux labeling on volume mounts. The option is supposed to be supported by both. Verified for (rootless) podman.

Fixes #320

Checklist

- [X] This pr contains no AI generated code
- [X] make package has been run and succeeded

no influence on those, I guess:
- [ ] cargo fmt has been run
- [ ] cargo clippy has been run
- [ ] A functionality test has been added
- [ ] make test has been run and passes