### PR TITLE
Handle failures in passwordless auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace7abce6e062ed7127c366bd444eede1129cab137b3990680497434af96af32"
+checksum = "05d8fd7e85181ba055b1ba618d48616a0af569389fb09323b3cecdab089fb9ae"
 dependencies = [
  "base64 0.22.1",
  "browser-window",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.4"
+version = "0.9.5"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "^1.0.96"
 tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.6.5", features = ["broker", "changepassword", "on_behalf_of"] }
+libhimmelblau = { version = "0.6.6", features = ["broker", "changepassword", "on_behalf_of"] }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.5.46"
 reqwest = { version = "^0.12.2", features = ["json"] }


### PR DESCRIPTION
Sometimes passwordless auth can fail. When this
happens, a browser auth works around the issue by
falling back to a password + MFA auth. We need to
do the same.