### PR TITLE
NixOS: Replace source filter in package derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,7 @@
             version = cargoToml.workspace.package.version;
             src = with lib.fileset; toSource {
               root = ./.;
-              fileset = difference (gitTracked ./.) (fileFilter
-                (file: file.hasExt "nix" || file.hasExt "md" || file == "Makefile") ./.);
+              fileset = unions [ ./src ./man ./Cargo.toml ./Cargo.lock ./scripts/test_script_echo.sh ];
             };
             outputs = [ "out" "man" ];
             cargoLock = {


### PR DESCRIPTION
Follow-up from #479

The previous design excluded files we know won't affect the build, preventing rebuilds when updating readme/makefile.
This design includes only files which will affect the build (cargo + src + man + test script).

The trade-off is that adding extra files/folders at the top-level needs to be added to the union if they are needed for package build.