### PR TITLE
Add authselect module for Rocky/Fedora

### DIFF
--- a/platform/el/authselect/README
+++ b/platform/el/authselect/README
@@ -1,0 +1,122 @@
+Himmelblau
+=======================================
+
+Selecting this profile enables local files for identity (like the "minimal"
+profile) and inserts Himmelblau into the PAM stacks to provide Microsoft
+Entra ID sign-in and session integration.
+
+This profile is intended for systems that utilizes both Entra Id enterprise
+sign-in, as well as local users/groups.
+
+WHAT THIS PROFILE CHANGES
+-------------------------
+
+PAM (both system-auth and password-auth):
+- Adds at the top of each stack:
+    `auth     sufficient   pam_himmelblau.so ignore_unknown_user`
+- Adds:
+    `account  sufficient   pam_himmelblau.so ignore_unknown_user`
+- Adds:
+    `password sufficient   pam_himmelblau.so ignore_unknown_user`
+- Adds:
+    `session  optional     pam_himmelblau.so`
+
+Notes:
+- `ignore_unknown_user` avoids failures for services with an unexpected user.
+- Himmelblau is placed before faillock/unix so that the correct prompts are
+  displayed. Himmelblau doesn't display a typical password prompt, like most
+  pam modules, but instead prompts for MFA and Hello PIN setup/auth. Placing
+  other pam modules before pam_himmelblau will cause the incorrect prompt to
+  be displayed (potentially confusing end users).
+
+AVAILABLE OPTIONAL FEATURES
+---------------------------
+
+with-faillock::
+    Enable account locking in case of too many consecutive
+    authentication failures.
+
+with-mkhomedir::
+    Enable automatic creation of home directories for users on their
+    first login.
+
+with-ecryptfs::
+    Enable automatic per-user ecryptfs.
+
+with-silent-lastlog::
+    Do not produce pam_lastlog message during login.
+
+with-pamaccess::
+    Check access.conf during account authorization.
+
+with-pwhistory::
+    Enable pam_pwhistory module for local users.
+
+with-altfiles::
+    Use nss_altfiles for passwd and group nsswitch databases.
+
+without-nullok::
+    Do not add nullok parameter to pam_unix.
+
+DISABLE SPECIFIC NSSWITCH DATABASES
+-----------------------------------
+
+Normally, nsswitch databases set by the profile overwrites values set in
+user-nsswitch.conf. The following options can force authselect to
+ignore value set by the profile and use the one set in user-nsswitch.conf
+instead.
+
+with-custom-aliases::
+Ignore "aliases" map set by the profile.
+
+with-custom-automount::
+Ignore "automount" map set by the profile.
+
+with-custom-ethers::
+Ignore "ethers" map set by the profile.
+
+with-custom-group::
+Ignore "group" map set by the profile.
+
+with-custom-hosts::
+Ignore "hosts" map set by the profile.
+
+with-custom-initgroups::
+Ignore "initgroups" map set by the profile.
+
+with-custom-netgroup::
+Ignore "netgroup" map set by the profile.
+
+with-custom-networks::
+Ignore "networks" map set by the profile.
+
+with-custom-passwd::
+Ignore "passwd" map set by the profile.
+
+with-custom-protocols::
+Ignore "protocols" map set by the profile.
+
+with-custom-publickey::
+Ignore "publickey" map set by the profile.
+
+with-custom-rpc::
+Ignore "rpc" map set by the profile.
+
+with-custom-services::
+Ignore "services" map set by the profile.
+
+with-custom-shadow::
+Ignore "shadow" map set by the profile.
+
+EXAMPLES
+--------
+
+* Enable the himmelblau profile
+
+  authselect select vendor/himmelblau
+
+SEE ALSO
+--------
+* man authselect(8)
+* man pam.d(5)
+* man pam_himmelblau(8)

--- a/platform/el/authselect/fingerprint-auth
+++ b/platform/el/authselect/fingerprint-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/platform/el/authselect/nsswitch.conf
+++ b/platform/el/authselect/nsswitch.conf
@@ -1,0 +1,14 @@
+aliases:    files                                                  {exclude if "with-custom-aliases"}
+automount:  files                                                  {exclude if "with-custom-automount"}
+ethers:     files                                                  {exclude if "with-custom-ethers"}
+group:      files {if "with-altfiles":altfiles }himmelblau systemd {exclude if "with-custom-group"}
+hosts:      files dns myhostname                                   {exclude if "with-custom-hosts"}
+initgroups: files                                                  {exclude if "with-custom-initgroups"}
+netgroup:   files                                                  {exclude if "with-custom-netgroup"}
+networks:   files                                                  {exclude if "with-custom-networks"}
+passwd:     files {if "with-altfiles":altfiles }himmelblau systemd {exclude if "with-custom-passwd"}
+protocols:  files                                                  {exclude if "with-custom-protocols"}
+publickey:  files                                                  {exclude if "with-custom-publickey"}
+rpc:        files                                                  {exclude if "with-custom-rpc"}
+services:   files                                                  {exclude if "with-custom-services"}
+shadow:     files                                                  {exclude if "with-custom-shadow"}

