### PR TITLE
Ignore demands for setting up MS Authenticator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d003f5b9b279b77c93a9c5af796adbbfa9ca59a82a0bcb85dcc768b611b063"
+checksum = "09d3dec286a5526320683e29dd16374971a0f4caf6559de9a90452ad925c4cfa"
 dependencies = [
  "base64 0.22.1",
  "browser-window",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "^1.0.140"
 tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.6.11", features = ["broker", "changepassword", "on_behalf_of"] }
+libhimmelblau = { version = "0.6.12", features = ["broker", "changepassword", "on_behalf_of"] }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.5.46"
 reqwest = { version = "^0.12.2", features = ["json"] }


### PR DESCRIPTION
We can't facilitate setting this up for the user,
so just ignore the prompt. The user can handle
this themselves later.

Fixes #462 