### PR TITLE
Enable configuration-less daemon startup

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -550,9 +550,7 @@ impl HimmelblauConfig {
             None => vec![],
         };
         let domain = match self.config.get("global", "domain") {
-            Some(val) => {
-                val.split(',').map(|s| s.trim().to_string()).collect()
-            }
+            Some(val) => val.split(',').map(|s| s.trim().to_string()).collect(),
             None => vec![],
         };
         domains.extend(domain);
@@ -769,6 +767,11 @@ impl HimmelblauConfig {
         }
 
         let domains = self.get_configured_domains();
+        if domains.is_empty() {
+            info!("No domains are configured.");
+            return None;
+        }
+
         let mut modified_config = false;
 
         // We don't recognize this alias, so now we need to search for it the

--- a/src/common/src/idprovider/interface.rs
+++ b/src/common/src/idprovider/interface.rs
@@ -210,28 +210,31 @@ pub trait IdProvider {
         _machine_key: &tpm::structures::StorageKey,
     ) -> Result<UserTokenState, IdpError>;
 
-    async fn unix_user_access(
+    async fn unix_user_access<D: KeyStoreTxn + Send>(
         &self,
         _id: &Id,
         _scopes: Vec<String>,
         _token: Option<&UserToken>,
         _client_id: Option<String>,
+        _keystore: &mut D,
         _tpm: &mut tpm::provider::BoxedDynTpm,
         _machine_key: &tpm::structures::StorageKey,
     ) -> Result<UnixUserToken, IdpError>;
 
-    async fn unix_user_ccaches(
+    async fn unix_user_ccaches<D: KeyStoreTxn + Send>(
         &self,
         _id: &Id,
         _old_token: Option<&UserToken>,
+        _keystore: &mut D,
         _tpm: &mut tpm::provider::BoxedDynTpm,
         _machine_key: &tpm::structures::StorageKey,
     ) -> (Vec<u8>, Vec<u8>);
 
-    async fn unix_user_prt_cookie(
+    async fn unix_user_prt_cookie<D: KeyStoreTxn + Send>(
         &self,
         _id: &Id,
         _token: Option<&UserToken>,
+        _keystore: &mut D,
         _tpm: &mut tpm::provider::BoxedDynTpm,
         _machine_key: &tpm::structures::StorageKey,
     ) -> Result<String, IdpError>;
@@ -317,7 +320,11 @@ pub trait IdProvider {
         _tpm: &mut tpm::provider::BoxedDynTpm,
     ) -> Result<GroupToken, IdpError>;
 
-    async fn get_cachestate(&self, _account_id: Option<&str>) -> CacheState;
+    async fn get_cachestate<D: KeyStoreTxn + Send>(
+        &self,
+        _account_id: Option<&str>,
+        _keystore: &mut D,
+    ) -> CacheState;
 
     async fn offline_break_glass(&self, _ttl: Option<u64>) -> Result<(), IdpError>;
 }


### PR DESCRIPTION
This new default behavior would determine the config entirely from the authenticating user, just like it's done on Windows.

Fixes #482
