### PR TITLE
Fix a regression in the 3.x password-only auth flow where a newly

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -2730,9 +2730,8 @@ impl IdProvider for HimmelblauProvider {
                     Ok((
                         AuthResult::Next(AuthRequest::SetupPin {
                             msg: format!(
-                                "Set up a PIN\n {}{}",
-                                "A Hello PIN is a fast, secure way to sign",
-                                "in to your device, apps, and services."
+                                "Set up a PIN\n {}",
+                                "A Hello PIN is a fast, secure way to sign in to your device, apps, and services.",
                             ),
                         }),
                         action,


### PR DESCRIPTION
Fix a regression in the 3.x password-only auth flow where a newly authenticated user on an already enrolled device could complete login without being prompted to set up Linux Hello PIN. Better prompting logic for `SetupPin`