### PR TITLE
feat: auto-sudo for device owner (first logged-in user)

### DIFF
--- a/docs-xml/himmelblauconf/base/auto_sudo_owner.xml
+++ b/docs-xml/himmelblauconf/base/auto_sudo_owner.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="auto_sudo_owner"
+           section="global"
+           type="bool"
+           rust_type="bool"
+           documented="true"
+           domain_specific="true"
+           order="22">
+<description>
+When set to
+.B true
+, the first Entra ID user to log in to each domain on this device is automatically
+granted sudo access via the local sudo group (see
+.B local_sudo_group
+). This user is considered the device owner. Subsequent users are not granted sudo
+by this mechanism, though they may still receive it via
+.B sudo_groups
+or
+.B local_groups
+configuration.
+.PP
+Ownership state is stored persistently under
+.I /var/lib/himmelblaud/
+and is not affected by cache clearing. To reset device ownership, delete the
+ownership state file or use
+.B aad-tool owner-reset
+.
+</description>
+<default>false</default>
+<example>auto_sudo_owner = true</example>
+</parameter>

--- a/docs-xml/himmelblauconf/base/auto_sudo_owner.xml
+++ b/docs-xml/himmelblauconf/base/auto_sudo_owner.xml
@@ -21,10 +21,11 @@ configuration.
 .PP
 Ownership state is stored persistently under
 .I /var/lib/himmelblaud/
-and is not affected by cache clearing. To reset device ownership, delete the
-ownership state file or use
+and is not affected by cache clearing. Use
+.B aad-tool owner-show
+to display the current owner, or
 .B aad-tool owner-reset
-.
+to reset ownership.
 </description>
 <default>false</default>
 <example>auto_sudo_owner = true</example>

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -403,6 +403,34 @@ A script that will execute every time a user logs on. Two environment variables 
 Example: logon_script = /etc/himmelblau/logon.sh
 
 .TP
+.B auto_sudo_owner
+.RE
+When set to
+.B true
+, the first Entra ID user to log in to each domain on this device is automatically
+granted sudo access via the local sudo group (see
+.B local_sudo_group
+). This user is considered the device owner. Subsequent users are not granted sudo
+by this mechanism, though they may still receive it via
+.B sudo_groups
+or
+.B local_groups
+configuration.
+.PP
+Ownership state is stored persistently under
+.I /var/lib/himmelblaud/
+and is not affected by cache clearing. To reset device ownership, delete the
+ownership state file or use
+.B aad-tool owner-reset
+.
+
+.P
+Default: false
+
+.P
+Example: auto_sudo_owner = true
+
+.TP
 .B logon_token_scopes
 .RE
 A comma-separated list of the scopes to be requested for the ACCESS_TOKEN during logon. These scopes
@@ -677,6 +705,17 @@ Default: /var/run/himmelblaud/broker_sock
 Example: broker_socket_path = /tmp/broker.sock
 
 .TP
+.B enable_passwordless
+.RE
+A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
+
+.P
+Default: true
+
+.P
+Example: enable_passwordless = false
+
+.TP
 .B home_prefix
 .RE
 The prefix to use for user home directories.
@@ -724,17 +763,6 @@ Default: spn
 
 .P
 Example: home_alias = SPN
-
-.TP
-.B enable_passwordless
-.RE
-A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
-
-.P
-Default: true
-
-.P
-Example: enable_passwordless = false
 
 .TP
 .B shell

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -332,6 +332,32 @@ in
       example = "/etc/himmelblau/logon.sh";
     };
 
