### PR TITLE
nix: add join_type option to nixos-module settings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,16 @@
                       issues over SSH. Mapping by name is recommeneded.
                     '';
                   };
+                  join_type = mkOption {
+                    type = types.enum [
+                      "join"
+                      "register"
+                    ];
+                    default = "join";
+                    description = ''
+                      The device join type for Azure. Standard device join, or register only.
+                    '';
+                  };
                   enable_hello = mkOption {
                     type = types.bool;
                     default = true;


### PR DESCRIPTION
Adds NixOS module config option for https://github.com/himmelblau-idm/himmelblau/pull/765