### PR TITLE
Always rebuild the o365 apps

### DIFF
--- a/src/o365/build.rs
+++ b/src/o365/build.rs
@@ -105,9 +105,6 @@ fn apps() -> Vec<App> {
 }
 
 fn main() {
-    // Rebuild triggers
-    println!("cargo:rerun-if-changed=build.rs");
-
     let exec = env::var("O365_EXEC").unwrap_or_else(|_| DEFAULT_EXEC.to_string());
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let gen_root = env::var("O365_GEN_DIR")


### PR DESCRIPTION
This was causing a nightly build failure, since we clean between builds, wiping out the entries.
