### PR TITLE
Fix Nix Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
           recipe = {lib, enableInteractive ? false}: rustPlatform.buildRustPackage {
             pname = "himmelblau";
             version = cargoToml.workspace.package.version;
-            src = ./.
+            src = ./.;
             outputs = [ "out" "man" ];
             cargoLock = {
               lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,7 @@
           recipe = {lib, enableInteractive ? false}: rustPlatform.buildRustPackage {
             pname = "himmelblau";
             version = cargoToml.workspace.package.version;
-            src = with lib.fileset; toSource {
-              root = ./.;
-              fileset = difference (gitTracked ./.) (fileFilter
-                (file: file.hasExt "nix" || file.hasExt "md" || file == "Makefile") ./.);
-            };
+            src = ./.
             outputs = [ "out" "man" ];
             cargoLock = {
               lockFile = ./Cargo.lock;


### PR DESCRIPTION
The package errors out with
```lib.fileset.gitTracked: Expected the argument (...) to point to a local working tree of a Git repository, but it’s not.```
as nix pulls without the .git folder.
Changing src to ./. fixes this problem and allows the package to build.

Tested in Hyper-V on NixOS 24.11