### PR TITLE
Entra Id no longer permits SFA enrollment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 kanidm_unix_common = { path = "src/glue" }
-libhimmelblau = { version = "0.5.1" }
+libhimmelblau = { version = "0.5.3" }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.4.1"
 reqwest = { version = "^0.12.2", features = ["json"] }


### PR DESCRIPTION
Entra Id is now rejecting authentication attempts
to the enrollment service with Single Factor
Authentication. We can work around this by
permitting users to authenticate with SFA if the
host is already enrolled. This means a user with
MFA will be required to enroll the host (which
just requires authenticating once).

Fixes #
