### PR TITLE
Add support for Fedora 43

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	  rocky|almalinux|rhel|ol|oraclelinux|centos|centos_stream|centos-stream) \
 		major=$$(echo "$$VER" | awk -F. '{print $$1}'); \
 		case "$$major" in 8) TARGET="rocky8" ;; 9) TARGET="rocky9" ;; 10) TARGET="rocky10" ;; esac ;; \
-	  fedora)         case "$$VER" in 41*) TARGET="fedora41" ;; 42*) TARGET="fedora42" ;; *) TARGET="rawhide" ;; esac ;; \
+	  fedora)         case "$$VER" in 41*) TARGET="fedora41" ;; 42*) TARGET="fedora42" ;; 43*) TARGET="fedora43" ;; *) TARGET="rawhide" ;; esac ;; \
 	  sles|sled|sle_micro|suse|suse-linux-enterprise) \
 		case "$$VER" in 15.6*|15-SP6*) TARGET="sle15sp6" ;; 15.7*|15-SP7*) TARGET="sle15sp7" ;; 16*|16.*) TARGET="sle16" ;; esac ;; \
 	  opensuse-leap)  case "$$VER" in 15.6*) TARGET="sle15sp6" ;; 15.7*) TARGET="sle15sp7" ;; esac ;; \
@@ -51,7 +51,7 @@ nix: .packaging ## Build Nix packages into ./packaging/
 	done
 
 DEB_TARGETS := ubuntu22.04 ubuntu24.04 debian12 debian13
-RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora41 fedora42
+RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora41 fedora42 fedora43
 SLE_TARGETS := sle15sp6 sle15sp7 sle16
 ALL_PACKAGE_TARGETS := $(DEB_TARGETS) $(RPM_TARGETS) $(SLE_TARGETS)
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You can also target specific distros explicitly.
 Available targets (as of now):
 
 * **DEB:** `ubuntu22.04` `ubuntu24.04` `debian12` `debian13`
-* **RHEL family:** `rocky8` `rocky9` `rocky10` `fedora41` `fedora42` `rawhide`
+* **RHEL family:** `rocky8` `rocky9` `rocky10` `fedora41` `fedora42` `fedora43` `rawhide`
 * **SUSE:** `sle15sp6` `sle15sp7` `sle16` `tumbleweed`
 
 Examples:
@@ -288,7 +288,7 @@ Setup PAM
     # vim /etc/pam.d/common-password
     password	sufficient	pam_himmelblau.so ignore_unknown_user
     password        optional        pam_gnome_keyring.so    use_authtok
-    password	sufficient	pam_unix.so	use_authtok nullok shadow try_first_pass 
+    password	sufficient	pam_unix.so	use_authtok nullok shadow try_first_pass
     password	required	pam_deny.so
 
 ---

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -111,7 +111,7 @@ CMD_SEP = f" && \ \n{CMD_TAB}"
 def build_deb_final_cmd(features: list, distro_slug: str) -> str:
     parts = []
     for pkg, _, needs_tpm in PACKAGES:
-        if pkg == "selinux": # Debian doesn't use selinux
+        if pkg == "selinux":  # Debian doesn't use selinux
             continue
         if not needs_tpm and "tpm" in features:
             features.remove("tpm")
@@ -127,10 +127,7 @@ def build_rpm_final_cmd(features: list, selinux: bool) -> str:
     feat_str = f" --features {','.join(features)}" if features else ""
     build = f"cargo build --release{feat_str} && \\ \n{CMD_TAB}"
     strip = CMD_SEP.join(
-        [
-            "strip -s target/release/%s" % s
-            for s in ["*.so", "aad-tool", "himmelblaud", "himmelblaud_tasks", "broker"]
-        ]
+        ["strip -s target/release/%s" % s for s in ["*.so", "aad-tool", "himmelblaud", "himmelblaud_tasks", "broker"]]
     )
     if selinux:
         pkgs = PACKAGES
@@ -186,6 +183,12 @@ DISTS = {
     "fedora42": {
         "family": "rpm",
         "image": "fedora:42",
+        "tpm": True,
+        "selinux": True,
+    },
+    "fedora43": {
+        "family": "rpm",
+        "image": "fedora:43",
         "tpm": True,
         "selinux": True,
     },
@@ -375,9 +378,7 @@ def render(dist_name, dist_cfg):
     pkgs = build_pkg_list(dist_cfg, selinux)
     bootstrap = fam["bootstrap"].format(pkgs=pkgs).rstrip()
     env = fam["env"] or ""
-    sle_connect = (
-        SLE_CONNECT_TPL % dist_cfg.get("scc_vers") if dist_cfg.get("scc") else ""
-    )
+    sle_connect = SLE_CONNECT_TPL % dist_cfg.get("scc_vers") if dist_cfg.get("scc") else ""
 
     # Features
     tpm = bool(dist_cfg.get("tpm", False))
@@ -413,9 +414,7 @@ def render(dist_name, dist_cfg):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default="./dockerfiles", help="Output directory")
-    ap.add_argument(
-        "--only", default="", help="Comma-separated list of dists to render"
-    )
+    ap.add_argument("--only", default="", help="Comma-separated list of dists to render")
     args = ap.parse_args()
 
     if args.only:


### PR DESCRIPTION
Fedora 43 was released on the 28th of October and should be supported. Builds fine on my machine and functions well on my F43 rig.

Fedora 41 will be deprecated on the 25th of November, but I've not removed it in this PR.