### PR TITLE
Fix passwordless FIDO authentication not being used when available

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -1374,6 +1374,21 @@ impl IdProvider for HimmelblauProvider {
                             return Err(IdpError::BadRequest);
                         }
                     );
+                    // Check if Azure provided FIDO credentials (passwordless FIDO/passkey)
+                    if let (Some(fido_challenge), Some(fido_allow_list)) =
+                        (flow.fido_challenge.clone(), flow.fido_allow_list.clone())
+                    {
+                        return Ok((
+                            AuthRequest::Fido {
+                                fido_challenge,
+                                fido_allow_list,
+                            },
+                            AuthCredHandler::MFA {
+                                flow,
+                                password: None,
+                            },
+                        ));
+                    }
                     let msg = flow.msg.clone();
                     let polling_interval = flow.polling_interval.unwrap_or(5000);
                     Ok((


### PR DESCRIPTION
I'd like to use Himmelblau with a Yubikey as passwordless login method, which is configured in my EntraID Account as primary method. However, the current himmelblau implementation did not navigate me to enter the FIDO PIN on the himmelblau-greeter, when the device is not (yet) EntraID joined.

When Azure provides FIDO credentials (passwordless FIDO/passkey), this fix ensures they are checked and used before falling back to MFA polling methods.

Without this fix, passwordless FIDO authentication would be ignored and the system would fall back to other MFA methods (phone app, SMS, etc.) even when FIDO credentials are available.