### PR TITLE
Fix libutf8proc dependency issue on Ubuntu 22.04

### DIFF
--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -47,7 +47,7 @@ libhimmelblau.workspace = true
 [package.metadata.deb]
 name = "himmelblau"
 maintainer = "David Mulder <dmulder@suse.com>"
-depends = ["libssl3", "libsqlite3-0", "libutf8proc3"]
+depends = ["$auto"]
 recommends = ["nss-himmelblau", "pam-himmelblau", "krb5-user"]
 assets = [
   ["../../platform/debian/himmelblau.conf.example", "etc/himmelblau/himmelblau.conf", "644"],


### PR DESCRIPTION
Fixes # 346

This was also effecting installation on Debian 12.