### PR TITLE
Default to request group info via Edge browser

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -440,11 +440,11 @@ logon_token_app_id = 544e695f-5d78-442e-b14e-e114e95e640c
 .TP
 .B app_id
 .RE
-Specifies the Entra ID application ID that grants Himmelblau permission to retrieve group names and the
+Specifies the Entra ID application identifier that permits Himmelblau to fetch the
 .B gidNumber
 extended attribute using the
 .B GroupMember.Read.All
-API permission. This is required to resolve group memberships and POSIX attributes for users.
+API permission for rfc2307 idmapping.
 
 If
 .B logon_token_app_id

--- a/platform/debian/himmelblau.conf.example
+++ b/platform/debian/himmelblau.conf.example
@@ -134,8 +134,7 @@ use_etc_skel = true
 # The `app_id` option specifies the Entra ID application ID that has the
 # necessary permissions to obtain access tokens for the `logon_script`. This
 # application SHOULD also include the `GroupMember.Read.All` permission,
-# enabling Himmelblau to retrieve group names and the `gidNumber` extended
-# attribute.
+# enabling Himmelblau to retrieve the `gidNumber` extended attribute.
 #
 # [example.com]
 # app_id = d023f7aa-d214-4b59-911d-6074de623765

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -47,3 +47,4 @@ pub const BROKER_CLIENT_IDENT: &str = "38aa3b87-a06d-4817-b275-7a316988d93b";
 pub const CN_NAME_MAPPING: bool = true;
 pub const DEFAULT_HELLO_PIN_MIN_LEN: usize = 6;
 pub const DEFAULT_CCACHE_DIR: &str = "/tmp/krb5cc_";
+pub const EDGE_BROWSER_CLIENT_ID: &str = "d7b530a4-7680-4c23-a8bf-c52c121d2e87";

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -132,8 +132,7 @@
 # The `app_id` option specifies the Entra ID application ID that has the
 # necessary permissions to obtain access tokens for the `logon_script`. This
 # application SHOULD also include the `GroupMember.Read.All` permission,
-# enabling Himmelblau to retrieve group names and the `gidNumber` extended
-# attribute.
+# enabling Himmelblau to retrieve the `gidNumber` extended attribute.
 #
 # [example.com]
 # app_id = d023f7aa-d214-4b59-911d-6074de623765


### PR DESCRIPTION
The MS Edge browser app_id grants us the ability
to read group names.

Fixes #270
