### PR TITLE
Order services before gdb/nss-user-target

### DIFF
--- a/platform/debian/himmelblaud-tasks.service
+++ b/platform/debian/himmelblaud-tasks.service
@@ -5,6 +5,12 @@
 Description=Himmelblau Local Tasks
 After=chronyd.service ntpd.service network-online.target himmelblaud.service
 
+# This prevents starting unixd-tasks before unixd is running and
+# has created the socket necessary for communication.
+# We need the check so that fs namespacing used by`ReadWritePaths` has a
+# strict enough target to namespace. Without the check it fails in a more confusing way.
+ConditionPathExists=/run/himmelblaud-unixd/task_sock
+
 [Service]
 User=root
 Type=notify
@@ -13,7 +19,7 @@ ExecStart=/usr/sbin/himmelblaud_tasks
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /var/run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
+ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
 NoNewPrivileges=true
 PrivateDevices=true
 ProtectHostname=true

--- a/platform/debian/himmelblaud-tasks.service
+++ b/platform/debian/himmelblaud-tasks.service
@@ -9,7 +9,7 @@ After=chronyd.service ntpd.service network-online.target himmelblaud.service
 # has created the socket necessary for communication.
 # We need the check so that fs namespacing used by`ReadWritePaths` has a
 # strict enough target to namespace. Without the check it fails in a more confusing way.
-ConditionPathExists=/run/himmelblaud-unixd/task_sock
+ConditionPathExists=/run/himmelblaud/task_sock
 
 [Service]
 User=root

--- a/platform/debian/himmelblaud.service
+++ b/platform/debian/himmelblaud.service
@@ -27,7 +27,7 @@ ExecStart=/usr/sbin/himmelblaud
 # Implied by dynamic user.
 # ProtectHome=
 # ProtectSystem=strict
-# ReadWritePaths=/var/run/himmelblaud-unixd /var/cache/himmelblaud-unixd
+# ReadWritePaths=/var/run/himmelblaud /var/cache/himmelblaud
 
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 NoNewPrivileges=true

--- a/platform/debian/himmelblaud.service
+++ b/platform/debian/himmelblaud.service
@@ -3,7 +3,16 @@
 
 [Unit]
 Description=Himmelblau Authentication Daemon
-After=chronyd.service ntpd.service network-online.target
+After=chronyd.service nscd.service ntpd.service network-online.target suspend.target
+Before=systemd-user-sessions.service sshd.service nss-user-lookup.target
+Wants=nss-user-lookup.target
+# While it seems confusing, we need to be after nscd.service so that the
+# Conflicts will trigger and then automatically stop it.
+Conflicts=nscd.service
+# `Upholds` like a `Wants` directive ensures that unixd-tasks is started but also 
+# ensures it's kept running. This allows for a repeatable & fast way of starting 
+# unixd-tasks at the right time.
+Upholds=himmelblaud-tasks.service
 
 [Service]
 DynamicUser=yes
@@ -18,7 +27,7 @@ ExecStart=/usr/sbin/himmelblaud
 # Implied by dynamic user.
 # ProtectHome=
 # ProtectSystem=strict
-# ReadWritePaths=/var/run/kanidm-unixd /var/cache/kanidm-unixd
+# ReadWritePaths=/var/run/himmelblaud-unixd /var/cache/himmelblaud-unixd
 
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 NoNewPrivileges=true

--- a/platform/opensuse/himmelblaud-tasks.service
+++ b/platform/opensuse/himmelblaud-tasks.service
@@ -9,7 +9,7 @@ After=chronyd.service ntpd.service network-online.target suspend.target himmelbl
 # has created the socket necessary for communication.
 # We need the check so that fs namespacing used by`ReadWritePaths` has a
 # strict enough target to namespace. Without the check it fails in a more confusing way.
-ConditionPathExists=/run/himmelblaud-unixd/task_sock
+ConditionPathExists=/run/himmelblaud/task_sock
 
 [Service]
 User=root

--- a/platform/opensuse/himmelblaud-tasks.service
+++ b/platform/opensuse/himmelblaud-tasks.service
@@ -5,6 +5,12 @@
 Description=Himmelblau Local Tasks
 After=chronyd.service ntpd.service network-online.target suspend.target himmelblaud.service
 
+# This prevents starting unixd-tasks before unixd is running and
+# has created the socket necessary for communication.
+# We need the check so that fs namespacing used by`ReadWritePaths` has a
+# strict enough target to namespace. Without the check it fails in a more confusing way.
+ConditionPathExists=/run/himmelblaud-unixd/task_sock
+
 [Service]
 User=root
 Type=notify
@@ -13,7 +19,7 @@ ExecStart=/usr/sbin/himmelblaud_tasks
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 ProtectSystem=strict
-ReadWritePaths=/home /var/run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
+ReadWritePaths=/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib
 NoNewPrivileges=true
 PrivateDevices=true
 ProtectHostname=true

--- a/platform/opensuse/himmelblaud.service
+++ b/platform/opensuse/himmelblaud.service
@@ -27,7 +27,7 @@ ExecStart=/usr/sbin/himmelblaud
 # Implied by dynamic user.
 # ProtectHome=
 # ProtectSystem=strict
-# ReadWritePaths=/var/run/himmelblaud-unixd /var/cache/himmelblaud-unixd
+# ReadWritePaths=/var/run/himmelblaud /var/cache/himmelblaud
 
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 NoNewPrivileges=true

--- a/platform/opensuse/himmelblaud.service
+++ b/platform/opensuse/himmelblaud.service
@@ -3,7 +3,16 @@
 
 [Unit]
 Description=Himmelblau Authentication Daemon
-After=chronyd.service ntpd.service network-online.target suspend.target
+After=chronyd.service nscd.service ntpd.service network-online.target suspend.target
+Before=systemd-user-sessions.service sshd.service nss-user-lookup.target
+Wants=nss-user-lookup.target
+# While it seems confusing, we need to be after nscd.service so that the
+# Conflicts will trigger and then automatically stop it.
+Conflicts=nscd.service
+# `Upholds` like a `Wants` directive ensures that unixd-tasks is started but also 
+# ensures it's kept running. This allows for a repeatable & fast way of starting 
+# unixd-tasks at the right time.
+Upholds=himmelblaud-tasks.service
 
 [Service]
 DynamicUser=yes
@@ -18,7 +27,7 @@ ExecStart=/usr/sbin/himmelblaud
 # Implied by dynamic user.
 # ProtectHome=
 # ProtectSystem=strict
-# ReadWritePaths=/var/run/kanidm-unixd /var/cache/kanidm-unixd
+# ReadWritePaths=/var/run/himmelblaud-unixd /var/cache/himmelblaud-unixd
 
 # SystemCallFilter=@aio @basic-io @chown @file-system @io-event @network-io @sync
 NoNewPrivileges=true


### PR DESCRIPTION
Ensure that the himmelblau resolver has started before the nss-user target. This target is very early in startup, and ensures that users can be resolved for *any* graphical display manager or incoming ssh request.


