### PR TITLE
Request a user token if NSS hasn't been called

### DIFF
--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -1076,6 +1076,12 @@ where
 
         let id = Id::Name(account_id.to_string());
         let (_expired, token) = self.get_cached_usertoken(&id).await?;
+        // If we don't have a token here, then NSS has yet to be called. Failing
+        // to request a token now will result in an auth failure in pam_account_authenticate_step.
+        let token = match token {
+            Some(token) => Some(token),
+            None => self.refresh_usertoken(&id, None).await?,
+        };
         let state = self.get_cachestate(Some(account_id)).await;
 
         let online_at_init = if !matches!(state, CacheState::Online) {


### PR DESCRIPTION
In the rare case that the system fails to call NSS for a user prior to attempting authentication, ensure we fetch a UserToken, otherwise we will get a "NotFound: token in AuthSession" error.

Fixes #872 and #865 

I think this is why in #865, the problem goes away after logging in via GDM, because GDM looks up the user via NSS prior to attempting to authenticate.