### PR TITLE
broker: add option to allow returning any unlocked and authenticated user

### DIFF
--- a/docs-xml/himmelblauconf/base/local_account_sso.xml
+++ b/docs-xml/himmelblauconf/base/local_account_sso.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="local_account_sso"
+           section="global"
+           type="bool"
+           rust_type="bool"
+           documented="true"
+           domain_specific="false"
+           order="48">
+<description>
+A boolean option that enables browser SSO for local Linux users who did not
+log in via Himmelblau PAM. When enabled, the broker will return cached Entra
+accounts to any local user requesting them, allowing browser extensions such
+as linux-entra-sso to acquire tokens and PRT SSO cookies on behalf of
+enrolled Entra accounts.
+
+.PP
+When disabled (the default), the broker only returns accounts whose UID
+matches the calling process, which requires the user to have logged in
+via Himmelblau PAM/NSS.
+
+.PP
+.B Prerequisite:
+The Entra user must have authenticated via Himmelblau PAM at least once
+since the daemon was started (e.g. by logging in at GDM or via
+.BR su ).
+The
+.B getAccounts
+broker method returns cached accounts immediately, but
+.B acquireTokenSilently
+and
+.B acquirePrtSsoCookie
+require the user\(aqs session credentials to be loaded in memory.
+
+.PP
+.B Security note:
+Enabling this option means any local user on the system can obtain SSO
+tokens for the enrolled Entra account. Only enable this on systems where
+all local users are trusted.
+</description>
+<default>false</default>
+<example>local_account_sso = true</example>
+</parameter>

--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -247,6 +247,12 @@ where
         dbtxn.get_accounts().map_err(|_| ())
     }
 