+    auto_sudo_owner = mkOption {
+      type = types.nullOr (types.bool);
+      default = false;
+      description = ''
+        When set to
+        **true**
+        , the first Entra ID user to log in to each domain on this device is automatically
+        granted sudo access via the local sudo group (see
+        **local_sudo_group**
+        ). This user is considered the device owner. Subsequent users are not granted sudo
+        by this mechanism, though they may still receive it via
+        **sudo_groups**
+        or
+        **local_groups**
+        configuration.
+        
+        Ownership state is stored persistently under
+        */var/lib/himmelblaud/*
+        and is not affected by cache clearing. To reset device ownership, delete the
+        ownership state file or use
+        **aad-tool owner-reset**
+        .
+      '';
+      example = true;
+    };
+
     logon_token_scopes = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;
@@ -572,6 +598,15 @@ in
       example = "/tmp/broker.sock";
     };
 
+    enable_passwordless = mkOption {
+      type = types.nullOr (types.bool);
+      default = true;
+      description = ''
+        A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
+      '';
+      example = false;
+    };
+
     home_prefix = mkOption {
       type = types.nullOr (types.str);
       default = "/home/";
@@ -609,15 +644,6 @@ in
         - CN
       '';
       example = "SPN";
-    };
-
-    enable_passwordless = mkOption {
-      type = types.nullOr (types.bool);
-      default = true;
-      description = ''
-        A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
-      '';
-      example = false;
     };
 
     shell = mkOption {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -628,6 +628,10 @@ async fn main() -> ExitCode {
             debug,
             domain: _,
         } => debug,
+        HimmelblauUnixOpt::OwnerShow {
+            debug,
+            domain: _,
+        } => debug,
         HimmelblauUnixOpt::ConfigurePam {
             debug,
             really: _,
@@ -1701,6 +1705,58 @@ async fn main() -> ExitCode {
                                     let domain_name = &name["owner.".len()..];
                                     println!("Reset device owner for domain '{}'.", domain_name);
                                     found = true;
+                                }
+                            }
+                        }
+                    }
+                    if !found {
+                        println!("No device owners set.");
+                    }
+                }
+            }
+            ExitCode::SUCCESS
+        }
+        HimmelblauUnixOpt::OwnerShow { debug: _, domain } => {
+            if unsafe { libc::geteuid() } != 0 {
+                error!("This command must be run as root.");
+                return ExitCode::FAILURE;
+            }
+
+            let owner_dir = Path::new("/var/lib/himmelblaud");
+            match domain {
+                Some(domain) => {
+                    let path = owner_dir.join(format!("owner.{}", domain));
+                    match fs::read_to_string(&path) {
+                        Ok(owner) => {
+                            let owner = owner.trim();
+                            if owner.is_empty() {
+                                println!("No device owner set for domain '{}'.", domain);
+                            } else {
+                                println!("{}: {}", domain, owner);
+                            }
+                        }
+                        Err(_) => {
+                            println!("No device owner set for domain '{}'.", domain);
+                        }
+                    }
+                }
+                None => {
+                    let mut found = false;
+                    if let Ok(entries) = fs::read_dir(owner_dir) {
+                        for entry in entries.flatten() {
+                            if let Some(name) = entry.file_name().to_str() {
+                                if name.starts_with("owner.") {
+                                    let domain_name = &name["owner.".len()..];
+                                    match fs::read_to_string(entry.path()) {
+                                        Ok(owner) => {
+                                            let owner = owner.trim();
+                                            if !owner.is_empty() {
+                                                println!("{}: {}", domain_name, owner);
+                                                found = true;
+                                            }
+                                        }
+                                        Err(_) => {}
+                                    }
                                 }
                             }
                         }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -624,6 +624,10 @@ async fn main() -> ExitCode {
             mapped: _,
             full: _,
         } => debug,
+        HimmelblauUnixOpt::OwnerReset {
+            debug,
+            domain: _,
+        } => debug,
         HimmelblauUnixOpt::ConfigurePam {
             debug,
             really: _,
@@ -1663,6 +1667,50 @@ async fn main() -> ExitCode {
                 println!("success");
                 ExitCode::SUCCESS
             }
+        }
+        HimmelblauUnixOpt::OwnerReset { debug: _, domain } => {
+            if unsafe { libc::geteuid() } != 0 {
+                error!("This command must be run as root.");
+                return ExitCode::FAILURE;
+            }
+
+            let owner_dir = Path::new("/var/lib/himmelblaud");
+            match domain {
+                Some(domain) => {
+                    let path = owner_dir.join(format!("owner.{}", domain));
+                    if path.exists() {
+                        if let Err(e) = fs::remove_file(&path) {
+                            error!("Failed to remove owner file {:?}: {}", path, e);
+                            return ExitCode::FAILURE;
+                        }
+                        println!("Device owner for domain '{}' has been reset.", domain);
+                    } else {
+                        println!("No device owner set for domain '{}'.", domain);
+                    }
+                }
+                None => {
+                    let mut found = false;
+                    if let Ok(entries) = fs::read_dir(owner_dir) {
+                        for entry in entries.flatten() {
+                            if let Some(name) = entry.file_name().to_str() {
+                                if name.starts_with("owner.") {
+                                    if let Err(e) = fs::remove_file(entry.path()) {
+                                        error!("Failed to remove {:?}: {}", entry.path(), e);
+                                        return ExitCode::FAILURE;
+                                    }
+                                    let domain_name = &name["owner.".len()..];
+                                    println!("Reset device owner for domain '{}'.", domain_name);
+                                    found = true;
+                                }
+                            }
+                        }
+                    }
+                    if !found {
+                        println!("No device owners set.");
+                    }
+                }
+            }
+            ExitCode::SUCCESS
         }
         HimmelblauUnixOpt::ConfigurePam {
             debug: _,

--- a/src/cli/src/opt/tool.rs
+++ b/src/cli/src/opt/tool.rs
@@ -424,6 +424,19 @@ pub enum HimmelblauUnixOpt {
         #[clap(long)]
         domain: Option<String>,
     },
+    /// Show the current device owner for a domain, or all domains.
+    ///
+    /// This command reads the ownership state stored under /var/lib/himmelblaud/
+    /// and displays the account ID of the device owner for each domain.
+    ///
+    /// This command must be run as root.
+    OwnerShow {
+        #[clap(short, long)]
+        debug: bool,
+        /// The domain to show ownership for. If omitted, shows all domains.
+        #[clap(long)]
+        domain: Option<String>,
+    },
     /// Configure PAM to use pam_himmelblau
     ConfigurePam {
         #[clap(short, long)]

--- a/src/cli/src/opt/tool.rs
+++ b/src/cli/src/opt/tool.rs
@@ -412,6 +412,18 @@ pub enum HimmelblauUnixOpt {
         #[clap(long)]
         full: bool,
     },
+    /// Reset the device owner for a domain. After resetting, the next user
+    /// to log in (when auto_sudo_owner is enabled) will become the new
+    /// device owner and receive sudo access.
+    ///
+    /// This command must be run as root.
+    OwnerReset {
+        #[clap(short, long)]
+        debug: bool,
+        /// The domain to reset ownership for. If omitted, resets all domains.
+        #[clap(long)]
+        domain: Option<String>,
+    },
     /// Configure PAM to use pam_himmelblau
     ConfigurePam {
         #[clap(short, long)]

--- a/src/config/himmelblau.conf.example
+++ b/src/config/himmelblau.conf.example
@@ -88,6 +88,11 @@
 # when groups are removed from this list. You must remove them manually.
 # local_groups =
 #
+# Automatically grant sudo access to the first Entra ID user who logs in to
+# each domain (the "device owner"). Subsequent users do not receive sudo via
+# this mechanism. Use `aad-tool owner-reset` to clear ownership.
+# auto_sudo_owner = false
+#
 # Logon user script. This script will execute every time a user logs on. Two
 # environment variables are set: USERNAME, and ACCESS_TOKEN. The ACCESS_TOKEN
 # environment variable is an access token for the MS graph. The token scope

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -20,6 +20,7 @@
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 use std::error::Error;
+use std::fs;
 use std::fs::metadata;
 use std::io;
 use std::io::{Error as IoError, ErrorKind};
@@ -162,6 +163,32 @@ fn rm_if_exist(p: &str) {
     } else {
         debug!("Path {:?} doesn't exist, not attempting to remove.", p);
     }
+}
+
+/// Returns the path to the device-owner state file for a given domain.
+fn owner_state_path(domain: &str) -> PathBuf {
+    PathBuf::from("/var/lib/himmelblaud").join(format!("owner.{}", domain))
+}
+
+/// Get the current device owner for a domain, if one has been established.
+fn get_device_owner(domain: &str) -> Option<String> {
+    fs::read_to_string(owner_state_path(domain))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Claim device ownership for a domain. Uses create_new to ensure
+/// only the first writer wins in a race.
+fn set_device_owner(domain: &str, account_id: &str) -> Result<(), io::Error> {
+    use std::io::Write;
+    let path = owner_state_path(domain);
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    file.write_all(account_id.as_bytes())?;
+    Ok(())
 }
 
 async fn handle_task_client(
@@ -750,6 +777,27 @@ async fn handle_client(
                                 let members = cachelayer.get_groupmembers(sudo_group_uuid).await;
                                 if members.contains(&account_id) {
                                     is_sudoer = true;
+                                }
+                            }
+
+                            // Auto-sudo for the device owner (first user to log in).
+                            if let Some((_user, domain)) = split_username(&account_id) {
+                                if cfg.get_auto_sudo_owner(Some(domain)) {
+                                    match get_device_owner(domain) {
+                                        Some(owner) => {
+                                            if owner.to_lowercase() == account_id.to_lowercase() {
+                                                debug!("User {} is the device owner for domain {}", account_id, domain);
+                                                is_sudoer = true;
+                                            }
+                                        }
+                                        None => {
+                                            info!("Setting device owner for domain {} to {}", domain, account_id);
+                                            match set_device_owner(domain, &account_id) {
+                                                Ok(()) => is_sudoer = true,
+                                                Err(e) => error!("Failed to persist device owner: {}", e),
+                                            }
+                                        }
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
## Summary
- Adds `auto_sudo_owner` config option (default: false). When enabled,
  the first Entra ID user to log into a device is automatically added
  to the local sudo group (e.g., `sudo` on Ubuntu, `wheel` on RHEL).
  The user still authenticates normally for sudo — this just grants
  group membership automatically.
- The owner is persisted per-domain. Subsequent users are NOT added.
- Adds `aad-tool owner-reset` CLI command to reset ownership (next login
  becomes the new owner). Supports `--domain` to target a specific domain.
- Adds `aad-tool owner-show` CLI command to display the current device
  owner per-domain or for all domains.
- Includes config XML, man page, Nix options, and example config updates.

## Files changed
- `docs-xml/himmelblauconf/base/auto_sudo_owner.xml` — new config option
- `src/daemon/src/daemon.rs` — owner tracking on first login
- `src/cli/src/main.rs` + `opt/tool.rs` — `owner-reset` + `owner-show` subcommands
- `man/`, `nix/`, `src/config/himmelblau.conf.example` — docs/config updates

## Test plan
- [ ] Enable `auto_sudo_owner = true`, log in as first user, verify
      user added to sudo group (`groups <user>`)
- [ ] Log in as second user — verify they are NOT added to sudo group
- [ ] Run `aad-tool owner-show` — displays owner per domain
- [ ] Run `aad-tool owner-show --domain example.com` — shows specific domain
- [ ] Run `aad-tool owner-reset` — next login becomes new owner
- [ ] Run `aad-tool owner-reset --domain example.com` — domain-specific reset
- [ ] Verify `auto_sudo_owner = false` (default) does not add to sudo group