### PR TITLE
deps(rust): bump tracing-subscriber in the cargo group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache
@@ -81,7 +81,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Setup sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - stable-0.7.x
       - stable-0.8.x
       - stable-0.9.x
+      - stable-1.x
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     # limit this to PRs opened by dependabot
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -14,6 +14,7 @@ name: Dependabot auto-approval and auto-merge
       - stable-0.7.x
       - stable-0.8.x
       - stable-0.9.x
+      - stable-1.x
 
 permissions:
   contents: write

--- a/.github/workflows/nixosbuild-ci.yml
+++ b/.github/workflows/nixosbuild-ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   nixos:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v25

--- a/.github/workflows/nixosbuild.yml
+++ b/.github/workflows/nixosbuild.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   nixos:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v25

--- a/.github/workflows/nixosbuild.yml
+++ b/.github/workflows/nixosbuild.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - stable-0.9.x
+      - stable-1.x
 
 jobs:
   nixos:

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -8,6 +8,7 @@ on:
       - stable-0.7.x
       - stable-0.8.x
       - stable-0.9.x
+      - stable-1.x
 
 permissions:
   contents: write

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout code

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-version:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "serde_json",
  "zbus",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "bindgen 0.72.0",
  "cc",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "kanidm_utils_users",
  "whoami",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "libc",
 ]
@@ -3171,11 +3171,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -3355,7 +3355,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3366,12 +3366,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3710,12 +3709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3741,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -4305,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "1.1.0"
+version = "1.2.1"
 
 [[package]]
 name = "quote"
@@ -4436,17 +4429,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4457,14 +4441,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5094,7 +5072,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketching"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "num_enum",
  "opentelemetry",
@@ -5188,11 +5166,11 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "1.1.0"
+version = "1.2.1"
 
 [[package]]
 name = "sso"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "broker-client",
  "clap",
@@ -5795,14 +5773,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "serde_json",
  "zbus",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "bindgen 0.72.0",
  "cc",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_crypto"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_lib_file_permissions"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "kanidm_utils_users",
  "whoami",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_proto"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base32",
  "base64urlsafedata",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "kanidm_utils_users"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "libc",
 ]
@@ -3355,7 +3355,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "quote"
@@ -5072,7 +5072,7 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketching"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "num_enum",
  "opentelemetry",
@@ -5166,11 +5166,11 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "1.2.1"
+version = "1.2.2"
 
 [[package]]
 name = "sso"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "broker-client",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = "^1.4.0"
 paste = "^1.0.12"
 serde = { version = "^1.0.219", features = ["derive"] }
 serde_json = "^1.0.141"
-tracing-subscriber = "^0.3.17"
+tracing-subscriber = "^0.3.20"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 libhimmelblau = { version = "0.7.10", features = ["broker", "changepassword", "on_behalf_of"] }


### PR DESCRIPTION
Bumps the cargo group with 1 update: [tracing-subscriber](https://github.com/tokio-rs/tracing).

Updates `tracing-subscriber` from 0.3.19 to 0.3.20
- [Release notes](https://github.com/tokio-rs/tracing/releases)
- [Commits](https://github.com/tokio-rs/tracing/compare/tracing-subscriber-0.3.19...tracing-subscriber-0.3.20)

---
updated-dependencies:
- dependency-name: tracing-subscriber dependency-version: 0.3.20 dependency-type: direct:production dependency-group: cargo ...

Fixes #