### PR TITLE
Encrypt hsm-pin using systemd-creds

### DIFF
--- a/scripts/gen_servicefiles.py
+++ b/scripts/gen_servicefiles.py
@@ -41,6 +41,7 @@ MINVER = {
     "MemoryDenyWriteExecute": 231,
     "CacheRuntimeStateDirs": 235,  # CacheDirectory/RuntimeDirectory/StateDirectory
     "ConditionPathExists": 12,
+    "LoadCredentialEncrypted": 250,
 }
 
 def detect_systemd_version():
@@ -218,6 +219,8 @@ Conflicts=nscd.service
 {os.linesep.join(dirs_block)}
 
 {type_line}
+{'LoadCredentialEncrypted=hsm-pin:/var/lib/himmelblaud/hsm-pin.enc' if supported('LoadCredentialEncrypted') else ''}
+{'Environment=HIMMELBLAU_HSM_PIN_PATH=%d/hsm-pin' if supported('LoadCredentialEncrypted') else ''}
 ExecStart=/usr/sbin/himmelblaud
 
 {daemon_rw_paths_comment}

--- a/src/cli/src/opt/tool.rs
+++ b/src/cli/src/opt/tool.rs
@@ -472,6 +472,11 @@ pub enum HimmelblauUnixOpt {
         #[clap(short, long)]
         debug: bool,
     },
+    /// Check whether Himmelblau is utilizing the TPM
+    Tpm {
+        #[clap(short, long)]
+        debug: bool,
+    },
     /// Show the version of this tool.
     Version {
         #[clap(short, long)]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -44,6 +44,7 @@ pub const DEFAULT_CONN_TIMEOUT: u64 = 30;
 pub const DEFAULT_CACHE_TIMEOUT: u64 = 300;
 pub const DEFAULT_SELINUX: bool = true;
 pub const DEFAULT_HSM_PIN_PATH: &str = "/var/lib/himmelblaud/hsm-pin";
+pub const DEFAULT_HSM_PIN_PATH_ENC: &str = "/var/lib/himmelblaud/hsm-pin.enc";
 pub const DEFAULT_HELLO_ENABLED: bool = true;
 pub const DEFAULT_SFA_FALLBACK_ENABLED: bool = false;
 pub const DEFAULT_ID_ATTR_MAP: IdAttr = IdAttr::Name;

--- a/src/daemon/scripts/postinst
+++ b/src/daemon/scripts/postinst
@@ -1,19 +1,33 @@
 #!/bin/sh
 set -e
 
-# Only patch on Debian 12
-if grep -q '^ID=debian' /etc/os-release && grep -q '^VERSION_ID="12"' /etc/os-release; then
-    echo "Patching Himmelblau systemd unit files for Debian 12"
-
-    # Patch himmelblaud.service: Type=notify-reload → Type=notify
-    sed -i 's/^Type=notify-reload/Type=notify/' /etc/systemd/system/himmelblaud.service
-
-    # Patch himmelblaud-tasks.service: remove ConditionPathExists line
-    sed -i '/^ConditionPathExists=\/run\/himmelblaud\/task_sock$/d' /etc/systemd/system/himmelblaud-tasks.service
-
-    # Reload systemd units in any case
-    systemctl daemon-reload || true
-fi
-
 # Add nss cache directory with correct permissions
 install -d -o root -g root -m 0600 /var/cache/himmelblau-policies
+
+gen_pin_hex() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 24 | tr -d '\n'
+    else
+        head -c 24 /dev/urandom | od -An -t x1 | tr -d ' \n'
+    fi
+}
+
+if command -v systemd-creds >/dev/null 2>&1; then
+    # Migrate the hsm-pin to a TPM bound cred (where a TPM is available)
+    LEGACY=/var/lib/private/himmelblaud/hsm-pin
+    CRED=/var/lib/private/himmelblaud/hsm-pin.enc
+
+    if [ ! -f $CRED ]; then
+        # Generate a new PIN if one doesn't exist, otherwise use the existing one
+        if [ ! -f $LEGACY ]; then
+            HSM_PIN=$(gen_pin_hex)
+        else
+            echo "Migrating existing HSM-PIN to encrypted credential"
+            HSM_PIN=$(cat $LEGACY)
+        fi
+
+        # Encrypt the PIN
+	install -d -m 755 /var/lib/private/himmelblaud
+        printf '%s' "$HSM_PIN" | systemd-creds encrypt --name=hsm-pin --with-key=auto --tpm2-device=auto - "$CRED" && (rm -f $LEGACY || true)
+    fi
+fi


### PR DESCRIPTION
This encrypts the hsm-pin using the TPM, if present. Also adding a aad-tool command to determine whether Himmelblau is utilizing the TPM. This change provides an easy upgrade path from soft-HSM to TPM. Technically we're still utilizing the soft-HSM here, but the AuthValue for the soft-HSM is TPM bound.
