### PR TITLE
Linux Intune policy application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "himmelblau_policies"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "himmelblau_unix_common",
+ "os-release",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "himmelblau_red_asn1"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2071,7 @@ dependencies = [
  "console-subscriber",
  "csv",
  "futures",
+ "himmelblau_policies",
  "himmelblau_unix_common",
  "identity_dbus_broker",
  "kanidm-hsm-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "broker-client"
+version = "1.0.0"
+dependencies = [
+ "serde_json",
+ "zbus",
+]
+
+[[package]]
 name = "browser-window"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2000,8 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "himmelblau_unix_common",
+ "libc",
+ "libhimmelblau",
  "os-release",
  "regex",
  "reqwest",
@@ -2000,6 +2010,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4716,12 +4727,12 @@ version = "1.0.0"
 name = "sso"
 version = "1.0.0"
 dependencies = [
+ "broker-client",
  "clap 4.5.38",
  "serde",
  "serde_json",
  "tokio",
  "uuid",
- "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"src/common",
 	"src/pam",
 	"src/nss",
+	"src/policies",
 	"src/sketching",
 	"src/proto",
 	"src/crypto",
@@ -47,6 +48,7 @@ anyhow = "^1.0.98"
 tokio = { version = "^1.45.0", features = ["rt", "macros", "sync", "time", "net", "io-util", "signal", "rt-multi-thread"] }
 tokio-util = { version = "^0.7.15", features = ["codec"] }
 async-trait = "^0.1.88"
+himmelblau_policies = { path = "src/policies" }
 pem = "^3.0.5"
 chrono = "^0.4.40"
 os-release = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
 	"src/sshd-config",
 	"src/sso",
 	"src/qr-greeter",
+	"src/broker-client",
 ]
 resolver = "2"
 
@@ -58,6 +59,7 @@ idmap = { path = "src/idmap" }
 identity_dbus_broker = "0.1.3"
 rustls = ">=0.23.19" # CVE-2024-11738
 console-subscriber = "0.4.1"
+broker-client = { path = "src/broker-client" }
 
 # Kanidm deps
 argon2 = { version = "0.5.2", features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Himmelblau is an interoperability suite for Microsoft Azure Entra ID and Intune.
 The name of the project comes from a German word for Azure (sky blue).
 
 Himmelblau supports Linux authentication to Microsoft Azure Entra ID via PAM and NSS modules.
-The PAM and NSS modules communicate with Entra ID via the himmelblaud daemon. Himmelblau plans to
-enforce Intune MDM policies, but this work isn't completed yet.
+The PAM and NSS modules communicate with Entra ID via the himmelblaud daemon. Himmelblau also
+supports Intune device enrollment, policy enforcement, and marking devices as compliant with
+Intune MDM policies.
 
 [![Azure Entra Id Authentication for Linux](img/sambaxp.png)](https://youtu.be/wCibnqVQ_bs "Azure Entra Id Authentication for Linux")
 

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -224,9 +224,7 @@ fi
 .TP
 .B apply_policy
 .RE
-A boolean option that enables the experimental application of Intune policies to the authenticated user. This setting does not mark the device as compliant in Entra ID, nor does it register the device as managed in Intune. Instead, it attempts to apply any assigned Intune policies to the user session.
-
-For this feature to function correctly, an `app_id` must be defined for the corresponding domain, and the "DeviceManagementConfiguration.Read.All" API permission must be granted to it.
+A boolean option that enables the application and enforcement of Intune policies to the authenticated user.
 
 By default, this option is disabled.
 

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -222,6 +222,18 @@ fi
 .RE
 
 .TP
+.B apply_policy
+.RE
+A boolean option that enables the experimental application of Intune policies to the authenticated user. This setting does not mark the device as compliant in Entra ID, nor does it register the device as managed in Intune. Instead, it attempts to apply any assigned Intune policies to the user session.
+
+For this feature to function correctly, an `app_id` must be defined for the corresponding domain, and the "DeviceManagementConfiguration.Read.All" API permission must be granted to it.
+
+By default, this option is disabled.
+
+.EXAMPLES
+apply_policy = false
+
+.TP
 .B authority_host
 .RE
 Specifies the hostname for Microsoft authentication. The default value is

--- a/platform/debian/himmelblaud-tasks.service
+++ b/platform/debian/himmelblaud-tasks.service
@@ -16,11 +16,11 @@ User=root
 Type=notify
 ExecStart=/usr/sbin/himmelblaud_tasks
 
-CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_SETUID
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
-NoNewPrivileges=true
+ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib /var/cache/himmelblaud
+NoNewPrivileges=false
 PrivateDevices=true
 ProtectHostname=true
 ProtectClock=true

--- a/platform/opensuse/himmelblaud-tasks.service
+++ b/platform/opensuse/himmelblaud-tasks.service
@@ -16,11 +16,11 @@ User=root
 Type=notify
 ExecStart=/usr/sbin/himmelblaud_tasks
 
-CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_SETUID
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
-NoNewPrivileges=true
+ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib /var/cache/himmelblaud
+NoNewPrivileges=false
 PrivateDevices=true
 ProtectHostname=true
 ProtectClock=true

--- a/src/broker-client/Cargo.toml
+++ b/src/broker-client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "broker-client"
+version.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde_json.workspace = true
+zbus = "^5.7"

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -554,6 +554,10 @@ impl HimmelblauConfig {
         self.config.get(domain, "logon_token_app_id")
     }
 
+    pub fn get_intune_device_id(&self, domain: &str) -> Option<String> {
+        self.config.get(domain, "intune_device_id")
+    }
+
     pub fn get_enable_experimental_mfa(&self) -> bool {
         match_bool(self.config.get("global", "enable_experimental_mfa"), true)
     }
@@ -1365,6 +1369,27 @@ mod tests {
         );
         let config_missing = HimmelblauConfig::new(None).unwrap();
         assert_eq!(config_missing.get_logon_script(), None);
+    }
+
+    #[test]
+    fn test_get_intune_device_id() {
+        let config_data = r#"
+        [example.com]
+        intune_device_id = 123e4567-e89b-12d3-a456-426614174000
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        assert_eq!(
+            config.get_intune_device_id("example.com"),
+            Some("123e4567-e89b-12d3-a456-426614174000".to_string())
+        );
+
+        // Test missing domain
+        assert_eq!(config.get_intune_device_id("missing.com"), None);
+        let config_missing = HimmelblauConfig::new(None).unwrap();
+        assert_eq!(config_missing.get_intune_device_id("example.com"), None);
     }
 
     #[test]

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -173,8 +173,8 @@ impl TaskRequest {
             TaskRequest::LoadProfilePhoto(account_id, _) => {
                 format!("LoadProfilePhoto({}, ...)", account_id)
             }
-            TaskRequest::ApplyPolicy(account_id, object_id, _) => {
-                format!("ApplyPolicy({}, {}, ...)", account_id, object_id)
+            TaskRequest::ApplyPolicy(account_id, _, _) => {
+                format!("ApplyPolicy({}, ...)", account_id)
             }
         }
     }

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -157,6 +157,7 @@ pub enum TaskRequest {
     LogonScript(String, String),
     KerberosCCache(uid_t, uid_t, Vec<u8>, Vec<u8>),
     LoadProfilePhoto(String, String),
+    ApplyPolicy(String, String, String),
 }
 
 impl TaskRequest {
@@ -171,6 +172,9 @@ impl TaskRequest {
             }
             TaskRequest::LoadProfilePhoto(account_id, _) => {
                 format!("LoadProfilePhoto({}, ...)", account_id)
+            }
+            TaskRequest::ApplyPolicy(account_id, object_id, _) => {
+                format!("ApplyPolicy({}, {}, ...)", account_id, object_id)
             }
         }
     }

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -92,11 +92,7 @@
 # provides flexibility for environments requiring custom name transformations.
 # name_mapping_script =
 #
-# Whether to apply Intune policies (experimental). This will not mark the device
-# compliant in Entra Id, nor create an Intune managed device in the portal. It
-# will only attempt to apply the policies assigned in Intune to the user. An
-# app_id MUST be defined for this domain for policy application to succeed, and
-# the "DeviceManagementConfiguration.Read.All" API permission MUST be granted.
+# Whether to apply Intune policies.
 # apply_policy = false ; {true|false}
 #
 # authority_host = login.microsoftonline.com

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -92,6 +92,13 @@
 # provides flexibility for environments requiring custom name transformations.
 # name_mapping_script =
 #
+# Whether to apply Intune policies (experimental). This will not mark the device
+# compliant in Entra Id, nor create an Intune managed device in the portal. It
+# will only attempt to apply the policies assigned in Intune to the user. An
+# app_id MUST be defined for this domain for policy application to succeed, and
+# the "DeviceManagementConfiguration.Read.All" API permission MUST be granted.
+# apply_policy = false ; {true|false}
+#
 # authority_host = login.microsoftonline.com
 #
 # The location of the cache database

--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -33,6 +33,7 @@ serde = { workspace = true }
 serde_json.workspace = true
 futures = "^0.3.28"
 systemd-journal-logger = "^2.2.2"
+himmelblau_policies = { workspace = true }
 users = "^0.11.0"
 sketching = { workspace = true }
 walkdir = { workspace = true }

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -35,7 +35,7 @@ use clap::{Arg, ArgAction, Command};
 use futures::{SinkExt, StreamExt};
 use himmelblau::{ClientInfo, IdToken, UserToken as UnixUserToken};
 use himmelblau_unix_common::config::{split_username, HimmelblauConfig};
-use himmelblau_unix_common::constants::DEFAULT_CONFIG_PATH;
+use himmelblau_unix_common::constants::{DEFAULT_APP_ID, DEFAULT_CONFIG_PATH};
 use himmelblau_unix_common::db::{Cache, CacheTxn, Db};
 use himmelblau_unix_common::idprovider::himmelblau::HimmelblauMultiProvider;
 use himmelblau_unix_common::idprovider::interface::Id;
@@ -506,73 +506,90 @@ async fn handle_client(
                                                     }
 
                                                     // Apply Intune policies
-                                                    let domain = split_username(account_id)
-                                                        .map(|(_, domain)| domain)
-                                                        .unwrap_or("");
                                                     if cfg.get_apply_policy()
-                                                        && cfg.get_app_id(domain).is_some()
                                                     {
-                                                        if let Some(token) = cachelayer
+                                                        let graph_token = cachelayer
                                                             .get_user_accesstoken(
-                                                                Id::Name(account_id.to_string()),
-                                                                vec!["DeviceManagementConfiguration.Read.All".to_string()],
-                                                                None,
-                                                            )
-                                                            .await {
-                                                            if let Ok(uuid) = token.uuid() {
-                                                                if let Some(access_token) =
-                                                                    token.access_token.clone()
-                                                                {
-                                                                    let (tx, rx) = oneshot::channel();
+                                                                Id::Name(account_id.clone()),
+                                                                vec!["00000003-0000-0000-c000-000000000000/.default".to_string()],
+                                                                Some(DEFAULT_APP_ID.to_string())
+                                                            ).await;
+                                                        let intune_token = cachelayer
+                                                            .get_user_accesstoken(
+                                                                Id::Name(account_id.clone()),
+                                                                vec!["0000000a-0000-0000-c000-000000000000/.default".to_string()],
+                                                                Some(DEFAULT_APP_ID.to_string())
+                                                            ).await;
 
-                                                                    match task_channel_tx
-                                                                        .send_timeout(
-                                                                            (
-                                                                                TaskRequest::ApplyPolicy(
-                                                                                    account_id.to_string(),
-                                                                                    uuid.to_string(),
-                                                                                    access_token
-                                                                                        .to_string(),
-                                                                                ),
-                                                                                tx,
+                                                        if let Some(graph_token) = graph_token {
+                                                            if let Some(intune_token) = intune_token {
+                                                                let (tx, rx) = oneshot::channel();
+
+                                                                match task_channel_tx
+                                                                    .send_timeout(
+                                                                        (
+                                                                            TaskRequest::ApplyPolicy(
+                                                                                account_id.clone(),
+                                                                                graph_token
+                                                                                    .access_token
+                                                                                    .clone()
+                                                                                    .unwrap_or("".to_string()),
+                                                                                intune_token
+                                                                                    .access_token
+                                                                                    .clone()
+                                                                                    .unwrap_or("".to_string()),
                                                                             ),
-                                                                            Duration::from_millis(100),
+                                                                            tx,
+                                                                        ),
+                                                                        Duration::from_millis(500),
+                                                                    )
+                                                                    .await
+                                                                {
+                                                                    Ok(()) => {
+                                                                        // Now wait for the other end OR timeout.
+                                                                        match time::timeout_at(
+                                                                            time::Instant::now()
+                                                                                + Duration::from_secs(
+                                                                                    5,
+                                                                                ),
+                                                                            rx,
                                                                         )
                                                                         .await
-                                                                    {
-                                                                        Ok(()) => {
-                                                                            // Now wait for the other end OR timeout.
-                                                                            match time::timeout_at(
-                                                                                time::Instant::now()
-                                                                                    + Duration::from_millis(
-                                                                                        1000,
-                                                                                    ),
-                                                                                rx,
-                                                                            )
-                                                                            .await
-                                                                            {
-                                                                                Ok(Ok(status)) => {
-                                                                                    if status == 0 {
-                                                                                        debug!("Successfully applied Intune policies");
-                                                                                    } else {
-                                                                                        debug!("Authentication was explicitly denied due to Intune failure");
-                                                                                        resp = PamAuthResponse::Denied;
-                                                                                    }
-                                                                                }
-                                                                                Ok(Err(e)) => {
-                                                                                    debug!("Authentication was explicitly denied due to Intune failure: {}", e);
-                                                                                    resp = PamAuthResponse::Denied;
-                                                                                }
-                                                                                Err(e) => {
-                                                                                    debug!("Authentication was explicitly denied due to Intune failure: {}", e);
-                                                                                    resp = PamAuthResponse::Denied;
+                                                                        {
+                                                                            Ok(Ok(status)) => {
+                                                                                if status == 0 {
+                                                                                    debug!("Successfully applied Intune policies");
+                                                                                } else {
+                                                                                    resp = PamAuthResponse::Denied(
+                                                                                        "Authentication was explicitly denied due to Intune failure".to_string()
+                                                                                    );
                                                                                 }
                                                                             }
+                                                                            Ok(Err(e)) => {
+                                                                                resp = PamAuthResponse::Denied(
+                                                                                    format!(
+                                                                                        "Authentication was explicitly denied due to Intune failure: {}",
+                                                                                        e
+                                                                                    )
+                                                                                );
+                                                                            }
+                                                                            Err(e) => {
+                                                                                resp = PamAuthResponse::Denied(
+                                                                                    format!(
+                                                                                        "Authentication was explicitly denied due to Intune failure: {}",
+                                                                                        e
+                                                                                    )
+                                                                                );
+                                                                            }
                                                                         }
-                                                                        Err(e) => {
-                                                                            debug!("Authentication was explicitly denied due to Intune failure: {}", e);
-                                                                            resp = PamAuthResponse::Denied;
-                                                                        }
+                                                                    }
+                                                                    Err(e) => {
+                                                                        resp = PamAuthResponse::Denied(
+                                                                            format!(
+                                                                                "Authentication was explicitly denied due to Intune failure: {}",
+                                                                                e
+                                                                            )
+                                                                        );
                                                                     }
                                                                 }
                                                             }

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -1300,11 +1300,16 @@ impl PamHooks for PamKanidm {
                                 "Entra Id Fido authentication failed.",
                                 e
                             );
-                        },
+                        }
                     };
                     match rt.block_on(async {
-                        app.acquire_token_by_mfa_flow(&account_id, Some(&assertion), None, &mut mfa_req)
-                            .await
+                        app.acquire_token_by_mfa_flow(
+                            &account_id,
+                            Some(&assertion),
+                            None,
+                            &mut mfa_req,
+                        )
+                        .await
                     }) {
                         Ok(token) => token,
                         Err(e) => {

--- a/src/policies/Cargo.toml
+++ b/src/policies/Cargo.toml
@@ -21,3 +21,8 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 regex = "^1.9.1"
+base64.workspace = true
+tokio.workspace = true
+himmelblau_unix_common = { workspace = true }
+os-release = "0.1.0"
+semver = "1.0.25"

--- a/src/policies/Cargo.toml
+++ b/src/policies/Cargo.toml
@@ -26,3 +26,6 @@ tokio.workspace = true
 himmelblau_unix_common = { workspace = true }
 os-release = "0.1.0"
 semver = "1.0.25"
+libhimmelblau.workspace = true
+uuid.workspace = true
+libc.workspace = true

--- a/src/policies/src/compliance_ext.rs
+++ b/src/policies/src/compliance_ext.rs
@@ -1,0 +1,268 @@
+/*
+   Unix Azure Entra ID implementation
+   Copyright (C) David Mulder <dmulder@samba.org> 2024
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+use crate::cse::CSE;
+use crate::policies::{Policy, ValueType};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use himmelblau_unix_common::config::HimmelblauConfig;
+use os_release::OsRelease;
+use regex::Regex;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::process::Command;
+
+pub async fn is_disk_encrypted() -> bool {
+    // Check for LUKS encryption using `lsblk`
+    if let Ok(output) = Command::new("lsblk")
+        .arg("-o")
+        .arg("NAME,FSTYPE")
+        .output()
+        .await
+    {
+        if let Ok(output_str) = String::from_utf8(output.stdout) {
+            if output_str.contains("crypt") {
+                return true;
+            }
+        }
+    }
+
+    // Check for entries in `/etc/crypttab`
+    if let Ok(crypttab) = fs::read_to_string("/etc/crypttab").await {
+        if !crypttab.trim().is_empty() {
+            return true;
+        }
+    }
+
+    // Check for mapped encrypted volumes in `/dev/mapper`
+    if let Ok(entries) = fs::read_dir("/dev/mapper").await {
+        let mut entries = entries;
+        while let Some(entry) = entries.next_entry().await.unwrap_or(None) {
+            if let Some(name_str) = entry.file_name().to_str() {
+                if name_str.contains("crypt") {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Check for `dm-crypt` devices using `lsblk`
+    if let Ok(output) = Command::new("lsblk")
+        .arg("-o")
+        .arg("NAME,TYPE,MOUNTPOINT")
+        .output()
+        .await
+    {
+        if let Ok(output_str) = String::from_utf8(output.stdout) {
+            if output_str.contains("dm-crypt") {
+                return true;
+            }
+        }
+    }
+
+    // No disk encryption detected
+    false
+}
+
+fn normalize_version(version: &str) -> String {
+    let parts: Vec<&str> = version.split('.').collect();
+    match parts.len() {
+        0 => version.to_string(), // Shouldn't happen.
+        1 => format!("{}.0.0", version),
+        2 => format!("{}.0", version),
+        _ => version.to_string(),
+    }
+}
+
+pub struct ComplianceCSE {
+    config: HimmelblauConfig,
+}
+
+#[async_trait]
+impl CSE for ComplianceCSE {
+    fn new(config: &HimmelblauConfig, _username: &str) -> Self {
+        ComplianceCSE {
+            config: config.clone(),
+        }
+    }
+
+    /// Process a group of policies. For deleted policies, no action is taken.
+    /// For changed policies, run compliance checks and return an error if any check fails.
+    async fn process_group_policy(&self, changed_gpo_list: Vec<Arc<dyn Policy>>) -> Result<bool> {
+        for policy in changed_gpo_list.iter() {
+            self.apply_compliance(policy.clone()).await?;
+        }
+        Ok(true)
+    }
+}
+
+impl ComplianceCSE {
+    /// Applies the compliance checks for a given policy.
+    ///
+    /// If any check fails, an error is returned with details on the failure.
+    async fn apply_compliance(&self, policy: Arc<dyn Policy>) -> Result<()> {
+        let mut errors: Vec<String> = Vec::new();
+
+        let pattern = Regex::new("linux_*")?;
+        let settings = policy.list_policy_settings(pattern)?;
+
+        for setting in settings.iter() {
+            match setting.key().as_str() {
+                "linux_distribution_alloweddistros" => {
+                    if let Some(ValueType::Collection(children)) = setting.value() {
+                        let mut allowed_distro = String::new();
+                        let mut min_version: Option<String> = None;
+                        let mut max_version: Option<String> = None;
+
+                        for child in children.iter() {
+                            let child_key = child.key();
+                            match child_key.as_str() {
+                                "linux_distribution_alloweddistros_item_$type" => {
+                                    if let Some(ValueType::Text(val)) = child.value() {
+                                        allowed_distro = val;
+                                    } else {
+                                        errors.push(
+                                            "Failed to read allowed distribution policy"
+                                                .to_string(),
+                                        );
+                                    }
+                                }
+                                "linux_distribution_alloweddistros_item_minimumversion" => {
+                                    if let Some(ValueType::Decimal(val)) = child.value() {
+                                        min_version = Some(normalize_version(&val.to_string()));
+                                    } else if let Some(ValueType::Text(val)) = child.value() {
+                                        if !val.is_empty() {
+                                            min_version = Some(normalize_version(&val));
+                                        }
+                                    } else {
+                                        errors.push(
+                                            "Failed to read allowed distribution minimum version policy"
+                                                .to_string(),
+                                        );
+                                    }
+                                }
+                                "linux_distribution_alloweddistros_item_maximumversion" => {
+                                    if let Some(ValueType::Decimal(val)) = child.value() {
+                                        max_version = Some(normalize_version(&val.to_string()));
+                                    } else if let Some(ValueType::Text(val)) = child.value() {
+                                        if !val.is_empty() {
+                                            max_version = Some(normalize_version(&val));
+                                        }
+                                    } else {
+                                        errors.push(
+                                            "Failed to read allowed distribution maximum version policy"
+                                                .to_string(),
+                                        );
+                                    }
+                                }
+                                unknown => {
+                                    errors.push(format!(
+                                        "Unrecognized compliance option '{}'",
+                                        unknown,
+                                    ));
+                                }
+                            }
+                        }
+
+                        let os_release = OsRelease::new()?;
+
+                        let system_distro = os_release.id;
+                        let system_version_str = normalize_version(&os_release.version_id);
+
+                        if !allowed_distro.is_empty() && system_distro != allowed_distro {
+                            errors.push(format!(
+                                "Distribution compliance failed: system distro '{}' is not '{}'",
+                                system_distro, allowed_distro
+                            ));
+                        }
+
+                        use semver::Version;
+                        let system_version = Version::parse(&system_version_str).map_err(|e| {
+                            anyhow!(
+                                "Failed to parse system version '{}' as semver: {}",
+                                system_version_str,
+                                e
+                            )
+                        })?;
+
+                        if let Some(ref min) = min_version {
+                            let min_semver = Version::parse(min).map_err(|e| {
+                                anyhow!(
+                                    "Failed to parse minimum version '{}' as semver: {}",
+                                    min,
+                                    e
+                                )
+                            })?;
+                            if system_version < min_semver {
+                                errors.push(format!(
+                                    "Version compliance failed: system version '{}' is less than minimum '{}'",
+                                    system_version, min_semver
+                                ));
+                            }
+                        }
+                        if let Some(ref max) = max_version {
+                            let max_semver = Version::parse(max).map_err(|e| {
+                                anyhow!(
+                                    "Failed to parse maximum version '{}' as semver: {}",
+                                    max,
+                                    e
+                                )
+                            })?;
+                            if system_version > max_semver {
+                                errors.push(format!(
+                                    "Version compliance failed: system version '{}' is greater than maximum '{}'",
+                                    system_version, max_semver
+                                ));
+                            }
+                        }
+                    }
+                }
+                "linux_deviceencryption_required" => {
+                    if let Some(ValueType::Boolean(required)) = setting.value() {
+                        if required && !is_disk_encrypted().await {
+                            errors.push("Device encryption compliance failed: encryption likely not enabled".to_string());
+                        }
+                    } else {
+                        errors.push("Failed to read device encryption policy".to_string());
+                    }
+                }
+                "linux_passwordpolicy_minimumlength" => {
+                    if let Some(ValueType::Decimal(min_length)) = setting.value() {
+                        let system_min_length = self.config.get_hello_pin_min_length();
+                        if system_min_length < min_length as usize {
+                            errors.push(format!(
+                                "Password policy compliance failed: system minimum length {} is less than required {}",
+                                system_min_length, min_length
+                            ));
+                        }
+                    } else {
+                        errors.push("Failed to read minimum password length policy".to_string());
+                    }
+                }
+                unknown => {
+                    errors.push(format!("Unrecognized compliance option '{}'", unknown));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!("Compliance check failures: {}", errors.join("; ")))
+        }
+    }
+}

--- a/src/policies/src/cse.rs
+++ b/src/policies/src/cse.rs
@@ -22,18 +22,13 @@
 use crate::policies::Policy;
 use anyhow::Result;
 use async_trait::async_trait;
-use std::collections::HashMap;
+use himmelblau_unix_common::config::HimmelblauConfig;
 use std::sync::Arc;
 
 #[async_trait]
 pub trait CSE: Send + Sync {
-    fn new(graph_url: &str, access_token: &str, id: &str) -> Self
+    fn new(config: &HimmelblauConfig, username: &str) -> Self
     where
         Self: Sized;
-    async fn process_group_policy(
-        &self,
-        deleted_gpo_list: Vec<Arc<dyn Policy>>,
-        changed_gpo_list: Vec<Arc<dyn Policy>>,
-    ) -> Result<bool>;
-    async fn rsop(&self, gpo: Arc<dyn Policy>) -> Result<HashMap<String, String>>;
+    async fn process_group_policy(&self, changed_gpo_list: Vec<Arc<dyn Policy>>) -> Result<bool>;
 }

--- a/src/policies/src/cse.rs
+++ b/src/policies/src/cse.rs
@@ -19,16 +19,15 @@
 /* Provides a trait which specifies a Client Side Extension for applying
  * Intune policy.
  */
-use crate::policies::Policy;
 use anyhow::Result;
 use async_trait::async_trait;
+use himmelblau::intune::IntuneStatus;
 use himmelblau_unix_common::config::HimmelblauConfig;
-use std::sync::Arc;
 
 #[async_trait]
 pub trait CSE: Send + Sync {
     fn new(config: &HimmelblauConfig, username: &str) -> Self
     where
         Self: Sized;
-    async fn process_group_policy(&self, changed_gpo_list: Vec<Arc<dyn Policy>>) -> Result<bool>;
+    async fn process_group_policy(&self, policies: &mut IntuneStatus) -> Result<bool>;
 }

--- a/src/policies/src/lib.rs
+++ b/src/policies/src/lib.rs
@@ -38,9 +38,6 @@ pub mod cse;
  */
 
 #[cfg(target_family = "unix")]
-pub mod chromium_ext;
-
-#[cfg(target_family = "unix")]
 pub mod scripts_ext;
 
 #[cfg(target_family = "unix")]

--- a/src/policies/src/lib.rs
+++ b/src/policies/src/lib.rs
@@ -39,3 +39,9 @@ pub mod cse;
 
 #[cfg(target_family = "unix")]
 pub mod chromium_ext;
+
+#[cfg(target_family = "unix")]
+pub mod scripts_ext;
+
+#[cfg(target_family = "unix")]
+pub mod compliance_ext;

--- a/src/policies/src/policies.rs
+++ b/src/policies/src/policies.rs
@@ -15,7 +15,6 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-use crate::chromium_ext::ChromiumUserCSE;
 use crate::compliance_ext::ComplianceCSE;
 use crate::cse::CSE;
 use crate::scripts_ext::ScriptsCSE;
@@ -928,7 +927,6 @@ pub async fn apply_group_policy(
     let changed_gpos = get_gpo_list(&graph_url, access_token, id).await?;
 
     let gp_extensions: Vec<Arc<dyn CSE>> = vec![
-        Arc::new(ChromiumUserCSE::new(config, account_id)),
         Arc::new(ScriptsCSE::new(config, account_id)),
         Arc::new(ComplianceCSE::new(config, account_id)),
     ];

--- a/src/policies/src/policies.rs
+++ b/src/policies/src/policies.rs
@@ -19,922 +19,111 @@ use crate::compliance_ext::ComplianceCSE;
 use crate::cse::CSE;
 use crate::scripts_ext::ScriptsCSE;
 use anyhow::{anyhow, Result};
-use async_trait::async_trait;
+use himmelblau::graph::Graph;
+use himmelblau::intune::{IntuneForLinux, IntuneStatus};
+use himmelblau::{ClientInfo, EnrollAttrs, IdToken, UserToken};
 use himmelblau_unix_common::config::{split_username, HimmelblauConfig};
-use regex::Regex;
-use reqwest::{header, Url};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::error;
+use tracing::{debug, instrument};
 
-pub trait PolicySetting: Send + Sync {
-    fn enabled(&self) -> bool;
-    fn class_type(&self) -> PolicyType;
-    fn key(&self) -> String;
-    fn value(&self) -> Option<ValueType>;
-    fn get_compare_pattern(&self) -> String;
-}
-
-#[async_trait]
-pub trait Policy: Send + Sync {
-    fn get_id(&self) -> String;
-    fn get_name(&self) -> String;
-    async fn load_policy_settings(&mut self, graph_url: &str, access_token: &str) -> Result<bool>;
-    fn list_policy_settings(&self, pattern: Regex) -> Result<Vec<Arc<dyn PolicySetting>>>;
-    fn clone(&self) -> Arc<dyn Policy>;
-}
-
-#[derive(Deserialize, Clone)]
-struct ConfigurationPolicy {
-    id: String,
-    name: String,
-    #[serde(skip)]
-    policy_definitions: Option<Vec<Arc<dyn PolicySetting>>>,
-}
-
-#[async_trait]
-impl Policy for ConfigurationPolicy {
-    fn get_id(&self) -> String {
-        self.id.clone()
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-
-    async fn load_policy_settings(&mut self, graph_url: &str, access_token: &str) -> Result<bool> {
-        let settings: Vec<ConfigurationPolicySetting> =
-            list_config_policy_settings(graph_url, access_token, &self.id).await?;
-        let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-        for setting in settings {
-            res.push(Arc::new(setting));
-        }
-        self.policy_definitions = Some(res);
-        Ok(true)
-    }
-
-    fn list_policy_settings(&self, pattern: Regex) -> Result<Vec<Arc<dyn PolicySetting>>> {
-        match &self.policy_definitions {
-            Some(policy_definitions) => {
-                let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-                for policy_definition in policy_definitions {
-                    if pattern.is_match(&policy_definition.get_compare_pattern()) {
-                        res.push(policy_definition.clone());
-                    }
-                }
-                Ok(res)
-            }
-            None => Err(anyhow!("Policy Definitions were not loaded")),
-        }
-    }
-
-    fn clone(&self) -> Arc<dyn Policy> {
-        Arc::new(ConfigurationPolicy {
-            id: self.id.clone(),
-            name: self.name.clone(),
-            policy_definitions: self.policy_definitions.clone(),
-        })
-    }
-}
-
-#[derive(Deserialize)]
-struct ConfigurationPolicies {
-    value: Vec<ConfigurationPolicy>,
-}
-
-async fn list_configuration_policies(
-    graph_url: &str,
-    access_token: &str,
-) -> Result<Vec<ConfigurationPolicy>> {
-    let url = Url::parse_with_params(
-        &format!("{}/beta/deviceManagement/configurationPolicies", graph_url),
-        &[
-            ("$select", "name,id"),
-            (
-                "$filter",
-                "(platforms eq 'linux') and (technologies has 'linuxMdm')",
-            ),
-        ],
-    )
-    .map_err(|e| anyhow!("{:?}", e))?;
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<ConfigurationPolicies>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-async fn get_compliance_policy_assigned(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-    policy_id: &str,
-) -> Result<bool> {
-    let url = &format!(
-        "{}/beta/deviceManagement/compliancePolicies/{}/assignments",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        let assignments = resp.json::<GroupPolicyAssignments>().await?.value;
-        parse_assignments(graph_url, access_token, id, policy_id, assignments).await
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-async fn list_compliance_policy_settings(
-    graph_url: &str,
-    access_token: &str,
-    policy_id: &str,
-) -> Result<Vec<ConfigurationPolicySetting>> {
-    let url = &format!(
-        "{}/beta/deviceManagement/compliancePolicies/{}/settings",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<ConfigurationPoliciesSettings>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Deserialize)]
-struct CompliancePolicy {
-    id: String,
-    name: String,
-    #[serde(skip)]
-    policy_definitions: Option<Vec<Arc<dyn PolicySetting>>>,
-}
-
-#[async_trait]
-impl Policy for CompliancePolicy {
-    fn get_id(&self) -> String {
-        self.id.clone()
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-
-    async fn load_policy_settings(&mut self, graph_url: &str, access_token: &str) -> Result<bool> {
-        let settings: Vec<ConfigurationPolicySetting> =
-            list_compliance_policy_settings(graph_url, access_token, &self.id).await?;
-        let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-        for setting in settings {
-            res.push(Arc::new(setting));
-        }
-        self.policy_definitions = Some(res);
-        Ok(true)
-    }
-
-    fn list_policy_settings(&self, pattern: Regex) -> Result<Vec<Arc<dyn PolicySetting>>> {
-        match &self.policy_definitions {
-            Some(policy_definitions) => {
-                let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-                for policy_definition in policy_definitions {
-                    if pattern.is_match(&policy_definition.get_compare_pattern()) {
-                        res.push(policy_definition.clone());
-                    }
-                }
-                Ok(res)
-            }
-            None => Err(anyhow!("Policy Definitions were not loaded")),
-        }
-    }
-
-    fn clone(&self) -> Arc<dyn Policy> {
-        Arc::new(CompliancePolicy {
-            id: self.id.clone(),
-            name: self.name.clone(),
-            policy_definitions: self.policy_definitions.clone(),
-        })
-    }
-}
-
-#[derive(Deserialize)]
-struct CompliancePolicies {
-    value: Vec<CompliancePolicy>,
-}
-
-async fn list_compliance_policies(
-    graph_url: &str,
-    access_token: &str,
-) -> Result<Vec<CompliancePolicy>> {
-    let url = Url::parse_with_params(
-        &format!("{}/beta/deviceManagement/compliancePolicies", graph_url),
-        &[
-            ("$select", "name,id"),
-            (
-                "$filter",
-                "(platforms eq 'linux') and (technologies has 'linuxMdm')",
-            ),
-        ],
-    )
-    .map_err(|e| anyhow!("{:?}", e))?;
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<CompliancePolicies>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct GroupPolicyConfiguration {
-    id: String,
-    enabled: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct GroupPolicyConfigurations {
-    value: Vec<GroupPolicyConfiguration>,
-}
-
-async fn list_group_policy_configurations(
-    graph_url: &str,
-    access_token: &str,
-    policy_id: &str,
-) -> Result<Vec<GroupPolicyConfiguration>> {
-    let url = &format!(
-        "{}/beta/deviceManagement/groupPolicyConfigurations/{}/definitionValues",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<GroupPolicyConfigurations>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Deserialize, Clone)]
-struct GroupPolicyDefinition {
-    #[serde(skip)]
-    enabled: bool,
-    #[serde(rename = "classType")]
-    class_type: String,
-    #[serde(rename = "displayName")]
-    display_name: String,
-    #[serde(rename = "categoryPath")]
-    category_path: String,
-    #[serde(skip)]
-    value: PresentationValue,
-}
-
-impl PolicySetting for GroupPolicyDefinition {
-    fn enabled(&self) -> bool {
-        self.enabled
-    }
-
-    fn class_type(&self) -> PolicyType {
-        if self.class_type == "user" {
-            PolicyType::User
-        } else if self.class_type == "device" {
-            PolicyType::Device
-        } else {
-            PolicyType::Unknown
-        }
-    }
-
-    fn key(&self) -> String {
-        self.display_name.clone()
-    }
-
-    fn value(&self) -> Option<ValueType> {
-        match &self.value.value {
-            Some(value) => Some(value.clone()),
-            None => self.value.values.as_ref().cloned(),
-        }
-    }
-
-    fn get_compare_pattern(&self) -> String {
-        self.category_path.clone()
-    }
-}
-
-async fn get_group_policy_definition(
-    graph_url: &str,
-    access_token: &str,
-    policy_id: &str,
-    def_id: &str,
-) -> Result<GroupPolicyDefinition> {
-    let url = &format!(
-        "{}/beta/deviceManagement/groupPolicyConfigurations/{}/definitionValues/{}/definition",
-        graph_url, policy_id, def_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<GroupPolicyDefinition>().await?)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Deserialize, Serialize, Clone)]
-#[serde(untagged)]
-pub enum ValueType {
-    Text(String),
-    Decimal(i64),
-    Boolean(bool),
-    MultiText(Vec<String>),
-    List(Vec<PresentationValueList>),
-    #[serde(skip)]
-    Collection(Vec<Arc<dyn PolicySetting>>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct PresentationValueList {
-    name: String,
-    value: Option<String>,
-}
-
-#[derive(Default, Deserialize, Clone)]
-struct PresentationValue {
-    value: Option<ValueType>,
-    values: Option<ValueType>,
-}
-
-#[derive(Deserialize)]
-struct PresentationValues {
-    value: Option<Vec<PresentationValue>>,
-}
-
-async fn get_group_policy_values(
-    graph_url: &str,
-    access_token: &str,
-    policy_id: &str,
-    definition_id: &str,
-) -> Result<PresentationValue> {
-    let url = &format!("{}/beta/deviceManagement/groupPolicyConfigurations/{}/definitionValues/{}/presentationValues", graph_url, policy_id, definition_id);
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        match resp.json::<PresentationValues>().await?.value {
-            Some(value) => {
-                // There should be exactly one value
-                if value.len() != 1 {
-                    Err(anyhow!("The wrong number of values were returned"))
-                } else {
-                    Ok(value[0].clone())
-                }
-            }
-            None => Err(anyhow!("No values were returned")),
-        }
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Deserialize, Clone)]
-pub struct GroupPolicy {
-    id: String,
-    #[serde(rename = "displayName")]
-    name: String,
-    #[serde(skip)]
-    policy_definitions: Option<Vec<Arc<dyn PolicySetting>>>,
-}
-
-#[async_trait]
-impl Policy for GroupPolicy {
-    fn get_id(&self) -> String {
-        self.id.clone()
-    }
-
-    fn get_name(&self) -> String {
-        self.name.clone()
-    }
-
-    async fn load_policy_settings(&mut self, graph_url: &str, access_token: &str) -> Result<bool> {
-        let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-        let definition_values =
-            list_group_policy_configurations(graph_url, access_token, &self.id).await?;
-        for definition_value in definition_values {
-            let mut definition = get_group_policy_definition(
-                graph_url,
-                access_token,
-                &self.id,
-                &definition_value.id,
-            )
-            .await?;
-            definition.enabled = definition_value.enabled;
-            match get_group_policy_values(graph_url, access_token, &self.id, &definition_value.id)
-                .await
-            {
-                Ok(val) => {
-                    definition.value = val;
-                    res.push(Arc::new(definition));
-                }
-                Err(e) => {
-                    error!(
-                        "Failed fetching presentation value for {}: {}",
-                        definition_value.id, e
-                    );
-                }
-            };
-        }
-        self.policy_definitions = Some(res);
-        Ok(true)
-    }
-
-    fn list_policy_settings(&self, pattern: Regex) -> Result<Vec<Arc<dyn PolicySetting>>> {
-        match &self.policy_definitions {
-            Some(policy_definitions) => {
-                let mut res: Vec<Arc<dyn PolicySetting>> = vec![];
-                for policy_definition in policy_definitions {
-                    if pattern.is_match(&policy_definition.get_compare_pattern()) {
-                        res.push(policy_definition.clone());
-                    }
-                }
-                Ok(res)
-            }
-            None => Err(anyhow!("Policy Definitions were not loaded")),
-        }
-    }
-
-    fn clone(&self) -> Arc<dyn Policy> {
-        Arc::new(GroupPolicy {
-            id: self.id.clone(),
-            name: self.name.clone(),
-            policy_definitions: self.policy_definitions.clone(),
-        })
-    }
-}
-
-#[derive(Deserialize)]
-struct GroupPolicies {
-    value: Vec<GroupPolicy>,
-}
-
-async fn list_group_policies(graph_url: &str, access_token: &str) -> Result<Vec<GroupPolicy>> {
-    let url = Url::parse_with_params(
-        &format!(
-            "{}/beta/deviceManagement/groupPolicyConfigurations",
-            graph_url
-        ),
-        &[("$select", "displayName,id")],
-    )
-    .map_err(|e| anyhow!("{:?}", e))?;
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<GroupPolicies>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(PartialEq)]
-pub enum PolicyType {
-    User,
-    Device,
-    Unknown,
-}
-
-#[derive(Serialize, Deserialize)]
-struct DirectoryObjectsRequest {
-    ids: Vec<String>,
-    types: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct MemberGroupsRequest {
-    #[serde(rename = "groupIds")]
-    group_ids: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct MemberGroupsResponse {
-    value: Vec<String>,
-}
-
-async fn id_memberof_group(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-    group_id: &str,
-) -> Result<bool> {
-    let url = &format!(
-        "{}/v1.0/directoryObjects/{}/checkMemberGroups",
-        graph_url, id
-    );
-    let client = reqwest::Client::new();
-
-    let json_payload = serde_json::to_string(&MemberGroupsRequest {
-        group_ids: vec![group_id.to_string()],
-    })?;
-
-    let resp = client
-        .post(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(json_payload)
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp
-            .json::<MemberGroupsResponse>()
-            .await?
-            .value
-            .contains(&group_id.to_string()))
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct GroupPolicyAssignmentTarget {
-    #[serde(rename = "@odata.type")]
-    odata_type: String,
-    #[serde(rename = "deviceAndAppManagementAssignmentFilterId")]
-    filter_id: Option<String>,
-    /* #[serde(rename = "deviceAndAppManagementAssignmentFilterType")]
-    filter_type: String,*/
-    #[serde(rename = "groupId")]
-    group_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GroupPolicyAssignment {
-    target: GroupPolicyAssignmentTarget,
-}
-
-#[derive(Debug, Deserialize)]
-struct GroupPolicyAssignments {
-    value: Vec<GroupPolicyAssignment>,
-}
-
-async fn parse_assignments(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-    policy_id: &str,
-    assignments: Vec<GroupPolicyAssignment>,
-) -> Result<bool> {
-    let mut assigned = false;
-    let mut excluded = false;
-    for rule in assignments {
-        if rule.target.filter_id.is_some() {
-            error!(
-                "TODO: Device filters have not been implemented, GPO {} will be disabled",
-                policy_id
-            );
-            return Ok(false);
-        }
-        match rule.target.odata_type.as_str() {
-            "#microsoft.graph.allLicensedUsersAssignmentTarget" => {
-                assigned = true;
-            }
-            "#microsoft.graph.allDevicesAssignmentTarget" => {
-                assigned = true;
-            }
-            "#microsoft.graph.groupAssignmentTarget" => match rule.target.group_id {
-                Some(group_id) => {
-                    let member_of =
-                        id_memberof_group(graph_url, access_token, id, &group_id).await?;
-                    if member_of {
-                        assigned = true;
-                    }
-                }
-                None => error!("GPO {}: groupAssignmentTarget missing group id", policy_id),
-            },
-            "#microsoft.graph.exclusionGroupAssignmentTarget" => match rule.target.group_id {
-                Some(group_id) => {
-                    let member_of =
-                        id_memberof_group(graph_url, access_token, id, &group_id).await?;
-                    if member_of {
-                        excluded = true;
-                    }
-                }
-                None => error!("GPO {}: groupAssignmentTarget missing group id", policy_id),
-            },
-            target => {
-                error!("GPO {}: unrecognized rule target \"{}\"", policy_id, target);
-            }
-        }
-    }
-    if assigned && !excluded {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-async fn get_gpo_assigned(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-    policy_id: &str,
-) -> Result<bool> {
-    let url = &format!(
-        "{}/beta/deviceManagement/groupPolicyConfigurations/{}/assignments",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        let assignments = resp.json::<GroupPolicyAssignments>().await?.value;
-        parse_assignments(graph_url, access_token, id, policy_id, assignments).await
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-async fn get_config_policy_assigned(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-    policy_id: &str,
-) -> Result<bool> {
-    let url = &format!(
-        "{}/beta/deviceManagement/configurationPolicies/{}/assignments",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        let assignments = resp.json::<GroupPolicyAssignments>().await?.value;
-        parse_assignments(graph_url, access_token, id, policy_id, assignments).await
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct SimpleSettingValue {
-    value: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct ChoiceSettingValue {
-    value: String,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct GroupSettingCollectionValue {
-    children: Vec<SettingInstance>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct SettingInstance {
-    #[serde(rename = "@odata.type")]
-    odata_type: String,
-    #[serde(rename = "settingDefinitionId")]
-    setting_definition_id: String,
-    #[serde(rename = "simpleSettingValue", default)]
-    simple_value: Option<SimpleSettingValue>,
-    #[serde(rename = "choiceSettingValue", default)]
-    choice_value: Option<ChoiceSettingValue>,
-    #[serde(rename = "groupSettingCollectionValue", default)]
-    group_value: Option<Vec<GroupSettingCollectionValue>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ConfigurationPolicySetting {
-    #[serde(rename = "settingInstance")]
-    setting_instance: SettingInstance,
-}
-
-pub fn parse_input_value(input: &str) -> ValueType {
-    // Attempt to parse the input as a decimal (i64)
-    if let Ok(decimal) = input.parse::<i64>() {
-        return ValueType::Decimal(decimal);
-    }
-
-    // Attempt to parse the input as a boolean
-    if input.eq_ignore_ascii_case("true") {
-        return ValueType::Boolean(true);
-    } else if input.eq_ignore_ascii_case("false") {
-        return ValueType::Boolean(false);
-    }
-
-    // If neither, treat it as plain text
-    ValueType::Text(input.to_string())
-}
-
-impl PolicySetting for ConfigurationPolicySetting {
-    fn enabled(&self) -> bool {
-        // Configuration Policies can't be disabled, so this is always true
-        true
-    }
-
-    fn class_type(&self) -> PolicyType {
-        let user = match Regex::new(r"^user_") {
-            Ok(user) => user,
-            Err(_e) => return PolicyType::Unknown,
-        };
-        let device = match Regex::new(r"^device_") {
-            Ok(device) => device,
-            Err(_e) => return PolicyType::Unknown,
-        };
-        if user.is_match(&self.setting_instance.setting_definition_id) {
-            PolicyType::User
-        } else if device.is_match(&self.setting_instance.setting_definition_id) {
-            PolicyType::Device
-        } else {
-            PolicyType::Unknown
-        }
-    }
-
-    fn key(&self) -> String {
-        self.setting_instance.setting_definition_id.to_string()
-    }
-
-    fn value(&self) -> Option<ValueType> {
-        match self.setting_instance.odata_type.as_str() {
-            "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance" => self
-                .setting_instance
-                .simple_value
-                .clone()
-                .map(|val| parse_input_value(&val.value)),
-            "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance" => {
-                let def_id = format!("{}_", self.setting_instance.setting_definition_id);
-                self.setting_instance
-                    .choice_value
-                    .as_ref()
-                    .and_then(|val| val.value.strip_prefix(&def_id).map(|s| s.to_string()))
-                    .as_deref()
-                    .map(parse_input_value)
-            }
-            "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance" => {
-                self.setting_instance.group_value.clone().map(|collection| {
-                    ValueType::Collection(
-                        collection
-                            .into_iter()
-                            .flat_map(|sub_collection| {
-                                sub_collection.children.into_iter().map(|child| {
-                                    Arc::new(ConfigurationPolicySetting {
-                                        setting_instance: child.clone(),
-                                    }) as Arc<dyn PolicySetting>
-                                })
-                            })
-                            .collect(),
-                    )
-                })
-            }
-            unknown => {
-                error!(
-                    "Unrecognized device management configuration setting instance: {}",
-                    unknown
-                );
-                None
-            }
-        }
-    }
-
-    fn get_compare_pattern(&self) -> String {
-        self.setting_instance.setting_definition_id.to_string()
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct ConfigurationPoliciesSettings {
-    value: Vec<ConfigurationPolicySetting>,
-}
-
-async fn list_config_policy_settings(
-    graph_url: &str,
-    access_token: &str,
-    policy_id: &str,
-) -> Result<Vec<ConfigurationPolicySetting>> {
-    let url = &format!(
-        "{}/beta/deviceManagement/configurationPolicies/{}/settings",
-        graph_url, policy_id
-    );
-    let client = reqwest::Client::new();
-    let resp = client
-        .get(url)
-        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
-        .send()
-        .await?;
-    if resp.status().is_success() {
-        Ok(resp.json::<ConfigurationPoliciesSettings>().await?.value)
-    } else {
-        Err(anyhow!(resp.status()))
-    }
-}
-
-/* get_gpo_list
- * Get the full list of Group Policy Objects for a given id (user or device).
- *
- * graph_url        The microsoft graph URL
- * access_token     An authenticated token for reading the graph
- * id               The ID of the user/group/device to list policies for
- */
-async fn get_gpo_list(
-    graph_url: &str,
-    access_token: &str,
-    id: &str,
-) -> Result<Vec<Arc<dyn Policy>>> {
-    let mut res: Vec<Arc<dyn Policy>> = vec![];
-    let config_policy_list = list_configuration_policies(graph_url, access_token).await?;
-    for mut policy in config_policy_list {
-        // Check assignments and whether this policy applies
-        let assigned = get_config_policy_assigned(graph_url, access_token, id, &policy.id).await?;
-        if assigned {
-            // Only load policy defs if we know we'll be using them
-            policy.load_policy_settings(graph_url, access_token).await?;
-            res.push(Arc::new(policy));
-        }
-    }
-    let group_policy_list = list_group_policies(graph_url, access_token).await?;
-    for mut gpo in group_policy_list {
-        // Check assignments and whether this policy applies
-        let assigned = get_gpo_assigned(graph_url, access_token, id, &gpo.id).await?;
-        if assigned {
-            // Only load policy defs if we know we'll be using them
-            gpo.load_policy_settings(graph_url, access_token).await?;
-            res.push(Arc::new(gpo));
-        }
-    }
-    let compliance_policy_list = list_compliance_policies(graph_url, access_token).await?;
-    for mut policy in compliance_policy_list {
-        // Check assignments and whether this policy applies
-        let assigned =
-            get_compliance_policy_assigned(graph_url, access_token, id, &policy.id).await?;
-        if assigned {
-            // Only load policy defs if we know we'll be using them
-            policy.load_policy_settings(graph_url, access_token).await?;
-            res.push(Arc::new(policy));
-        }
-    }
-    Ok(res)
-}
-
-pub async fn apply_group_policy(
+#[instrument(skip(config, graph_token, intune_token))]
+pub async fn apply_intune_policy(
     config: &HimmelblauConfig,
-    access_token: &str,
     account_id: &str,
-    id: &str,
+    graph_token: &str,
+    intune_token: &str,
 ) -> Result<bool> {
+    debug!(?account_id, "Attempting to enforce policies");
+
     let domain = split_username(account_id)
         .map(|(_, domain)| domain)
         .ok_or(anyhow!(
             "Failed to parse domain name from account id '{}'",
             account_id
         ))?;
-    let graph_url = config
-        .get_graph_url(domain)
-        .ok_or(anyhow!("Failed to find graph url for domain {}", domain))?;
-    let changed_gpos = get_gpo_list(&graph_url, access_token, id).await?;
+
+    let intune_device_id = match config.get_intune_device_id(&domain) {
+        Some(id) => id,
+        // This device isn't enrolled in Intune, there is nothing to enforce
+        None => {
+            debug!("Device not enrolled in Intune, skipping");
+            return Ok(true);
+        }
+    };
+    debug!(
+        ?account_id,
+        ?intune_device_id,
+        "Applying policies for user and device"
+    );
+
+    let graph = Graph::new(&config.get_odc_provider(domain), domain, None, None, None)
+        .await
+        .map_err(|e| anyhow!(e))?;
+
+    let endpoints = graph
+        .intune_service_endpoints(graph_token)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    debug!("Discovered Intune service endpoints");
+
+    let intune = IntuneForLinux::new(endpoints).map_err(|e| anyhow!(e))?;
+
+    let token = UserToken {
+        token_type: String::new(),
+        scope: None,
+        expires_in: 0,
+        ext_expires_in: 0,
+        refresh_token: String::new(),
+        access_token: Some(intune_token.to_string()),
+        client_info: ClientInfo::default(),
+        id_token: IdToken::default(),
+        prt: None,
+    };
+
+    // Update device details
+    let attrs =
+        EnrollAttrs::new(domain.to_string(), None, None, None, None).map_err(|e| anyhow!(e))?;
+    intune
+        .details(&token, &attrs, &intune_device_id)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    debug!("Updated Intune device details");
+
+    // Get the list of policies to apply
+    let policies = intune
+        .policies(&token, &intune_device_id)
+        .await
+        .map_err(|e| anyhow!(e))?;
+    debug!("Received policy enforcement actions:\n{:#?}", policies);
+    let mut statuses: IntuneStatus = policies.into();
+    statuses.set_device_id(intune_device_id);
 
     let gp_extensions: Vec<Arc<dyn CSE>> = vec![
         Arc::new(ScriptsCSE::new(config, account_id)),
         Arc::new(ComplianceCSE::new(config, account_id)),
     ];
 
+    let mut errors = vec![];
     for ext in gp_extensions {
-        let cchanged_gpos: Vec<Arc<dyn Policy>> = changed_gpos.to_vec();
-        ext.process_group_policy(cchanged_gpos).await?;
+        match ext.process_group_policy(&mut statuses).await {
+            Ok(_) => {}
+            Err(e) => {
+                errors.push(e);
+            }
+        }
     }
+    debug!("Enforced Intune policy");
 
-    Ok(true)
+    // Report policy status
+    debug!("Reporting Intune policy status:\n{:#?}", statuses);
+    intune
+        .status(&token, statuses)
+        .await
+        .map_err(|e| anyhow!(e))?;
+
+    if !errors.is_empty() {
+        Err(anyhow!("Policy enforcement failed: {:?}", errors))
+    } else {
+        Ok(true)
+    }
 }

--- a/src/policies/src/scripts_ext.rs
+++ b/src/policies/src/scripts_ext.rs
@@ -1,0 +1,269 @@
+/*
+   Unix Azure Entra ID implementation
+   Copyright (C) David Mulder <dmulder@samba.org> 2024
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+use crate::cse::CSE;
+use crate::policies::{Policy, ValueType};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use himmelblau_unix_common::config::HimmelblauConfig;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// A simple persistent cache mapping usernames to the set of applied policy IDs.
+#[derive(Serialize, Deserialize, Default)]
+pub struct PolicyCache {
+    pub user_policies: HashMap<String, HashSet<String>>,
+}
+
+impl PolicyCache {
+    /// Loads the cache from the given file path. If the file does not exist, returns an empty cache.
+    pub async fn load(path: &PathBuf) -> Result<Self> {
+        if let Ok(data) = fs::read_to_string(path).await {
+            let cache = serde_json::from_str(&data)?;
+            Ok(cache)
+        } else {
+            Ok(PolicyCache::default())
+        }
+    }
+
+    /// Saves the cache to the given file path.
+    pub async fn save(&self, path: &PathBuf) -> Result<()> {
+        let data = serde_json::to_string_pretty(self)?;
+        fs::write(path, data).await?;
+        Ok(())
+    }
+
+    /// Returns the set of applied policy IDs for the specified user.
+    pub fn get_for_user(&self, username: &str) -> HashSet<String> {
+        self.user_policies
+            .get(username)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Updates the cache for the given user.
+    pub fn update_for_user(&mut self, username: &str, applied_policy_ids: HashSet<String>) {
+        self.user_policies
+            .insert(username.to_string(), applied_policy_ids);
+    }
+}
+
+pub struct ScriptsCSE {
+    username: String,
+    config: HimmelblauConfig,
+}
+
+#[async_trait]
+impl CSE for ScriptsCSE {
+    fn new(config: &HimmelblauConfig, username: &str) -> Self {
+        ScriptsCSE {
+            username: username.to_string(),
+            config: config.clone(),
+        }
+    }
+
+    async fn process_group_policy(&self, changed_gpo_list: Vec<Arc<dyn Policy>>) -> Result<bool> {
+        // Generate the persistent cache path.
+        let cache_path_str = self.cache_path().await?;
+        let cache_path = PathBuf::from(cache_path_str);
+        // Load the existing cache.
+        let mut cache = PolicyCache::load(&cache_path).await?;
+        let cached_policy_ids = cache.get_for_user(&self.username);
+        // Collect new policy IDs from the changed policies.
+        let new_policy_ids: HashSet<String> = changed_gpo_list.iter().map(|p| p.get_id()).collect();
+
+        // Remove policies that were applied before but are not in the new set.
+        for old_policy in cached_policy_ids.difference(&new_policy_ids) {
+            let script_path = self.script_path().await?;
+            let cron_file = format!("/etc/cron.d/policy_{}", old_policy);
+            let script_file = format!("{}/policy_{}_script.sh", script_path, old_policy);
+            let wrapper_file = format!("{}/policy_{}_wrapper.sh", script_path, old_policy);
+            let _ = fs::remove_file(&cron_file).await;
+            let _ = fs::remove_file(&script_file).await;
+            let _ = fs::remove_file(&wrapper_file).await;
+        }
+
+        // Process and apply the changed policies.
+        for policy in changed_gpo_list.iter() {
+            self.apply_policy(policy.clone()).await?;
+        }
+
+        // Update and save the cache.
+        cache.update_for_user(&self.username, new_policy_ids);
+        cache.save(&cache_path).await?;
+
+        Ok(true)
+    }
+}
+
+impl ScriptsCSE {
+    async fn script_path(&self) -> Result<String> {
+        let db_path = self.config.get_db_path();
+        let mut cache_path = PathBuf::from(db_path);
+        cache_path.pop();
+        cache_path.push("bin");
+        let script_path = cache_path
+            .to_str()
+            .ok_or(anyhow!("Failed to convert to string"))
+            .map(|val| val.to_string())?;
+        let _ = fs::create_dir_all(script_path.clone()).await;
+        Ok(script_path)
+    }
+
+    async fn cache_path(&self) -> Result<String> {
+        let db_path = self.config.get_db_path();
+        let mut path = PathBuf::from(db_path);
+        path.pop();
+        // Append a filename, e.g., "cache_<username>_scripts.json"
+        path.push(format!("cache_{}_scripts.json", self.username));
+        path.to_str()
+            .map(|s| s.to_string())
+            .ok_or(anyhow!("Failed to convert cache path to string"))
+    }
+
+    async fn apply_policy(&self, policy: Arc<dyn Policy>) -> Result<()> {
+        let pattern = Regex::new(r"linux_customconfig_.*")?;
+        let settings = policy.list_policy_settings(pattern)?;
+
+        let mut execution_context = "root".to_string();
+        let mut frequency = "1hour".to_string();
+        let mut retries = 0;
+        let mut script_b64: Option<String> = None;
+
+        // Process each setting.
+        for setting in settings.iter() {
+            match setting.key().as_str() {
+                "linux_customconfig_executioncontext" => {
+                    if let Some(ValueType::Text(val)) = setting.value() {
+                        match val.as_str() {
+                            "root" => execution_context = val.to_string(),
+                            "user" => execution_context = self.username.to_string(),
+                            _ => return Err(anyhow!("Unrecognized execution context '{}'", val)),
+                        }
+                    } else {
+                        return Err(anyhow!("Failed to parse script execution context"));
+                    }
+                }
+                "linux_customconfig_executionfrequency" => {
+                    if let Some(ValueType::Text(val)) = setting.value() {
+                        frequency = val.to_string();
+                    } else {
+                        return Err(anyhow!("Failed to parse script execution frequency"));
+                    }
+                }
+                "linux_customconfig_executionretries" => {
+                    if let Some(ValueType::Decimal(val)) = setting.value() {
+                        retries = val;
+                    } else {
+                        return Err(anyhow!("Failed to parse script execution retries"));
+                    }
+                }
+                "linux_customconfig_script" => {
+                    if let Some(ValueType::Text(val)) = setting.value() {
+                        script_b64 = Some(val.to_string());
+                    } else {
+                        return Err(anyhow!("Failed to parse script"));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let script_path = self.script_path().await?;
+
+        let script_b64 =
+            script_b64.ok_or(anyhow!("Policy setting missing: script not provided"))?;
+        let script_bytes = STANDARD.decode(script_b64)?;
+        let script_content = String::from_utf8(script_bytes)?;
+
+        let script_path = format!("{}/policy_{}_script.sh", script_path, policy.get_id());
+        let mut script_file = fs::File::create(&script_path).await?;
+        script_file.write_all(script_content.as_bytes()).await?;
+        Command::new("chmod")
+            .arg("+x")
+            .arg(&script_path)
+            .output()
+            .await?;
+
+        let wrapper_path = format!("{}/policy_{}_wrapper.sh", script_path, policy.get_id());
+        let wrapper_script = format!(
+            r#"#!/bin/bash
+# Wrapper script for policy execution with retry logic.
+retries={}
+attempts=0
+while [ $attempts -le $retries ]; do
+    {}
+    exit_code=$?
+    if [ $exit_code -eq 0 ]; then
+        exit 0
+    fi
+    attempts=$((attempts+1))
+done
+exit $exit_code
+"#,
+            retries, script_path
+        );
+        let mut wrapper_file = fs::File::create(&wrapper_path).await?;
+        wrapper_file.write_all(wrapper_script.as_bytes()).await?;
+        Command::new("chmod")
+            .arg("+x")
+            .arg(&wrapper_path)
+            .output()
+            .await?;
+
+        let cron_schedule = match frequency.as_str() {
+            "15minutes" => "*/15 * * * *", // Every 15 minutes
+            "30minutes" => "*/30 * * * *", // Every 30 minutes
+            "1hour" => "0 * * * *",        // At the top of every hour
+            "2hours" => "0 */2 * * *",     // Every 2 hours at minute 0
+            "3hours" => "0 */3 * * *",     // Every 3 hours at minute 0
+            "6hours" => "0 */6 * * *",     // Every 6 hours at minute 0
+            "12hours" => "0 */12 * * *",   // Every 12 hours at minute 0
+            "1day" => "0 0 * * *",         // Every day at midnight
+            "1week" => "0 0 * * 0",        // Every week on Sunday at midnight
+            _ => {
+                return Err(anyhow!(
+                    "Unknown script application frequency '{}' for policy {}.",
+                    frequency,
+                    policy.get_id()
+                ))
+            }
+        };
+
+        let cron_job_line = format!("{} {} {}\n", cron_schedule, execution_context, wrapper_path);
+
+        let cron_file_path = format!("/etc/cron.d/policy_{}", policy.get_id());
+        let mut cron_file = fs::File::create(&cron_file_path).await?;
+        cron_file.write_all(cron_job_line.as_bytes()).await?;
+
+        Command::new("chmod")
+            .arg("644")
+            .arg(&cron_file_path)
+            .output()
+            .await?;
+
+        Ok(())
+    }
+}

--- a/src/policies/src/scripts_ext.rs
+++ b/src/policies/src/scripts_ext.rs
@@ -16,20 +16,19 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 use crate::cse::CSE;
-use crate::policies::{Policy, ValueType};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use himmelblau::intune::{IntuneStatus, PolicyStatus};
 use himmelblau_unix_common::config::HimmelblauConfig;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+use tracing::debug;
 
 /// A simple persistent cache mapping usernames to the set of applied policy IDs.
 #[derive(Serialize, Deserialize, Default)]
@@ -84,19 +83,31 @@ impl CSE for ScriptsCSE {
         }
     }
 
-    async fn process_group_policy(&self, changed_gpo_list: Vec<Arc<dyn Policy>>) -> Result<bool> {
+    async fn process_group_policy(&self, policies: &mut IntuneStatus) -> Result<bool> {
         // Generate the persistent cache path.
-        let cache_path_str = self.cache_path().await?;
+        let cache_path_str = self
+            .cache_path()
+            .await
+            .map_err(|e| anyhow!("Failed to determine cache path: {}", e))?;
         let cache_path = PathBuf::from(cache_path_str);
         // Load the existing cache.
-        let mut cache = PolicyCache::load(&cache_path).await?;
+        let mut cache = PolicyCache::load(&cache_path)
+            .await
+            .map_err(|e| anyhow!("Failed to load policy cache: {}", e))?;
         let cached_policy_ids = cache.get_for_user(&self.username);
         // Collect new policy IDs from the changed policies.
-        let new_policy_ids: HashSet<String> = changed_gpo_list.iter().map(|p| p.get_id()).collect();
+        let new_policy_ids: HashSet<String> = policies
+            .policy_statuses
+            .iter()
+            .map(|p| p.policy_id.clone())
+            .collect();
 
         // Remove policies that were applied before but are not in the new set.
         for old_policy in cached_policy_ids.difference(&new_policy_ids) {
-            let script_path = self.script_path().await?;
+            let script_path = self
+                .script_path()
+                .await
+                .map_err(|e| anyhow!("Failed to determine script path: {}", e))?;
             let cron_file = format!("/etc/cron.d/policy_{}", old_policy);
             let script_file = format!("{}/policy_{}_script.sh", script_path, old_policy);
             let wrapper_file = format!("{}/policy_{}_wrapper.sh", script_path, old_policy);
@@ -106,13 +117,23 @@ impl CSE for ScriptsCSE {
         }
 
         // Process and apply the changed policies.
-        for policy in changed_gpo_list.iter() {
-            self.apply_policy(policy.clone()).await?;
+        for policy in policies.policy_statuses.iter_mut() {
+            // Validate this is a scripts policy
+            if policy
+                .details
+                .iter()
+                .any(|d| d.setting_definition_item_id == "linux_customconfig_script")
+            {
+                self.apply_policy(policy).await?;
+            }
         }
 
         // Update and save the cache.
         cache.update_for_user(&self.username, new_policy_ids);
-        cache.save(&cache_path).await?;
+        cache
+            .save(&cache_path)
+            .await
+            .map_err(|e| anyhow!("Failed to save policy cache: {}", e))?;
 
         Ok(true)
     }
@@ -128,7 +149,9 @@ impl ScriptsCSE {
             .to_str()
             .ok_or(anyhow!("Failed to convert to string"))
             .map(|val| val.to_string())?;
-        let _ = fs::create_dir_all(script_path.clone()).await;
+        fs::create_dir_all(script_path.clone())
+            .await
+            .map_err(|e| anyhow!("Failed to create script path {}: {}", script_path, e))?;
         Ok(script_path)
     }
 
@@ -143,71 +166,92 @@ impl ScriptsCSE {
             .ok_or(anyhow!("Failed to convert cache path to string"))
     }
 
-    async fn apply_policy(&self, policy: Arc<dyn Policy>) -> Result<()> {
-        let pattern = Regex::new(r"linux_customconfig_.*")?;
-        let settings = policy.list_policy_settings(pattern)?;
-
+    async fn apply_policy(&self, policy: &mut PolicyStatus) -> Result<()> {
         let mut execution_context = "root".to_string();
         let mut frequency = "1hour".to_string();
         let mut retries = 0;
         let mut script_b64: Option<String> = None;
 
         // Process each setting.
-        for setting in settings.iter() {
-            match setting.key().as_str() {
-                "linux_customconfig_executioncontext" => {
-                    if let Some(ValueType::Text(val)) = setting.value() {
-                        match val.as_str() {
-                            "root" => execution_context = val.to_string(),
-                            "user" => execution_context = self.username.to_string(),
-                            _ => return Err(anyhow!("Unrecognized execution context '{}'", val)),
-                        }
-                    } else {
-                        return Err(anyhow!("Failed to parse script execution context"));
+        for detail in policy.details.iter_mut() {
+            match detail.setting_definition_item_id.as_str() {
+                "linux_customconfig_executioncontext" => match detail.expected_value.as_str() {
+                    "root" => {
+                        execution_context = detail.expected_value.clone();
+                        detail.actual_value = detail.expected_value.clone();
+                        detail.new_compliance_state = "Compliant".to_string();
                     }
-                }
+                    "user" => {
+                        execution_context = self.username.to_string();
+                        detail.actual_value = detail.expected_value.clone();
+                        detail.new_compliance_state = "Compliant".to_string();
+                    }
+                    _ => {
+                        return Err(anyhow!(
+                            "Unrecognized execution context '{}'",
+                            detail.expected_value
+                        ))
+                    }
+                },
                 "linux_customconfig_executionfrequency" => {
-                    if let Some(ValueType::Text(val)) = setting.value() {
-                        frequency = val.to_string();
-                    } else {
-                        return Err(anyhow!("Failed to parse script execution frequency"));
-                    }
+                    frequency = detail.expected_value.clone();
+                    detail.actual_value = detail.expected_value.clone();
+                    detail.new_compliance_state = "Compliant".to_string();
                 }
                 "linux_customconfig_executionretries" => {
-                    if let Some(ValueType::Decimal(val)) = setting.value() {
+                    if let Ok(val) = detail.expected_value.parse::<u32>() {
                         retries = val;
+                        detail.actual_value = detail.expected_value.clone();
+                        detail.new_compliance_state = "Compliant".to_string();
                     } else {
                         return Err(anyhow!("Failed to parse script execution retries"));
                     }
                 }
                 "linux_customconfig_script" => {
-                    if let Some(ValueType::Text(val)) = setting.value() {
-                        script_b64 = Some(val.to_string());
-                    } else {
-                        return Err(anyhow!("Failed to parse script"));
-                    }
+                    script_b64 = Some(detail.expected_value.clone());
+                    detail.actual_value = detail.expected_value.clone();
+                    detail.new_compliance_state = "Compliant".to_string();
                 }
                 _ => {}
             }
         }
 
-        let script_path = self.script_path().await?;
+        let script_directory = self
+            .script_path()
+            .await
+            .map_err(|e| anyhow!("Failed to determine script path: {}", e))?;
 
-        let script_b64 =
-            script_b64.ok_or(anyhow!("Policy setting missing: script not provided"))?;
-        let script_bytes = STANDARD.decode(script_b64)?;
-        let script_content = String::from_utf8(script_bytes)?;
+        let script_b64 = match script_b64 {
+            Some(val) => val,
+            // This isn't a script policy, nothing to do
+            None => return Ok(()),
+        };
+        let script_bytes = STANDARD
+            .decode(script_b64)
+            .map_err(|e| anyhow!("Failed to decode script: {}", e))?;
+        let script_content = String::from_utf8(script_bytes)
+            .map_err(|e| anyhow!("Failed to convert script to utf8 string: {}", e))?;
 
-        let script_path = format!("{}/policy_{}_script.sh", script_path, policy.get_id());
-        let mut script_file = fs::File::create(&script_path).await?;
-        script_file.write_all(script_content.as_bytes()).await?;
+        let script_file_path =
+            format!("{}/policy_{}_script.sh", script_directory, policy.policy_id);
+        let mut script_file = fs::File::create(&script_file_path)
+            .await
+            .map_err(|e| anyhow!("Failed to create script file: {}", e))?;
+        script_file
+            .write_all(script_content.as_bytes())
+            .await
+            .map_err(|e| anyhow!("Failed to write script to file: {}", e))?;
         Command::new("chmod")
             .arg("+x")
-            .arg(&script_path)
+            .arg(&script_file_path)
             .output()
-            .await?;
+            .await
+            .map_err(|e| anyhow!("Failed to set script permissions: {}", e))?;
 
-        let wrapper_path = format!("{}/policy_{}_wrapper.sh", script_path, policy.get_id());
+        let wrapper_script_path = format!(
+            "{}/policy_{}_wrapper.sh",
+            script_directory, policy.policy_id
+        );
         let wrapper_script = format!(
             r#"#!/bin/bash
 # Wrapper script for policy execution with retry logic.
@@ -223,46 +267,71 @@ while [ $attempts -le $retries ]; do
 done
 exit $exit_code
 "#,
-            retries, script_path
+            retries, script_file_path
         );
-        let mut wrapper_file = fs::File::create(&wrapper_path).await?;
-        wrapper_file.write_all(wrapper_script.as_bytes()).await?;
+        let mut wrapper_script_file =
+            fs::File::create(&wrapper_script_path).await.map_err(|e| {
+                anyhow!(
+                    "Failed to create wrapper file {}: {}",
+                    wrapper_script_path,
+                    e
+                )
+            })?;
+        wrapper_script_file
+            .write_all(wrapper_script.as_bytes())
+            .await
+            .map_err(|e| anyhow!("Failed to write wrapper script to file: {}", e))?;
         Command::new("chmod")
             .arg("+x")
-            .arg(&wrapper_path)
+            .arg(&wrapper_script_path)
             .output()
-            .await?;
+            .await
+            .map_err(|e| anyhow!("Failed to set wrapper script permissions: {}", e))?;
 
         let cron_schedule = match frequency.as_str() {
-            "15minutes" => "*/15 * * * *", // Every 15 minutes
-            "30minutes" => "*/30 * * * *", // Every 30 minutes
-            "1hour" => "0 * * * *",        // At the top of every hour
-            "2hours" => "0 */2 * * *",     // Every 2 hours at minute 0
-            "3hours" => "0 */3 * * *",     // Every 3 hours at minute 0
-            "6hours" => "0 */6 * * *",     // Every 6 hours at minute 0
-            "12hours" => "0 */12 * * *",   // Every 12 hours at minute 0
-            "1day" => "0 0 * * *",         // Every day at midnight
-            "1week" => "0 0 * * 0",        // Every week on Sunday at midnight
+            "15" => "*/15 * * * *",  // Every 15 minutes
+            "30" => "*/30 * * * *",  // Every 30 minutes
+            "60" => "0 * * * *",     // At the top of every hour
+            "120" => "0 */2 * * *",  // Every 2 hours at minute 0
+            "180" => "0 */3 * * *",  // Every 3 hours at minute 0
+            "360" => "0 */6 * * *",  // Every 6 hours at minute 0
+            "720" => "0 */12 * * *", // Every 12 hours at minute 0
+            "1440" => "0 0 * * *",   // Every day at midnight
+            "10080" => "0 0 * * 0",  // Every week on Sunday at midnight
             _ => {
                 return Err(anyhow!(
                     "Unknown script application frequency '{}' for policy {}.",
                     frequency,
-                    policy.get_id()
+                    policy.policy_id
                 ))
             }
         };
 
-        let cron_job_line = format!("{} {} {}\n", cron_schedule, execution_context, wrapper_path);
+        let cron_job_line = format!(
+            "{} {} {}\n",
+            cron_schedule, execution_context, wrapper_script_path
+        );
 
-        let cron_file_path = format!("/etc/cron.d/policy_{}", policy.get_id());
-        let mut cron_file = fs::File::create(&cron_file_path).await?;
-        cron_file.write_all(cron_job_line.as_bytes()).await?;
+        let cron_file_path = format!("/etc/cron.d/policy_{}", policy.policy_id);
+        let mut cron_file = fs::File::create(&cron_file_path)
+            .await
+            .map_err(|e| anyhow!("Failed to create cron file: {}", e))?;
+        cron_file
+            .write_all(cron_job_line.as_bytes())
+            .await
+            .map_err(|e| anyhow!("Failed to write cron job to file: {}", e))?;
 
         Command::new("chmod")
             .arg("644")
             .arg(&cron_file_path)
             .output()
-            .await?;
+            .await
+            .map_err(|e| anyhow!("Failed to set cron file permissions: {}", e))?;
+
+        debug!(
+            "Installed script policy to {} for user {}, enforced via cron {}.",
+            &wrapper_script_path, &self.username, &cron_file_path
+        );
 
         Ok(())
     }

--- a/src/sso/Cargo.toml
+++ b/src/sso/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-zbus = "5.2.0"
+broker-client.workspace = true
 
 [package.metadata.deb]
 name = "himmelblau-sso"

--- a/src/sso/src/main.rs
+++ b/src/sso/src/main.rs
@@ -15,11 +15,10 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-use serde_json::json;
-mod broker;
-use broker::BrokerClient;
+use broker_client::BrokerClient;
 use clap::{CommandFactory, Parser, Subcommand};
 use serde::Serialize;
+use serde_json::json;
 use serde_json::Value;
 use std::env;
 use std::error::Error;


### PR DESCRIPTION
Fixes #60 

### Summary of Changes

Himmelblau now fetches and applies Linux Intune policies when they are configured in Microsoft's Intune portal. This update introduces two new policy implementations for Linux devices:

- **Script Policy:** Scripts from Intune are decoded, written to disk, and scheduled to run via cron.

- **Linux Compliance Policy:** Validates system configuration against policy settings such as allowed Linux distributions, required device encryption, and password policy minimum length (which applies to the Hello PIN length).

**Important Notes:**
- Himmelblau now fully supports marking devices as compliant with Intune MDM policies.
- When Intune policy application is enabled, devices which fail to comply with Intune policy will be prohibited from authenticating users.

**Current Limitations:**
- The following compliance policies are not yet implemented. Enforcing these policies will cause authentication to fail:
  - Password policies (note that **Minimum Length** *is* implemented):
    - Minimum digits
    - Minimum Lowercase
    - Minimum Uppercase
    - Minimum Symbols
  - Custom Compliance