### PR TITLE
OIDC: remove trailing slash trimming for issuer url

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -812,7 +812,6 @@ impl HimmelblauConfig {
             s.trim()
                 .strip_suffix("/.well-known/openid-configuration")
                 .unwrap_or(s.trim())
-                .trim_end_matches('/')
                 .to_string()
         });
         if let Some(ref s) = res {


### PR DESCRIPTION
If the issuer has a trailing /, then currently the config strips it. The correct way is to leave the daemon to strip it and allow the issuer url to be valid.