### PR TITLE
Add `fedora42` build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ nix: .packaging .submodules
 	done
 
 DEB_TARGETS := ubuntu22.04 ubuntu24.04 debian12
-RPM_TARGETS := rocky8 rocky9 sle15sp6 tumbleweed rawhide fedora41
+RPM_TARGETS := rocky8 rocky9 sle15sp6 tumbleweed rawhide fedora41 fedora42
 
 .PHONY: package deb rpm $(DEB_TARGETS) $(RPM_TARGETS)
 

--- a/images/rpm/Dockerfile.fedora42
+++ b/images/rpm/Dockerfile.fedora42
@@ -1,0 +1,51 @@
+# Use the official Fedora 42 image as the base
+FROM fedora:42
+
+# Update the package list and install essential build dependencies
+RUN dnf -y update && \
+    dnf -y install \
+    wget \
+    git \
+    gcc \
+    gcc-c++ \
+    make \
+    openssl-devel \
+    dbus-devel \
+    libtool \
+    pkg-config \
+    autoconf \
+    pam-devel \
+    systemd-devel \
+    krb5-devel \
+    pcre2-devel \
+    clang \
+    gettext \
+    sqlite-devel \
+    libunistring-devel \
+    cargo \
+    gobject-introspection-devel \
+    cairo-devel \
+    libsoup3-devel \
+    javascriptcoregtk4.1-devel \
+    webkit2gtk4.1-devel \
+    pango-devel \
+    atk-devel \
+    gtk3-devel \
+    tpm2-tss-devel \
+    utf8proc-devel \
+    webkit2gtk3-devel && \
+    dnf clean all
+
+# Set environment for Rust
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+VOLUME /himmelblau
+
+# Change directory to the repository
+WORKDIR /himmelblau
+
+# Install the cargo-deb tool
+RUN cargo install cargo-generate-rpm
+
+# Build the project and create the RPM package
+CMD cargo build --release --features interactive,tpm && strip -s target/release/*.so && strip -s target/release/aad-tool && strip -s target/release/himmelblaud && strip -s target/release/himmelblaud_tasks && strip -s target/release/broker && cargo generate-rpm -p src/daemon && cargo generate-rpm -p src/nss && cargo generate-rpm -p src/pam && cargo generate-rpm -p src/sshd-config && cargo generate-rpm -p src/sso && cargo generate-rpm -p src/qr-greeter


### PR DESCRIPTION
Adds `fedora42` as a build target, corresponding container image, and add `utf8proc-devel` as a build dependency.

The build targeting `rawhide` doesn't install on Fedora 42, as `pam-himmelblau` will depend on a newer version of libFLAC.

I've tested Himmelblau on multiple Fedora 42 machines since it's release, and it's works well.