### PR TITLE
OIDC auth no longer requires a domain name

### DIFF
--- a/docs-xml/himmelblauconf/base/oidc_issuer_url.xml
+++ b/docs-xml/himmelblauconf/base/oidc_issuer_url.xml
@@ -15,14 +15,10 @@ This option enables generic OIDC authentication support and allows Himmelblau
 to authenticate against any standards-compliant OIDC provider, rather than
 using the built-in Microsoft Entra ID defaults.
 
-When this option is set, the following options are
+When this option is set, the following option is
 .B REQUIRED
 and must be configured consistently:
-
 .RS
-.IP \(bu 2
-.B domain
-\(en Used for username normalization and login prompts
 .IP \(bu 2
 .B app_id
 \(en Used as the OIDC client identifier

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -78,14 +78,10 @@ This option enables generic OIDC authentication support and allows Himmelblau
 to authenticate against any standards-compliant OIDC provider, rather than
 using the built-in Microsoft Entra ID defaults.
 
-When this option is set, the following options are
+When this option is set, the following option is
 .B REQUIRED
 and must be configured consistently:
-
 .RS
-.IP \(bu 2
-.B domain
-\(en Used for username normalization and login prompts
 .IP \(bu 2
 .B app_id
 \(en Used as the OIDC client identifier


### PR DESCRIPTION
Refactor OIDC authentication to remove the
requirement for a domain name during
configuration and authentication. Previously,
OIDC auth mandated a User Principal Name (UPN)
for authentication and the 'domain' setting in
himmelblau.conf. This was problematic for OIDC
providers not using UPNs or supporting multiple
domains.

Fixes #968 