### PR TITLE
Improve error messages served to pam deny

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -85,6 +85,69 @@ use zeroize::Zeroizing;
 // authentication without group name resolution.
 const CONSENT_REQUIRED: u32 = 65002;
 
+/// Convert an MsalError to a short, user-friendly message for PAM display.
+/// This intentionally ignores the internal string contents of error variants
+/// to avoid leaking verbose or sensitive information to the user.
+fn msal_error_to_user_message(e: &MsalError) -> String {
+    match e {
+        MsalError::InvalidJson(_)
+        | MsalError::InvalidBase64(_)
+        | MsalError::InvalidParse(_)
+        | MsalError::InvalidRegex(_)
+        | MsalError::FormatError(_) => {
+            "Authentication failed: Invalid server response.".to_string()
+        }
+        MsalError::AcquireTokenFailed(error_response) => {
+            // This case is typically handled separately with error_description,
+            // but provide a fallback if it reaches this function.
+            error_response.error_description.to_string()
+        }
+        MsalError::RequestFailed(_) => {
+            "Authentication failed: Unable to reach authentication server.".to_string()
+        }
+        MsalError::AuthTypeUnsupported => {
+            "Authentication failed: Authentication method not supported.".to_string()
+        }
+        MsalError::TPMFail(_) => "Authentication failed: Security hardware error.".to_string(),
+        MsalError::URLFormatFailed(_) => "Authentication failed: Configuration error.".to_string(),
+        MsalError::DeviceEnrollmentFail(_) => {
+            "Device enrollment failed. Please contact your administrator.".to_string()
+        }
+        MsalError::CryptoFail(_) => "Authentication failed: Cryptographic error.".to_string(),
+        MsalError::ConfigError(_) => "Authentication failed: Configuration error.".to_string(),
+        MsalError::MFAPollContinue => {
+            // This is an internal state, should not reach the user.
+            "Authentication in progress.".to_string()
+        }
+        MsalError::AADSTSError(aadsts_err) => {
+            // AADSTSError has a useful description from Azure AD
+            aadsts_err.to_string()
+        }
+        MsalError::Missing(_) => "Authentication failed: Missing required data.".to_string(),
+        MsalError::ChangePassword => {
+            // Internal state, should not bubble up to user.
+            "Password change required. Please contact your administrator.".to_string()
+        }
+        MsalError::PasswordRequired => {
+            // Internal state, should not bubble up to user.
+            "Password entry required.".to_string()
+        }
+        MsalError::ConsentRequested(_) => {
+            // Internal state, should not bubble up to user.
+            "Consent required. Please contact your administrator.".to_string()
+        }
+        MsalError::AuthCodeReceived(_) => {
+            // Internal state, should not bubble up to user.
+            "Authentication in progress.".to_string()
+        }
+        MsalError::MFARequired => {
+            // Internal state, should not bubble up to user.
+            "Multi-factor authentication required.".to_string()
+        }
+        _ => "Authentication failed. Please contact your administrator.".to_string(),
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
 enum Providers {
     Oidc(OidcProvider),
@@ -1569,7 +1632,7 @@ impl IdProvider for HimmelblauProvider {
                             },
                             |msg: String| {
                                 error!("{}", msg);
-                                return Err(IdpError::BadRequest)
+                                return Ok((AuthResult::Denied(msg), AuthCacheAction::None))
                             }
                         )
                     },
@@ -1602,12 +1665,18 @@ impl IdProvider for HimmelblauProvider {
                         config.set(&self.domain, "intune_device_id", &intune_device_id);
                         if let Err(e) = config.write_server_config() {
                             error!(?e, "Failed to write Intune join configuration.");
-                            return Err(IdpError::BadRequest);
+                            return Ok((
+                                AuthResult::Denied("Failed to save device configuration. Please contact your administrator.".to_string()),
+                                AuthCacheAction::None,
+                            ));
                         }
                         let intune_tag = self.fetch_intune_key_tag();
                         if let Err(e) = keystore.insert_tagged_hsm_key(&intune_tag, &intune_key) {
                             error!(?e, "Failed inserting the intune key into the keystore.");
-                            return Err(IdpError::BadRequest);
+                            return Ok((
+                                AuthResult::Denied("Failed to store device credentials. Please contact your administrator.".to_string()),
+                                AuthCacheAction::None,
+                            ));
                         }
                     }
                     Err(IdpError::NotFound { .. }) => {}
@@ -1622,12 +1691,13 @@ impl IdProvider for HimmelblauProvider {
             ($token:ident) => {{
                 if !self.is_domain_joined(keystore).await {
                     debug!("Device is not enrolled. Enrolling now.");
-                    self.join_domain(tpm, &$token, keystore, machine_key)
-                        .await
-                        .map_err(|e| {
-                            error!("Failed to join domain: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
+                    if let Err(e) = self.join_domain(tpm, &$token, keystore, machine_key).await {
+                        error!("Failed to join domain: {:?}", e);
+                        return Ok((
+                            AuthResult::Denied("Failed to join domain. Please contact your administrator.".to_string()),
+                            AuthCacheAction::None,
+                        ));
+                    }
                 } else if !self.is_intune_enrolled(keystore).await {
                     intune_enroll!($token);
                 }
@@ -1684,8 +1754,10 @@ impl IdProvider for HimmelblauProvider {
                                         Ok(token) => token,
                                         Err(e) => {
                                             error!("{:?}", e);
-                                            return Err(IdpError::NotFound {
-                                                what: "token".to_string(), where_: "refresh".to_string() });
+                                            return Ok((
+                                                AuthResult::Denied(msal_error_to_user_message(&e)),
+                                                AuthCacheAction::None,
+                                            ));
                                         }
                                     )
                                 } else if err_resp.error_codes.contains(&CONSENT_REQUIRED) {
@@ -1697,12 +1769,20 @@ impl IdProvider for HimmelblauProvider {
                                            Group names will not be resolved.");
                                     $token.clone()
                                 } else {
-                                    return Err(IdpError::NotFound {
-                                        what: "DEVICE_AUTH_FAIL".to_string(), where_: "acq_token".to_string() });
+                                    // Return the AAD error description to the user
+                                    return Ok((
+                                        AuthResult::Denied(err_resp.error_description.clone()),
+                                        AuthCacheAction::None,
+                                    ));
                                 }
                             }
-                            _ => return Err(IdpError::NotFound {
-                                what: "AcquireTokenFailed".to_string(), where_: "acq_token".to_string() }),
+                            _ => {
+                                // Return a user-friendly error message
+                                return Ok((
+                                    AuthResult::Denied(msal_error_to_user_message(&e)),
+                                    AuthCacheAction::None,
+                                ));
+                            }
                         }
                     }
                 )
@@ -1849,7 +1929,7 @@ impl IdProvider for HimmelblauProvider {
                                     },
                                     |msg: String| {
                                         error!("{}", msg);
-                                        return Err(IdpError::BadRequest)
+                                        return Ok((AuthResult::Denied(msg), AuthCacheAction::None))
                                     }
                                 )
                             }
@@ -2024,7 +2104,10 @@ impl IdProvider for HimmelblauProvider {
                                                 }
                                                 Err(e) => {
                                                     error!("Failed to exchange PRT (retry): {:?}", e);
-                                                    return Err(IdpError::BadRequest);
+                                                    return Ok((
+                                                        AuthResult::Denied("Authentication failed. Please try signing in again.".to_string()),
+                                                        AuthCacheAction::None,
+                                                    ));
                                                 }
                                             }
                                     } else {
@@ -2034,7 +2117,7 @@ impl IdProvider for HimmelblauProvider {
                                             },
                                             |msg: String| {
                                                 error!("{}", msg);
-                                                return Err(IdpError::BadRequest)
+                                                return Ok((AuthResult::Denied(msg), AuthCacheAction::None))
                                             }
                                         )
                                     }
