### PR TITLE
Update kanidm-hsm-crypto to v0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "kanidm-hsm-crypto"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b3a38360cb864a945dfcfaaf09c9e5fc6f22f8997b226b1f13f65572cef74b"
+checksum = "61cafdd63d3c246fd7a7318de64e35d2c744ebb2c5a51a407a2985ad6fe29908"
 dependencies = [
  "crypto-glue",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ tracing-opentelemetry = "0.28.0"
 tracing-core = "0.1.34"
 tonic = "0.14.2"
 compact_jwt = { version = "0.5.3-dev", features = ["msextensions"] }
-kanidm-hsm-crypto = { version = "^0.3.4" }
+kanidm-hsm-crypto = { version = "^0.3.5" }
 whoami = "1.6.1"
 kanidm_lib_file_permissions = "1.8.1"
 md4 = "0.10.2"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -395,8 +395,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.kanidm-hsm-crypto]]
-version = "0.3.4"
-when = "2025-06-28"
+version = "0.3.5"
+when = "2025-11-21"
 user-id = 31100
 user-login = "Firstyear"
 user-name = "Firstyear"


### PR DESCRIPTION
Related to https://github.com/himmelblau-idm/himmelblau/issues/740

This update **might** resolve the issue reported in #740. It resolves a single case where an object was mistakenly not unloaded from the TPM. It also adds extra debugging to we can spot issues more easily in the future.