### PR TITLE
himmelblau.conf alias `domain` as `domains`

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -429,6 +429,14 @@ impl HimmelblauConfig {
             Some(val) => val.split(',').map(|s| s.trim().to_string()).collect(),
             None => vec![],
         };
+        let domain = match self.config.get("global", "domain") {
+            Some(val) => {
+                info!("Mistyped `domain` parameter detected in himmelblau.conf. Did you mean `domains`?");
+                val.split(',').map(|s| s.trim().to_string()).collect()
+            }
+            None => vec![],
+        };
+        domains.extend(domain);
         let mut sections = self.config.sections();
         sections.retain(|s| s != "global");
         for section in sections {

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -161,7 +161,11 @@ impl HimmelblauMultiProvider {
 
         let mut providers = HashMap::new();
         let cfg = config.read().await;
-        for domain in cfg.get_configured_domains() {
+        let domains = cfg.get_configured_domains();
+        if domains.len() == 0 {
+            return Err(anyhow!("No domains configured in himmelblau.conf"));
+        }
+        for domain in domains {
             debug!("Adding provider for domain {}", domain);
             let authority_host = cfg.get_authority_host(&domain);
             let tenant_id = cfg.get_tenant_id(&domain);


### PR DESCRIPTION
Someone reported an obscure error caused by a
simple typo of writing `domain` in their
himmelblau.conf instead of `domains`. Catch that
particular typo and continue startup, but also
report a better error when there are no domains
configured.
