### PR TITLE
Return PAM_IGNORE in chauthtok for local users

### DIFF
--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -468,23 +468,18 @@ impl PamHooks for PamKanidm {
         // Local user (no UPN): not a Himmelblau/Entra account. Skip before touching the
         // daemon so local password changes (e.g. sudo passwd <local_user>) never depend
         // on himmelblaud and continue to pam_unix.
-        if split_username(&account_id).is_none() {
-            debug!(%account_id, "chauthtok: not a UPN, skipping (local user)");
-            return PamResultCode::PAM_IGNORE;
-        }
+        let (_, domain) = match split_username(&account_id) {
+            Some(resp) => resp,
+            None => {
+                debug!(%account_id, "chauthtok: not a UPN, skipping (local user)");
+                return PamResultCode::PAM_IGNORE;
+            }
+        };
 
         let mut daemon_client = match DaemonClientBlocking::new(cfg.get_socket_path().as_str()) {
             Ok(dc) => dc,
             Err(e) => {
                 error!(err = ?e, "Error DaemonClientBlocking::new()");
-                return PamResultCode::PAM_SERVICE_ERR;
-            }
-        };
-
-        let (_, domain) = match split_username(&account_id) {
-            Some(resp) => resp,
-            None => {
-                error!(%account_id, "chauthtok: split_username failed unexpectedly");
                 return PamResultCode::PAM_SERVICE_ERR;
             }
         };


### PR DESCRIPTION
When the target user has no UPN (split_username returns None), treat them as a local account and return PAM_IGNORE so the PAM stack continues to pam_unix. Skip before touching the daemon so local password changes (for example, sudo passwd <local_user>) never depend on himmelblaud.

Fixes: https://github.com/himmelblau-idm/himmelblau/issues/1078


