### PR TITLE
Fix HSM pin migration failure on Debian/Ubuntu upgrades from v1.4.x

### DIFF
--- a/src/daemon/scripts/postinst
+++ b/src/daemon/scripts/postinst
@@ -7,6 +7,24 @@ systemd-tmpfiles --create /usr/lib/tmpfiles.d/himmelblau-policies.conf 2>/dev/nu
 # Ensure private data directory is created with correct permissions
 systemd-tmpfiles --create /usr/lib/tmpfiles.d/himmelblaud.conf 2>/dev/null || true
 
+# Remove old service files from /etc/systemd/system/ that were installed by v1.4.x
+# These take precedence over the new files in /usr/lib/systemd/system/ and lack
+# the LoadCredentialEncrypted directive needed for HSM pin handling.
+for OLD_FILE in \
+    "/etc/systemd/system/himmelblaud.service" \
+    "/etc/systemd/system/himmelblaud-tasks.service" \
+    "/etc/systemd/system/gdm3.service.d/override.conf"; do
+    if [ -f "$OLD_FILE" ]; then
+        echo "Removing old service file: $OLD_FILE"
+        rm -f "$OLD_FILE"
+    fi
+done
+
+# Reload systemd to pick up the new service files from /usr/lib/systemd/system/
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload || true
+fi
+
 gen_pin_hex() {
     if command -v openssl >/dev/null 2>&1; then
         openssl rand -hex 24 | tr -d '\n'
@@ -20,7 +38,32 @@ if command -v systemd-creds >/dev/null 2>&1; then
     LEGACY=/var/lib/private/himmelblaud/hsm-pin
     CRED=/var/lib/private/himmelblaud/hsm-pin.enc
 
-    if [ ! -f $CRED ]; then
+    if [ -f $LEGACY ] && [ -f $CRED ]; then
+        # Both files exist - this can happen if a previous upgrade failed due to
+        # missing LoadCredentialEncrypted in the service file (issue #987).
+        # The daemon would have generated a new plaintext hsm-pin which is now
+        # the active PIN matching the machine key. Try starting the daemon first
+        # to see if it works, and only re-encrypt if we get an HSM pin error.
+        echo "Both hsm-pin and hsm-pin.enc exist, checking if recovery is needed..."
+        if command -v systemctl >/dev/null 2>&1; then
+            # Try to restart the daemon and capture the result
+            systemctl restart himmelblaud.service 2>/dev/null || true
+            sleep 2
+            # Check if the daemon failed with an HSM pin error
+            if ! systemctl is-active --quiet himmelblaud.service; then
+                DAEMON_LOG=$(journalctl -u himmelblaud.service -n 50 --no-pager 2>/dev/null || true)
+                if echo "$DAEMON_LOG" | grep -q "Unable to load machine root key"; then
+                    echo "Re-encrypting HSM-PIN (recovering from failed upgrade)"
+                    HSM_PIN=$(cat $LEGACY)
+                    printf '%s' "$HSM_PIN" | systemd-creds encrypt --name=hsm-pin --with-key=auto --tpm2-device=auto - "$CRED" && rm -f $LEGACY
+                fi
+            else
+                # Daemon is running fine, just clean up the legacy file
+                echo "Daemon running successfully, removing legacy hsm-pin file"
+                rm -f $LEGACY
+            fi
+        fi
+    elif [ ! -f $CRED ]; then
         # Generate a new PIN if one doesn't exist, otherwise use the existing one
         if [ ! -f $LEGACY ]; then
             HSM_PIN=$(gen_pin_hex)


### PR DESCRIPTION
When upgrading from v1.4.x to v2.x on Debian/Ubuntu, the old service files at /etc/systemd/system/ were not being removed. Since systemd prioritizes files in /etc/ over /usr/lib/, the old service files (lacking LoadCredentialEncrypted directive) were still being used.

This caused the daemon to fail to decrypt the HSM pin that was encrypted during the upgrade by the postinst script. The daemon would then generate a new HSM pin, which couldn't decrypt the existing machine key, causing the daemon to crash with:
  "Unable to load machine root key - This can occur if you have
   changed your HSM pin"

The fix removes the old service files from /etc/systemd/system/ during package installation, allowing systemd to use the new files from /usr/lib/systemd/system/ which have proper LoadCredentialEncrypted support.

Fixes #987 
