### PR TITLE
Fix QR greeter dependency name for Debian/Ubuntu

### DIFF
--- a/src/qr-greeter/Cargo.toml
+++ b/src/qr-greeter/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 [package.metadata.deb]
 name = "himmelblau-qr-greeter"
 depends = ["gnome-shell", "himmelblau"]
-recommends = ["dconf"]
+recommends = ["dconf-cli"]
 assets = [
   ["target/release/qr-greeter-build/qr-greeter@himmelblau-idm.org/extension.js", "usr/share/gnome-shell/extensions/qr-greeter@himmelblau-idm.org/extension.js", "644"],
   ["target/release/qr-greeter-build/qr-greeter@himmelblau-idm.org/qrcodegen.js", "usr/share/gnome-shell/extensions/qr-greeter@himmelblau-idm.org/qrcodegen.js", "644"],


### PR DESCRIPTION
On Debian and Ubuntu there is no all-in-one `dconf` package.
The `dconf` command is provided by `dconf-cli` instead.
