### PR TITLE
Fix nightly build caused by Makefile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := $(shell command -v bash)
+SHELL := /bin/sh
 
 all: .packaging dockerfiles ## Auto-detect host distro and build packages just for this host
 	@set -euo pipefail; \


### PR DESCRIPTION
This shell command was causing these errors on
the build host:
make: command: Command not found
make: -c: Command not found