### PR TITLE
Enable Intune policy application by default

### DIFF
--- a/docs-xml/himmelblauconf/base/apply_policy.xml
+++ b/docs-xml/himmelblauconf/base/apply_policy.xml
@@ -7,8 +7,10 @@
            domain_specific="false"
            order="28">
 <description>
-A boolean option that enables the application and enforcement of Intune policies to the authenticated user.
+A boolean option that enables the application and enforcement of Intune device compliance policies during non-OIDC authentication.
+When enabled (the default), non-compliant devices may be denied authentication in accordance with the configured policies.
+This setting does not affect OIDC-based authentication flows.
 </description>
-<default>false</default>
-<example>apply_policy = true</example>
+<default>true</default>
+<example>apply_policy = false</example>
 </parameter>

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -1,4 +1,4 @@
-.TH HIMMELBLAU.CONF "5" "February 2026" "Himmelblau Configuration" "File Formats"
+.TH HIMMELBLAU.CONF "5" "March 2026" "Himmelblau Configuration" "File Formats"
 .SH NAME
 himmelblau.conf \- Configuration file for Himmelblau, enabling Azure Entra ID authentication on Linux.
 
@@ -504,13 +504,15 @@ Example: name_mapping_script = /path/to/mapping_script.sh
 .TP
 .B apply_policy
 .RE
-A boolean option that enables the application and enforcement of Intune policies to the authenticated user.
+A boolean option that enables the application and enforcement of Intune device compliance policies during non-OIDC authentication.
+When enabled (the default), non-compliant devices may be denied authentication in accordance with the configured policies.
+This setting does not affect OIDC-based authentication flows.
 
 .P
-Default: false
+Default: true
 
 .P
-Example: apply_policy = true
+Example: apply_policy = false
 
 .TP
 .B authority_host

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -427,11 +427,13 @@ in
 
     apply_policy = mkOption {
       type = types.nullOr (types.bool);
-      default = false;
+      default = true;
       description = ''
-        A boolean option that enables the application and enforcement of Intune policies to the authenticated user.
+        A boolean option that enables the application and enforcement of Intune device compliance policies during non-OIDC authentication.
+        When enabled (the default), non-compliant devices may be denied authentication in accordance with the configured policies.
+        This setting does not affect OIDC-based authentication flows.
       '';
-      example = true;
+      example = false;
     };
 
     authority_host = mkOption {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -1042,15 +1042,15 @@ mod tests {
     fn test_get_apply_policy() {
         let config_data = r#"
         [global]
-        apply_policy = true
+        apply_policy = false
         "#;
 
         let temp_file = create_temp_config(config_data);
         let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
 
-        assert_eq!(config.get_apply_policy(), true);
+        assert_eq!(config.get_apply_policy(), false);
         let config_empty = create_empty_config();
-        assert_eq!(config_empty.get_apply_policy(), false);
+        assert_eq!(config_empty.get_apply_policy(), true);
     }
 
     #[test]


### PR DESCRIPTION
Intune policy application has matured enough that this can be enabled by default. It also only prevents authentication _if_ policy was enforced _and_ Intune determines the device is outside compliance. There is no reason to leave this disabled. It also has no effect on OIDC auth.
