### PR TITLE
deps(rust): bump tracing-subscriber in the cargo group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,11 +2825,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3026,12 +3026,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3394,12 +3393,6 @@ checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pam_himmelblau"
@@ -4009,17 +4002,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4030,14 +4014,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5217,14 +5195,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "kanidm_utils_users",
  "whoami",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "libc",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "nss_himmelblau"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "authenticator",
  "base64 0.22.1",
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "0.9.22"
+version = "0.9.23"
 
 [[package]]
 name = "quote"
@@ -4538,7 +4538,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketching"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "gethostname",
  "num_enum",
@@ -4613,11 +4613,11 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sshd-config"
-version = "0.9.22"
+version = "0.9.23"
 
 [[package]]
 name = "sso"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.22"
+version = "0.9.23"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ lazy_static = "^1.4.0"
 paste = "^1.0.12"
 serde = { version = "^1.0.180", features = ["derive"] }
 serde_json = "^1.0.96"
-tracing-subscriber = "^0.3.17"
+tracing-subscriber = "^0.3.20"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 libhimmelblau = { version = "0.6.29", features = ["broker", "changepassword", "on_behalf_of"] }


### PR DESCRIPTION
Bumps the cargo group with 1 update: [tracing-subscriber](https://github.com/tokio-rs/tracing).

Updates `tracing-subscriber` from 0.3.19 to 0.3.20
- [Release notes](https://github.com/tokio-rs/tracing/releases)
- [Commits](https://github.com/tokio-rs/tracing/compare/tracing-subscriber-0.3.19...tracing-subscriber-0.3.20)

---
updated-dependencies:
- dependency-name: tracing-subscriber dependency-version: 0.3.20 dependency-type: direct:production dependency-group: cargo ...

Fixes #