### PR TITLE
 Ignore demands for setting up MS Authenticator (0.9.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "clap 4.5.31",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "kanidm_utils_users",
  "whoami",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "libc",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "nss_himmelblau"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3453,7 +3453,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pam_himmelblau"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "authenticator",
  "base64 0.22.1",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "0.9.8"
+version = "0.9.9"
 
 [[package]]
 name = "quote"
@@ -4608,7 +4608,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketching"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "gethostname",
  "num_enum",
@@ -4683,11 +4683,11 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sshd-config"
-version = "0.9.8"
+version = "0.9.9"
 
 [[package]]
 name = "sso"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "clap 4.5.31",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "clap 4.5.31",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "kanidm_utils_users",
  "whoami",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "libc",
 ]
@@ -2697,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d003f5b9b279b77c93a9c5af796adbbfa9ca59a82a0bcb85dcc768b611b063"
+checksum = "09d3dec286a5526320683e29dd16374971a0f4caf6559de9a90452ad925c4cfa"
 dependencies = [
  "base64 0.22.1",
  "browser-window",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "nss_himmelblau"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3453,7 +3453,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pam_himmelblau"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "authenticator",
  "base64 0.22.1",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "0.9.6"
+version = "0.9.8"
 
 [[package]]
 name = "quote"
@@ -4608,7 +4608,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketching"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "gethostname",
  "num_enum",
@@ -4683,11 +4683,11 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sshd-config"
-version = "0.9.6"
+version = "0.9.8"
 
 [[package]]
 name = "sso"
-version = "0.9.6"
+version = "0.9.8"
 dependencies = [
  "clap 4.5.31",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = "^1.0.96"
 tracing-subscriber = "^0.3.17"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.6.9", features = ["broker", "changepassword", "on_behalf_of"] }
+libhimmelblau = { version = "0.6.12", features = ["broker", "changepassword", "on_behalf_of"] }
 clap = { version = "^4.5", features = ["derive", "env"] }
 clap_complete = "^4.5.46"
 reqwest = { version = "^0.12.2", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.9"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]


### PR DESCRIPTION
We can't facilitate setting this up for the user,
so just ignore the prompt. The user can handle
this themselves later.

Fixes #462 