### PR TITLE
Use older python3 argparse syntax

### DIFF
--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -429,7 +429,9 @@ def main():
     )
     ap.add_argument(
         "--no-patch-libhimmelblau",
-        dest="patch_libhimmelblau", action="store_false", help=argparse.SUPPRESS
+        dest="patch_libhimmelblau",
+        action="store_false",
+        help=argparse.SUPPRESS
     )
     ap.set_defaults(patch_libhimmelblau=False)
     args = ap.parse_args()


### PR DESCRIPTION
This newer syntax causes the build to fail on the build host because it's using an older version of python3.