@@ -2058,16 +2141,25 @@ impl IdProvider for HimmelblauProvider {
                                     // It's ok to reset the pin count here, since they must
                                     // online auth at this point and create a new pin.
                                     self.bad_pin_counter.reset_bad_pin_count(account_id).await;
-                                    debug!("Returning BadRequest due to failed PRT exchange.");
-                                    return Err(IdpError::BadRequest);
+                                    debug!("Session expired, requesting re-authentication.");
+                                    return Ok((
+                                        AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                                        AuthCacheAction::None,
+                                    ));
                                 }
                             }
                     } else if let Some(RefreshCacheEntry::RefreshToken(refresh_token)) = refresh_cache_entry {
                         // We have a refresh token, exchange that for an access token
-                        let app = PublicClientApplication::new(BROKER_APP_ID, None).map_err(|e| {
-                            error!("Failed to create PublicClientApplication: {:?}", e);
-                            IdpError::BadRequest
-                        })?;
+                        let app = match PublicClientApplication::new(BROKER_APP_ID, None) {
+                            Ok(app) => app,
+                            Err(e) => {
+                                error!("Failed to create PublicClientApplication: {:?}", e);
+                                return Ok((
+                                    AuthResult::Denied("Authentication service unavailable. Please try again later.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
+                            }
+                        };
                         match app.acquire_token_by_refresh_token(
                             &refresh_token,
                             vec![],
@@ -2135,7 +2227,10 @@ impl IdProvider for HimmelblauProvider {
                                 // It's ok to reset the pin count here, since they must
                                 // online auth at this point and create a new pin.
                                 self.bad_pin_counter.reset_bad_pin_count(account_id).await;
-                                return Err(IdpError::BadRequest);
+                                return Ok((
+                                    AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
                             }
                         }
                     } else {
@@ -2253,7 +2348,10 @@ impl IdProvider for HimmelblauProvider {
                      * continue from a Pin auth. */
                     Ok(AuthResult::Next(_)) => {
                         debug!("Invalid additional authentication requested with Hello auth.");
-                        Err(IdpError::BadRequest)
+                        Ok((
+                            AuthResult::Denied("Unexpected authentication step. Please try signing in again.".to_string()),
+                            AuthCacheAction::None,
+                        ))
                     }
                     Ok(auth_result) => {
                         debug!("Hello auth failed.");
@@ -2269,10 +2367,18 @@ impl IdProvider for HimmelblauProvider {
 
         match (&mut *cred_handler, pam_next_req) {
             (AuthCredHandler::SetupPin { token }, PamAuthRequest::SetupPin { pin }) => {
-                let token = token.clone().ok_or_else(|| {
-                    error!("Missing enrollment token for Hello PIN setup.");
-                    IdpError::BadRequest
-                })?;
+                let token = match token.clone() {
+                    Some(t) => t,
+                    None => {
+                        error!("Missing enrollment token for Hello PIN setup.");
+                        return Ok((
+                            AuthResult::Denied(
+                                "PIN setup failed. Please try signing in again.".to_string(),
+                            ),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                };
                 // Skip Hello enrollment if the token doesn't have the ngcmfa amr
                 let amr_ngcmfa = token.amr_ngcmfa().unwrap_or(false);
                 let hello_tag = self.fetch_hello_key_tag(account_id, amr_ngcmfa);
@@ -2492,15 +2598,27 @@ impl IdProvider for HimmelblauProvider {
                     resp,
                     // FIDO
                     {
-                        let fido_challenge = resp.fido_challenge.clone().ok_or({
-                            debug!("FIDO challenge missing in MFA response");
-                            IdpError::BadRequest
-                        })?;
+                        let fido_challenge = match resp.fido_challenge.clone() {
+                            Some(challenge) => challenge,
+                            None => {
+                                debug!("FIDO challenge missing in MFA response");
+                                return Ok((
+                                    AuthResult::Denied("FIDO authentication not available. Please try a different authentication method.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
+                            }
+                        };
 
-                        let fido_allow_list = resp.fido_allow_list.clone().ok_or({
-                            debug!("FIDO allow list missing in MFA response");
-                            IdpError::BadRequest
-                        })?;
+                        let fido_allow_list = match resp.fido_allow_list.clone() {
+                            Some(list) => list,
+                            None => {
+                                debug!("FIDO allow list missing in MFA response");
+                                return Ok((
+                                    AuthResult::Denied("FIDO authentication not available. Please try a different authentication method.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
+                            }
+                        };
                         *cred_handler = AuthCredHandler::MFA {
                             flow: resp,
                             password: Some(cred.clone()),
@@ -2652,7 +2770,12 @@ impl IdProvider for HimmelblauProvider {
                 let max_poll_attempts = flow.max_poll_attempts.unwrap_or(180);
                 if poll_attempt > max_poll_attempts {
                     error!("MFA polling timed out");
-                    return Err(IdpError::BadRequest);
+                    return Ok((
+                        AuthResult::Denied(
+                            "Authentication timed out. Please try again.".to_string(),
+                        ),
+                        AuthCacheAction::None,
+                    ));
                 }
                 let token = net_down_check!(
                     self.client

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -1103,12 +1103,18 @@ impl IdProvider for OidcProvider {
                                 Ok(RefreshCacheEntry::RefreshToken(refresh_token)) => refresh_token,
                                 Ok(_) => {
                                     error!("Invalid refresh cache entry type");
-                                    return Err(IdpError::BadRequest);
+                                    return Ok((
+                                        AuthResult::Denied("Session data corrupted. Please sign in again.".to_string()),
+                                        AuthCacheAction::None,
+                                    ));
                                 }
                                 Err(e2) => {
                                     error!(?e, "Failed unsealing hello refresh token from TPM");
                                     error!(?e2, "Failed retrieving refresh token from mem cache");
-                                    return Err(IdpError::BadRequest);
+                                    return Ok((
+                                        AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                                        AuthCacheAction::None,
+                                    ));
                                 }
                             },
                         }
@@ -1117,11 +1123,17 @@ impl IdProvider for OidcProvider {
                             Ok(RefreshCacheEntry::RefreshToken(refresh_token)) => refresh_token,
                             Ok(_) => {
                                 error!("Invalid refresh cache entry type");
-                                return Err(IdpError::BadRequest);
+                                return Ok((
+                                    AuthResult::Denied("Session data corrupted. Please sign in again.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
                             }
                             Err(e) => {
                                 error!(?e, "Failed retrieving refresh token from mem cache");
-                                return Err(IdpError::BadRequest);
+                                return Ok((
+                                    AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
                             }
                         }
                     };
@@ -1193,7 +1205,10 @@ impl IdProvider for OidcProvider {
                             // It's ok to reset the pin count here, since they must
                             // online auth at this point and create a new pin.
                             self.bad_pin_counter.reset_bad_pin_count(account_id).await;
-                            return Err(IdpError::BadRequest);
+                            return Ok((
+                                AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                                AuthCacheAction::None,
+                            ));
                         }
                     }
                 } else {
@@ -1205,7 +1220,10 @@ impl IdProvider for OidcProvider {
                                 error!("Failed to delete hello key: {:?}", e);
                                 IdpError::Tpm
                             })?;
-                    return Err(IdpError::BadRequest);
+                    return Ok((
+                        AuthResult::Denied("Your session has expired. Please sign in again.".to_string()),
+                        AuthCacheAction::None,
+                    ));
                 };
 
                 // Cache the refresh token to disk for offline auth SSO
@@ -1215,11 +1233,16 @@ impl IdProvider for OidcProvider {
                         error!("Failed loading hello key for refresh token cache: {:?}", e);
                         IdpError::Tpm
                     })?;
-                let refresh_token_zeroizing =
-                    zeroize::Zeroizing::new(token.refresh_token().map(|r| r.secret().to_owned()).ok_or_else(|| {
+                let refresh_token_zeroizing = match token.refresh_token().map(|r| r.secret().to_owned()) {
+                    Some(rt) => zeroize::Zeroizing::new(rt.as_bytes().to_vec()),
+                    None => {
                         error!("Missing refresh token in OIDC response");
-                        IdpError::BadRequest
-                    })?.as_bytes().to_vec());
+                        return Ok((
+                            AuthResult::Denied("Authentication incomplete. Please try again.".to_string()),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                };
                 let token2 = self.client.user_token_from_oidc(
                     &token,
                     &*self.config.read().await,
@@ -1274,7 +1297,10 @@ impl IdProvider for OidcProvider {
                      * continue from a Pin auth. */
                     Ok(AuthResult::Next(_)) => {
                         debug!("Invalid additional authentication requested with Hello auth.");
-                        Err(IdpError::BadRequest)
+                        Ok((
+                            AuthResult::Denied("Unexpected authentication step. Please try signing in again.".to_string()),
+                            AuthCacheAction::None,
+                        ))
                     }
                     Ok(auth_result) => {
                         debug!("Hello auth failed.");
@@ -1332,16 +1358,38 @@ impl IdProvider for OidcProvider {
                 let max_poll_attempts = flow.max_poll_attempts.unwrap_or(180);
                 if poll_attempt > max_poll_attempts {
                     error!("MFA polling timed out");
-                    return Err(IdpError::BadRequest);
+                    return Ok((
+                        AuthResult::Denied(
+                            "Authentication timed out. Please try again.".to_string(),
+                        ),
+                        AuthCacheAction::None,
+                    ));
                 }
-                let dag_json = extra_data.as_ref().ok_or_else(|| {
-                    error!("Missing extra_data in OIDC MFA handler");
-                    IdpError::BadRequest
-                })?;
-                let flow = serde_json::from_str(dag_json).map_err(|e| {
-                    error!(?e, "Failed to deserialize OIDC DAG");
-                    IdpError::BadRequest
-                })?;
+                let dag_json = match extra_data.as_ref() {
+                    Some(data) => data,
+                    None => {
+                        error!("Missing extra_data in OIDC MFA handler");
+                        return Ok((
+                            AuthResult::Denied(
+                                "Authentication session data missing. Please try again."
+                                    .to_string(),
+                            ),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                };
+                let flow = match serde_json::from_str(dag_json) {
+                    Ok(f) => f,
+                    Err(e) => {
+                        error!(?e, "Failed to deserialize OIDC DAG");
+                        return Ok((
+                            AuthResult::Denied(
+                                "Authentication session corrupted. Please try again.".to_string(),
+                            ),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                };
                 match self.client.acquire_token_by_device_flow(&flow).await {
                     Ok(token) => match self.token_validate(account_id, &token).await {
                         Ok(AuthResult::Success { token: token2 }) => {
@@ -1377,7 +1425,10 @@ impl IdProvider for OidcProvider {
                     )),
                     Err(e) => {
                         error!("{:?}", e);
-                        return Err(IdpError::BadRequest);
+                        return Ok((
+                            AuthResult::Denied(format!("Authentication failed: {}", e)),
+                            AuthCacheAction::None,
+                        ));
                     }
                 }
             }
@@ -1403,7 +1454,12 @@ impl IdProvider for OidcProvider {
             }
             _ => {
                 error!("Invalid auth step");
-                Err(IdpError::BadRequest)
+                Ok((
+                    AuthResult::Denied(
+                        "Unexpected authentication step. Please try signing in again.".to_string(),
+                    ),
+                    AuthCacheAction::None,
+                ))
             }
         }
     }


### PR DESCRIPTION
When the authentication fails, we should print user friendly error messages which better indicate what went wrong, and how to proceed.

This should improve the issue with https://github.com/himmelblau-idm/himmelblau/issues/991, since users should actually see the error message response about SSPR.