### PR TITLE
We should still encourage mapping by name

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -100,7 +100,7 @@ Removes group from user if they are no longer a member of the specified entra gr
 .TP
 .B id_attr_map
 .RE
-Specify whether to map uid/gid based on the object name, the object uuid, or based on the rfc2307 schema extension attributes synchronized from an on-prem Active Directory instance. Mapping by uuid or by rfc2307 is recommeneded. By name mapping is the default.
+Specify whether to map uid/gid based on the object name, the object uuid, or based on the rfc2307 schema extension attributes synchronized from an on-prem Active Directory instance. Mapping by name or by rfc2307 is recommeneded. By name mapping is the default.
 
 .EXAMPLES
 id_attr_map = <name|uuid|rfc2307>


### PR DESCRIPTION
Id mapping by UUID doesn't work prior to the host
being joined (since the lookup requires an
enrolled host auth). So we STILL have a broken
looked for the very first auth.

Fixes #