--- a/platform/el/authselect/password-auth
+++ b/platform/el/authselect/password-auth
@@ -1,0 +1,27 @@
+auth        sufficient                                   pam_himmelblau.so ignore_unknown_user
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
+auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     sufficient                                   pam_himmelblau.so ignore_unknown_user
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so
+
+password    sufficient                                   pam_himmelblau.so ignore_unknown_user
+password    requisite                                    pam_pwquality.so
+password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
+password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
+password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so
+session     optional                                     pam_himmelblau.so

--- a/platform/el/authselect/postlogin
+++ b/platform/el/authselect/postlogin
@@ -1,0 +1,8 @@
+auth        optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+password    optional                   pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+
+session     optional                   pam_umask.so silent
+session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet
+session     [default=1]                pam_lastlog.so nowtmp {if "with-silent-lastlog":silent|showfailed}
+session     optional                   pam_lastlog.so silent noupdate showfailed

--- a/platform/el/authselect/smartcard-auth
+++ b/platform/el/authselect/smartcard-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/platform/el/authselect/system-auth
+++ b/platform/el/authselect/system-auth
@@ -1,0 +1,27 @@
+auth        sufficient                                   pam_himmelblau.so ignore_unknown_user
+auth        required                                     pam_faildelay.so delay=2000000
+auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
+auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        required                                     pam_deny.so
+
+account     required                                     pam_access.so                                          {include if "with-pamaccess"}
+account     sufficient                                   pam_himmelblau.so ignore_unknown_user
+account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+account     required                                     pam_unix.so
+
+password    sufficient                                   pam_himmelblau.so ignore_unknown_user
+password    requisite                                    pam_pwquality.so
+password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
+password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
+password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    required                                     pam_deny.so
+
+session     optional                                     pam_keyinit.so revoke
+session     required                                     pam_limits.so
+session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd.so
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
+session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     required                                     pam_unix.so
+session     optional                                     pam_himmelblau.so

--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -99,6 +99,4 @@ nss-himmelblau = "*"
 pam-himmelblau = "*"
 krb5 = "*"
 cron = "*" # For Intune policy scripts
-
-[package.metadata.generate-rpm.requires]
 system-user-tss = "*"

--- a/src/o365/Cargo.toml
+++ b/src/o365/Cargo.toml
@@ -35,6 +35,6 @@ assets = [
 post_install_script = "scripts/postinst"
 post_uninstall_script = "scripts/postrm"
 
-[package.metadata.generate-rpm.requires]
+[package.metadata.generate-rpm.recommends]
 curl = "*"
 libfuse2 = "*"

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -45,6 +45,7 @@ name = "pam-himmelblau"
 maintainer = "David Mulder <dmulder@suse.com>"
 assets = [
   { source = "target/release/libpam_himmelblau.so", dest = "/usr/lib64/security/pam_himmelblau.so", mode = "755" },
+  { source = "platform/el/authselect/*", dest = "/usr/share/authselect/vendor/himmelblau/", mode = "755" },
 ]
 post_install_script = '''
 # Only create a symlink if it doesn't already exist
@@ -52,10 +53,29 @@ if [ ! -e /lib64/security/pam_himmelblau.so ]; then
     mkdir -p /lib64/security
     ln -s /usr/lib64/security/pam_himmelblau.so /lib64/security/pam_himmelblau.so
 fi
+if command -v authselect >/dev/null 2>&1; then
+    feats="$(authselect current 2>/dev/null | awk '"'"'/Enabled features:/{f=1;next} f && /^-/{print $2}'"'"')"
+    authselect select himmelblau $feats --force >/dev/null 2>&1 || :
+    authselect apply-changes >/dev/null 2>&1 || :
+fi
 '''
 post_uninstall_script = '''
 # Only remove a symlink if it exists and is a symlink
 if [ -L /lib64/security/pam_himmelblau.so ]; then
     rm -f /lib64/security/pam_himmelblau.so
+fi
+'''
+pre_uninstall_script='''
+# $1 is set by RPM: 0=uninstall, 1=upgrade. If your packager doesn’t pass it, we default to 0.
+if [ "${1:-0}" -ne 0 ]; then exit 0; fi   # don’t switch on upgrade
+if command -v authselect >/dev/null 2>&1; then
+    if authselect current 2>/dev/null | grep -qE "^Profile ID:\s+himmelblau$"; then
+        if   [ -d /usr/share/authselect/default/local   ]; then base=local
+        elif [ -d /usr/share/authselect/default/minimal ]; then base=minimal
+        else base=sssd; fi
+        feats="$(authselect current 2>/dev/null | awk '"'"'/Enabled features:/{f=1;next} f && /^-/{print $2}'"'"')"
+        authselect select "$base" $feats --force >/dev/null 2>&1 || :
+        authselect apply-changes >/dev/null 2>&1 || :
+    fi
 fi
 '''


### PR DESCRIPTION
This should resolve various pam configuration issues on the RHEL/Rocky/Fedora distros. Also is available on openSUSE, but isn't default.