+    /// Return all cached user tokens. Used by the broker to serve
+    /// accounts to local users when `local_account_sso` is enabled.
+    pub async fn get_all_usertokens(&self) -> Result<Vec<UserToken>, ()> {
+        self.get_cached_usertokens().await
+    }
+
     async fn get_cached_grouptokens(&self) -> Result<Vec<GroupToken>, ()> {
         let mut dbtxn = self.db.write().await;
         dbtxn.get_groups().map_err(|_| ())

--- a/src/daemon/src/broker.rs
+++ b/src/daemon/src/broker.rs
@@ -18,6 +18,7 @@
 use async_trait::async_trait;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
+use himmelblau_unix_common::config::HimmelblauConfig;
 use himmelblau_unix_common::idprovider::himmelblau::HimmelblauMultiProvider;
 use himmelblau_unix_common::idprovider::interface::Id;
 use himmelblau_unix_common::resolver::Resolver;
@@ -28,8 +29,9 @@ use serde_json::json;
 use std::error::Error;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::debug;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct AccountReq {
     username: String,
 }
@@ -58,6 +60,7 @@ struct SsoCookieReq {
 #[derive(Clone)]
 pub(crate) struct Broker {
     pub(crate) cachelayer: Arc<Resolver<HimmelblauMultiProvider>>,
+    pub(crate) cfg: HimmelblauConfig,
 }
 
 #[async_trait]
@@ -80,23 +83,40 @@ impl HimmelblauBroker for Broker {
         request_json: String,
         uid: uid_t,
     ) -> Result<String, Box<dyn Error>> {
-        // Double check the user is making a request for their own account
-        let user = self
-            .cachelayer
-            .get_usertoken(Id::Gid(uid))
-            .await
-            .map_err(|_| "Unable to load account")?
-            .ok_or("Unable to find account")?;
         let request: TokenReq =
             serde_json::from_str(&request_json).map_err(|e| format!("{:?}", e))?;
         // account can be at root (Firefox, Chrome) or in authParameters (Edge)
         let account = match request.account {
-            Some(x) => x,
-            None => request.auth_parameters.account.ok_or("Missing account")?,
+            Some(ref x) => x.clone(),
+            None => request
+                .auth_parameters
+                .account
+                .as_ref()
+                .ok_or("Missing account")?
+                .clone(),
         };
-        if account.username.to_lowercase() != user.spn.to_lowercase() {
-            return Err("Invalid request for user!".into());
-        }
+        // Try UID-based lookup first
+        let user = match self.cachelayer.get_usertoken(Id::Gid(uid)).await {
+            Ok(Some(token)) => {
+                // Verify the request matches the UID-bound account
+                if account.username.to_lowercase() != token.spn.to_lowercase() {
+                    return Err("Invalid request for user!".into());
+                }
+                token
+            }
+            _ => {
+                // UID lookup failed — fall back to username if local_account_sso enabled
+                if !self.cfg.get_local_account_sso() {
+                    return Err("Unable to find account".into());
+                }
+                debug!("local_account_sso: looking up account by username '{}'", account.username);
+                self.cachelayer
+                    .get_usertoken(Id::Name(account.username.clone()))
+                    .await
+                    .map_err(|_| "Unable to load account")?
+                    .ok_or("Unable to find account")?
+            }
+        };
         let token = self
             .cachelayer
             .get_user_accesstoken(
@@ -132,16 +152,25 @@ impl HimmelblauBroker for Broker {
         _request_json: String,
         uid: uid_t,
     ) -> Result<String, Box<dyn Error>> {
-        // Only return the account for the requesting user
-        let user = self
-            .cachelayer
-            .get_usertoken(Id::Gid(uid))
-            .await
-            .map_err(|_| "Unable to load account")?
-            .ok_or("Unable to find account")?;
-        let res = json!({
-            "accounts": [
-                {
+        // Try UID-based lookup first
+        let users = match self.cachelayer.get_usertoken(Id::Gid(uid)).await {
+            Ok(Some(user)) => vec![user],
+            _ => {
+                // UID lookup failed — return all cached accounts if local_account_sso enabled
+                if !self.cfg.get_local_account_sso() {
+                    return Err("Unable to find account".into());
+                }
+                debug!("local_account_sso: returning all cached accounts for uid {}", uid);
+                self.cachelayer
+                    .get_all_usertokens()
+                    .await
+                    .map_err(|_| "Unable to load accounts")?
+            }
+        };
+        let accounts: Vec<_> = users
+            .iter()
+            .map(|user| {
+                json!({
                     "environment": "login.windows.net",
                     "givenName": user.displayname,
                     "homeAccountId": format!("{}.{}", user.uuid.to_string(), user.tenant_id.map(|uuid| uuid.to_string()).unwrap_or("".to_string())),
@@ -149,9 +178,10 @@ impl HimmelblauBroker for Broker {
                     "name": user.displayname,
                     "realm": user.tenant_id.map(|uuid| uuid.to_string()).unwrap_or("".to_string()),
                     "username": user.spn
-                }
-            ]
-        });
+                })
+            })
+            .collect();
+        let res = json!({ "accounts": accounts });
         Ok(res.to_string())
     }
 
@@ -172,18 +202,29 @@ impl HimmelblauBroker for Broker {
         request_json: String,
         uid: uid_t,
     ) -> Result<String, Box<dyn Error>> {
-        // Double check the user is making a request for their own account
-        let user = self
-            .cachelayer
-            .get_usertoken(Id::Gid(uid))
-            .await
-            .map_err(|_| "Unable to load account")?
-            .ok_or("Unable to find account")?;
         let request: SsoCookieReq =
             serde_json::from_str(&request_json).map_err(|e| format!("{:?}", e))?;
-        if request.account.username.to_lowercase() != user.spn.to_lowercase() {
-            return Err("Invalid request for user!".into());
-        }
+        // Try UID-based lookup first
+        let user = match self.cachelayer.get_usertoken(Id::Gid(uid)).await {
+            Ok(Some(token)) => {
+                if request.account.username.to_lowercase() != token.spn.to_lowercase() {
+                    return Err("Invalid request for user!".into());
+                }
+                token
+            }
+            _ => {
+                // UID lookup failed — fall back to username if local_account_sso enabled
+                if !self.cfg.get_local_account_sso() {
+                    return Err("Unable to find account".into());
+                }
+                debug!("local_account_sso: looking up account by username '{}'", request.account.username);
+                self.cachelayer
+                    .get_usertoken(Id::Name(request.account.username.clone()))
+                    .await
+                    .map_err(|_| "Unable to load account")?
+                    .ok_or("Unable to find account")?
+            }
+        };
         let prt = self
             .cachelayer
             .get_user_prt_cookie(Id::Name(user.spn.clone()))

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -1378,7 +1378,7 @@ async fn main() -> ExitCode {
             let dbus_cachelayer = cachelayer.clone();
             let e_broadcast_rx = broadcast_tx.subscribe();
             let task_d = match himmelblau_broker_serve::<Broker>(
-                Broker { cachelayer: dbus_cachelayer },
+                Broker { cachelayer: dbus_cachelayer, cfg: cfg.clone() },
                 &broker_socket_path,
                 e_broadcast_rx
             ).await {


### PR DESCRIPTION
Currently only the user logged in via PAM is returned by getAccounts and similar interfaces. Add an option that, when no uid match is found, returns all authenticated and unlocked accounts. This is useful to run or test on existing systems that are not provisioned via Entra, but that use existing local accounts, with different usernames.
The option is disabled by default to preserve existing behaviour.