### PR TITLE
Fix GOA crash when krb5.conf doesn't include /etc/krb5.conf.d - Stable 0.8.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/platform/debian/scripts/postinst
+++ b/platform/debian/scripts/postinst
@@ -49,3 +49,14 @@ if [[ -f /etc/apparmor.d/usr.lib.libreoffice.program.soffice.bin ]]; then
 	# Reload the AppArmor profile to apply the changes
 	apparmor_parser -r /etc/apparmor.d/usr.lib.libreoffice.program.soffice.bin || echo "apparmor reload failed"
 fi
+
+# Ensure `includedir /etc/krb5.conf.d` is present in /etc/krb5.conf
+KRB5_CONF="/etc/krb5.conf"
+KRB5_INCLUDE_LINE="includedir /etc/krb5.conf.d"
+
+if [[ -f "$KRB5_CONF" ]]; then
+    if ! grep -qF "$KRB5_INCLUDE_LINE" "$KRB5_CONF"; then
+        printf "\n%s\n" "$KRB5_INCLUDE_LINE" >> "$KRB5_CONF"
+        echo "Added '$KRB5_INCLUDE_LINE' to $KRB5_CONF"
+    fi
+fi


### PR DESCRIPTION
We should still follow up with mitkrb5 to fix the
bug which caused the crash.