### PR TITLE
Ensure only the base URL is printed to log

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -49,7 +49,7 @@ use uuid::Uuid;
 
 macro_rules! extract_base_url {
     ($msg:expr) => {{
-        if let Some(regex) = Regex::new(r#"https?://[^\s"'<>]+"#).ok() {
+        if let Ok(regex) = Regex::new(r#"https?://[^\s"'<>]+"#) {
             if let Some(mat) = regex.find(&$msg) {
                 if let Ok(mut parsed) = Url::parse(mat.as_str()) {
                     parsed.set_query(None);
@@ -806,7 +806,8 @@ impl IdProvider for HimmelblauProvider {
                 match $res {
                     Ok(val) => val,
                     Err(MsalError::RequestFailed(msg)) => {
-                        info!(?msg, "Network down detected");
+                        let url = extract_base_url!(msg);
+                        info!(?url, "Network down detected");
                         let mut state = self.state.lock().await;
                         *state = CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
                         return Ok(UserTokenState::UseCached)
@@ -971,7 +972,8 @@ impl IdProvider for HimmelblauProvider {
                 match $res {
                     Ok(val) => val,
                     Err(MsalError::RequestFailed(msg)) => {
-                        info!(?msg, "Network down detected");
+                        let url = extract_base_url!(msg);
+                        info!(?url, "Network down detected");
                         let mut state = self.state.lock().await;
                         *state = CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
                         return Ok((
@@ -1008,8 +1010,7 @@ impl IdProvider for HimmelblauProvider {
                 *state = CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
                 return Ok((
                     AuthRequest::InitDenied {
-                        msg: "Network outage detected."
-                            .to_string(),
+                        msg: "Network outage detected.".to_string(),
                     },
                     AuthCredHandler::None,
                 ));
@@ -1033,8 +1034,7 @@ impl IdProvider for HimmelblauProvider {
                     if !self.attempt_online(tpm, SystemTime::now()).await {
                         return Ok((
                             AuthRequest::InitDenied {
-                                msg: "Network outage detected."
-                                    .to_string(),
+                                msg: "Network outage detected.".to_string(),
                             },
                             AuthCredHandler::None,
                         ));
@@ -1282,7 +1282,8 @@ impl IdProvider for HimmelblauProvider {
                     // If the network goes down during an online PIN auth, we can downgrade to an
                     // offline auth and permit the authentication to proceed.
                     Err(MsalError::RequestFailed(msg)) => {
-                        info!(?msg, "Network down detected");
+                        let url = extract_base_url!(msg);
+                        info!(?url, "Network down detected");
                         let mut state = self.state.lock().await;
                         *state =
                             CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
@@ -1843,8 +1844,7 @@ impl IdProvider for HimmelblauProvider {
         } else {
             Ok((
                 AuthRequest::InitDenied {
-                    msg: "Network outage detected."
-                        .to_string(),
+                    msg: "Network outage detected.".to_string(),
                 },
                 AuthCredHandler::None,
             ))


### PR DESCRIPTION
When a network down is detected, make sure the
URL printed to the log is only ever the base URL.
