### PR TITLE
Enforce strict order for the systemd units

### DIFF
--- a/platform/debian/himmelblaud-tasks.service
+++ b/platform/debian/himmelblaud-tasks.service
@@ -4,6 +4,7 @@
 [Unit]
 Description=Himmelblau Local Tasks
 After=chronyd.service ntpd.service network-online.target himmelblaud.service
+Requires=himmelblaud.service
 
 # This prevents starting unixd-tasks before unixd is running and
 # has created the socket necessary for communication.


### PR DESCRIPTION
In my test Debian Bookworm VM image the following occurs:

```
systemd[1]: Starting himmelblaud-tasks.service - Himmelblau Local Tasks...
(ud_tasks)[499]: himmelblaud-tasks.service: Failed to set up mount namespacing: /run/systemd/unit-root/run/himmelblaud: No such file or d>
(ud_tasks)[499]: himmelblaud-tasks.service: Failed at step NAMESPACE spawning /usr/sbin/himmelblaud_tasks: No such file or directory
systemd[1]: himmelblaud-tasks.service: Main process exited, code=exited, status=226/NAMESPACE
systemd[1]: himmelblaud-tasks.service: Failed with result 'exit-code'.
systemd[1]: Failed to start himmelblaud-tasks.service - Himmelblau Local Tasks.
```

For completeness, after starting himmelblaud-tasks manually, the basic 2FA login works to a tenant (not yet far enough to say anything about Windows Hello).

Fix this by adding `Requires=himmelblaud.service`, which results:

```
Starting himmelblaud-tasks.service - Himmelblau Local Tasks... Started himmelblaud-tasks.service - Himmelblau Local Tasks.
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Attempting to connect to himmelblaud ...
00000000-0000-0000-0000-000000000000 DEBUG    🐛 [debug]: \---> Os { code: 2, kind: NotFound, message: "No such file or directory" }
00000000-0000-0000-0000-000000000000 ERROR    🚨 [error]: Unable to find himmelblaud, sleeping ...
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Attempting to connect to himmelblaud ...
00000000-0000-0000-0000-000000000000 INFO     ｉ [info]: Found himmelblaud, waiting for tasks ...
```

[ Just for the record: I have no idea what that debug message is referring
  to. ]