### PR TITLE
broker: return passwordExpiry too

### DIFF
--- a/src/daemon/src/broker.rs
+++ b/src/daemon/src/broker.rs
@@ -147,6 +147,7 @@ impl HimmelblauBroker for Broker {
                     "homeAccountId": format!("{}.{}", user.uuid.to_string(), user.tenant_id.map(|uuid| uuid.to_string()).unwrap_or("".to_string())),
                     "localAccountId": user.uuid.to_string(),
                     "name": user.displayname,
+                    "passwordExpiry": 0,
                     "realm": user.tenant_id.map(|uuid| uuid.to_string()).unwrap_or("".to_string()),
                     "username": user.spn
                 }


### PR DESCRIPTION
linux-entra-sso and sso-mib expect a passwordExpiry field in the getAccounts response, and fail without it, so include it. With this, they work out of the box with the himmelblau broker.

https://github.com/siemens/linux-entra-sso
https://github.com/siemens/sso-mib
