### PR TITLE
Document the new oidc_issuer_url option

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -61,6 +61,42 @@ for successful authentication. If it is not specified, no users will be permitte
 domain = example.com
 
 .TP
+.B oidc_issuer_url
+.RE
+Specifies the OpenID Connect (OIDC) issuer URL used by Himmelblau to discover
+OIDC provider metadata and endpoints.
+
+This option enables generic OIDC authentication support and allows Himmelblau
+to authenticate against any standards-compliant OIDC provider, rather than
+using the built-in Microsoft Entra ID defaults.
+
+When this option is set, the following options are
+.B REQUIRED
+and must be configured consistently:
+
+.RS
+.IP \(bu 2
+.B domain
+– Used for username normalization and login prompts
+.IP \(bu 2
+.B app_id
+– Used as the OIDC client identifier
+.RE
+
+The issuer URL
+.B MUST
+exactly match the issuer value advertised by the OIDC provider, including
+any required path components.
+Incorrect issuer URLs will cause provider discovery to fail.
+
+If this option is not set, Himmelblau defaults to its native Microsoft Entra ID
+authentication flow.
+
+.EXAMPLES
+.P
+oidc_issuer_url = https://login.microsoftonline.com/0656e57d-a8fc-4aa4-8366-8045787115ca/v2.0
+
+.TP
 .B debug
 .RE
 A boolean option that enables debug-level logging. When set to


### PR DESCRIPTION
This option explains how to configure an OIDC endpoint for authentication.
