### PR TITLE
Handle SSPR error AADSTS50125 with device flow

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -84,6 +84,8 @@ use zeroize::Zeroizing;
 // the Graph API. When this happens, we should gracefully fallback and continue
 // authentication without group name resolution.
 const CONSENT_REQUIRED: u32 = 65002;
+// AADSTS50125: PasswordResetRegistrationRequiredInterrupt
+const PASSWORD_RESET_REGISTRATION_REQUIRED: u32 = 50125;
 
 /// Convert an MsalError to a short, user-friendly message for PAM display.
 /// This intentionally ignores the internal string contents of error variants
@@ -1787,6 +1789,55 @@ impl IdProvider for HimmelblauProvider {
                 )
             }};
         }
+        macro_rules! request_dag {
+            () => {{
+                let console_password_only = self.config.read().await.get_allow_console_password_only();
+                let remote_services = self
+                    .config
+                    .read()
+                    .await
+                    .get_password_only_remote_services_deny_list();
+                let is_remote_service = service.starts_with("remote:")
+                    || remote_services.iter().any(|s| service.contains(s));
+                let mut auth_options = vec![];
+                if is_remote_service || !console_password_only {
+                    auth_options.push(AuthOption::ForceMFA);
+                }
+                if is_remote_service {
+                    auth_options.push(AuthOption::RemoteSession);
+                }
+                let resp = net_down_check!(
+                    self.client
+                        .read()
+                        .await
+                        .initiate_device_flow_for_device_enrollment(&auth_options)
+                        .await,
+                    Ok(resp) => resp,
+                    Err(e) => {
+                        error!("{:?}", e);
+                        return Err(IdpError::BadRequest);
+                    }
+                );
+                let mut flow: MFAAuthContinue = resp.into();
+                if !self.is_domain_joined(keystore).await {
+                    flow.resource = Some("https://enrollment.manage.microsoft.com".to_string());
+                }
+                let msg = flow.msg.clone();
+                let polling_interval = flow.polling_interval.unwrap_or(5000);
+                *cred_handler = AuthCredHandler::MFA {
+                    flow,
+                    password: None,
+                    extra_data: None,
+                };
+                return Ok((
+                    AuthResult::Next(AuthRequest::MFAPoll {
+                        msg,
+                        polling_interval: polling_interval / 1000,
+                    }),
+                    AuthCacheAction::None,
+                ));
+            }};
+        }
         macro_rules! auth_and_validate_hello_key {
             ($hello_key:ident, $keytype:ident, $cred:ident) => {{
                 // CRITICAL: Validate that we can load the key, otherwise the offline
@@ -1881,6 +1932,12 @@ impl IdProvider for HimmelblauProvider {
                             }
                         }
                         Err(MsalError::AcquireTokenFailed(e)) => {
+                            if e.error_codes.contains(&PASSWORD_RESET_REGISTRATION_REQUIRED) {
+                                info!(
+                                    "Password reset registration required, initiating device flow"
+                                );
+                                request_dag!();
+                            }
                             if e.error_codes.contains(&CONSENT_REQUIRED) {
                                 /* Consent has not been granted for the application
                                  * to access the Graph API. Retry without Graph API
@@ -1934,6 +1991,14 @@ impl IdProvider for HimmelblauProvider {
                             }
                         }
                         Err(e) => {
+                            if let MsalError::AADSTSError(ref aadsts_err) = e {
+                                if aadsts_err.code == PASSWORD_RESET_REGISTRATION_REQUIRED {
+                                    info!(
+                                        "Password reset registration required, initiating device flow"
+                                    );
+                                    request_dag!();
+                                }
+                            }
                             error!("Failed to authenticate with hello key: {:?}", e);
                             handle_hello_bad_pin_count!(self, account_id, keystore, |msg: &str| {
                                 Ok((AuthResult::Denied(msg.to_string()), AuthCacheAction::None))
@@ -2066,6 +2131,15 @@ impl IdProvider for HimmelblauProvider {
                                     }
                                 }
                                 Err(MsalError::AcquireTokenFailed(e)) => {
+                                    if e
+                                        .error_codes
+                                        .contains(&PASSWORD_RESET_REGISTRATION_REQUIRED)
+                                    {
+                                        info!(
+                                            "Password reset registration required, initiating device flow"
+                                        );
+                                        request_dag!();
+                                    }
                                     if e.error_codes.contains(&CONSENT_REQUIRED) {
                                         /* Consent has not been granted for the application
                                          * to access the Graph API. Retry without Graph API


### PR DESCRIPTION
When a PasswordResetRegistrationRequiredInterrupt error is received, perform a DAG authentication.

Fixes #991
