### PR TITLE
fix(auth): restore safe offline fallback when decoupled Hello reauth starts offline

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -2057,6 +2057,78 @@ impl IdProvider for HimmelblauProvider {
                 )
             }};
         }
+            macro_rules! offline_auth_defensive_revalidation {
+                ($reauth_pin_value:expr) => {{
+                    let mut state = self.state.lock().await;
+                    *state = CacheState::OfflineNextCheck(
+                        SystemTime::now() + OFFLINE_NEXT_CHECK,
+                    );
+                    // Defensive re-validation: only allow offline fallback
+                    // if the Hello key can still be loaded with this PIN.
+                    let (hello_key, _keytype) = match self.fetch_hello_key(account_id, keystore) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!(?e, "Reauth fallback failed. Hello key missing.");
+                            return Ok((
+                                AuthResult::Denied(
+                                    "Failed to authenticate with Hello PIN.".to_string(),
+                                ),
+                                AuthCacheAction::None,
+                            ));
+                        }
+                    };
+                    let pin = PinValue::new($reauth_pin_value.as_str()).map_err(|e| {
+                        error!(?e, "Failed setting pin value during reauth fallback");
+                        IdpError::Tpm
+                    })?;
+                    if let Err(e) = tpm.ms_hello_key_load(machine_key, &hello_key, &pin) {
+                        error!(?e, "Reauth fallback failed. Invalid Hello PIN.");
+                        return Ok((
+                            AuthResult::Denied(
+                                "Failed to authenticate with Hello PIN.".to_string(),
+                            ),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                    // If we validated the Hello PIN but cannot start online
+                    // re-auth due to a network outage, fall back to offline
+                    // unlock using the existing cached token.
+                    if check_hello_totp_enabled!(self) {
+                        let reauth_pin = $reauth_pin_value.to_string();
+                        if !check_hello_totp_setup!(self, account_id, keystore) {
+                            return impl_setup_hello_totp!(
+                                self,
+                                account_id,
+                                keystore,
+                                old_token,
+                                reauth_pin,
+                                tpm,
+                                machine_key,
+                                cred_handler
+                            );
+                        } else {
+                            *cred_handler = AuthCredHandler::HelloTOTP {
+                                cred: reauth_pin,
+                                pending_sealed_totp: None,
+                            };
+                            return Ok((
+                                AuthResult::Next(AuthRequest::HelloTOTP {
+                                    msg: "Please enter your Hello TOTP code from your Authenticator: "
+                                    .to_string(),
+                            }),
+                            AuthCacheAction::None,
+                        ));
+                    }
+                }
+
+                return Ok((
+                    AuthResult::Success {
+                        token: old_token.clone(),
+                    },
+                    AuthCacheAction::None,
+                ));
+            }}
+        }
         // Issue #1051: Initiate online re-authentication when the cached
         // PRT/refresh token has expired but the Hello key and PIN are still valid.
         // The validated PIN is carried through so the new PRT can be sealed with
@@ -2124,14 +2196,7 @@ impl IdProvider for HimmelblauProvider {
                         Err(MsalError::RequestFailed(msg)) => {
                             let url = extract_base_url!(msg);
                             info!(?url, "Network down detected during reauth MFA initiation");
-                            let mut state = self.state.lock().await;
-                            *state = CacheState::OfflineNextCheck(
-                                SystemTime::now() + OFFLINE_NEXT_CHECK,
-                            );
-                            return Ok((
-                                AuthResult::Denied("Network outage detected.".to_string()),
-                                AuthCacheAction::None,
-                            ));
+                            offline_auth_defensive_revalidation!(reauth_pin_value)
                         }
                         Err(MsalError::PasswordRequired) => {
                             // Azure requires a password for this flow. Prompt for
@@ -2215,14 +2280,7 @@ impl IdProvider for HimmelblauProvider {
                         Err(MsalError::RequestFailed(msg)) => {
                             let url = extract_base_url!(msg);
                             info!(?url, "Network down detected during reauth DAG initiation");
-                            let mut state = self.state.lock().await;
-                            *state = CacheState::OfflineNextCheck(
-                                SystemTime::now() + OFFLINE_NEXT_CHECK,
-                            );
-                            return Ok((
-                                AuthResult::Denied("Network outage detected.".to_string()),
-                                AuthCacheAction::None,
-                            ));
+                            offline_auth_defensive_revalidation!(reauth_pin_value)
                         }
                         Err(e) => {
                             error!("Failed to initiate reauth device flow: {:?}", e);


### PR DESCRIPTION
Issue #1206 is a regression in 3.x decoupled Hello reauthentication handling: when a valid Hello PIN is entered but online reauth (MFA/DAG initiation) fails with `MsalError::RequestFailed`, the flow returned `AuthResult::Denied("Network outage detected.")` instead of allowing the existing offline unlock behavior. This can leave users stuck on unlock after suspend/network flap until connectivity returns. This change targets only the reauth network-failure branches in `request_reauth!` and preserves decoupled Hello reauth semantics when online is available.
Changes:
- In both reauth initiation failure paths:
  - `Network down detected during reauth MFA initiation`
  - `Network down detected during reauth DAG initiation`
- Keep state transition to `CacheState::OfflineNextCheck(...)`.
- Add defensive Hello verification before any offline success fallback:
  - fetch current Hello key from keystore
  - re-validate the supplied PIN with `tpm.ms_hello_key_load(...)`
- If Hello key/PIN validation fails, return a denial (`"Failed to authenticate with Hello PIN."`) instead of success.
- If validation succeeds:
  - preserve existing Hello TOTP policy behavior (setup/challenge),
  - otherwise return offline success with `old_token` to unblock unlock. Security/behavior notes:
- Does NOT bypass Hello validation for offline fallback.
- Does NOT change successful online reauth behavior.
- Does NOT change when/why decoupled reauth is triggered.
- Only affects the narrow case where reauth cannot be initiated due to network outage.
- Restores expected offline unlock ergonomics while retaining 3.x decoupled key preservation and reauth flow improvements.

Fixes #1206
