### PR TITLE
Update NixOS support to 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739206421,
-        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "lastModified": 1752620740,
+        "narHash": "sha256-f3pO+9lg66mV7IMmmIqG4PL3223TYMlnlw+pnpelbss=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "rev": "32a4e87942101f1c9f9865e04dc3ddb175f5f32e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -33,7 +33,7 @@
               pam dbus.dev udev.dev
             ] ++ lib.optionals enableInteractive [
               gobject-introspection.dev cairo.dev gdk-pixbuf.dev
-              libsoup.dev pango.dev atk.dev gtk3.dev webkitgtk_4_1
+              libsoup_2_4.dev pango.dev atk.dev gtk3.dev webkitgtk_4_1
             ];
             postBuild = "cp -r man $man/";
             postInstall = "ln -s $out/lib/libnss_himmelblau.so $out/lib/libnss_himmelblau.so.2";


### PR DESCRIPTION
Re: https://github.com/himmelblau-idm/himmelblau/pull/606#issuecomment-3074073176

Updated NixOS dependency to 25.05, and confirmed himmelblau builds fine for me locally. 

I could only see one build error in CI, but there was no error printed for the build, which makes me think that the job ran out of disk or memory. If this PR fails in the same way, I'll change the build command to be a bit more verbose and hopefully let us see where it's dying.