### PR TITLE
Replace RwLock with Mutex in provider layer to fix deadlocks

### DIFF
--- a/src/common/src/idprovider/common.rs
+++ b/src/common/src/idprovider/common.rs
@@ -240,7 +240,7 @@ macro_rules! handle_hello_bad_pin_count {
             .increment_bad_pin_count($account_id)
             .await;
 
-        let hello_pin_retry_count = $self.config.read().await.get_hello_pin_retry_count();
+        let hello_pin_retry_count = $self.config.lock().await.get_hello_pin_retry_count();
         let bad_pin_count = $self.bad_pin_counter.bad_pin_count($account_id).await;
 
         if bad_pin_count == hello_pin_retry_count {
@@ -297,7 +297,7 @@ macro_rules! impl_offline_break_glass {
     ($self:ident, $ttl:ident) => {{
         let mut state = $self.state.lock().await;
         let (ttl, enabled) = {
-            let cfg = $self.config.read().await;
+            let cfg = $self.config.lock().await;
             (
                 match $ttl {
                     Some(ttl) => ttl,
@@ -368,7 +368,7 @@ macro_rules! load_cached_prt {
         if let Ok(Some(hello_prt)) = $keystore.get_tagged_hsm_key(&hello_prt_tag) {
             let prt = $self
                 .client
-                .read()
+                .lock()
                 .await
                 .unseal_user_prt_with_hello_key(&hello_prt, &$hello_key, &$cred, $tpm, $machine_key)
                 .map_err(|e| {
@@ -379,7 +379,7 @@ macro_rules! load_cached_prt {
             // This happens after 14 days of no online contact.
             if $self
                 .client
-                .read()
+                .lock()
                 .await
                 .is_prt_expired(&prt, $tpm, $machine_key)
                 .map_err(|e| {
@@ -412,7 +412,7 @@ macro_rules! impl_himmelblau_offline_auth_init {
     ($self:ident, $account_id:expr, $no_hello_pin:ident, $keystore:expr, $password_auth:expr) => {{
         let hello_key = $self.fetch_hello_key($account_id, $keystore).ok();
         let (sfa_enabled, hello_pin_retry_count, breakglass_enabled) = {
-            let cfg = $self.config.read().await;
+            let cfg = $self.config.lock().await;
             (
                 cfg.get_enable_sfa_fallback(),
                 cfg.get_hello_pin_retry_count(),
@@ -560,7 +560,7 @@ macro_rules! check_hello_totp_setup {
 #[macro_export]
 macro_rules! check_hello_totp_enabled {
     ($self:ident) => {{
-        let cfg = $self.config.read().await;
+        let cfg = $self.config.lock().await;
         cfg.get_enable_hello_totp()
     }};
 }
@@ -669,7 +669,7 @@ macro_rules! entra_id_prt_token_fetch {
     ($self:ident, $prt:ident, $scopes:ident, $client_id:ident, $redirect_uri:ident, $tpm:ident, $machine_key:ident) => {{
         $self
             .client
-            .read()
+            .lock()
             .await
             .exchange_prt_for_access_token(
                 &$prt,
@@ -796,7 +796,7 @@ macro_rules! seal_prt_with_existing_hello_key {
     ($self:expr, $account_id:expr, $token:expr, $hello_key:expr, $pin:expr, $keystore:expr, $tpm:expr, $machine_key:expr) => {{
         // Seal the PRT with the existing Hello key
         if let Some(prt) = &$token.prt {
-            match $self.client.read().await.seal_user_prt_with_hello_key(
+            match $self.client.lock().await.seal_user_prt_with_hello_key(
                 prt,
                 $hello_key,
                 $pin,
@@ -862,7 +862,7 @@ macro_rules! impl_provision_hello_key {
     ($self:ident, $token:ident, $cred:ident, $tpm:ident, $machine_key:ident) => {
         $self
             .client
-            .read()
+            .lock()
             .await
             .provision_hello_for_business_key(&$token, $tpm, $machine_key, &$cred)
             .await

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -293,11 +293,20 @@ macro_rules! find_provider {
         match $providers.get($domain) {
             Some(provider) => Some(provider),
             None => {
-                // Attempt to match a provider alias
-                let mut cfg = $hmp.config.lock().await;
-                match cfg.get_primary_domain_from_alias($domain).await {
-                    Some(domain) => $providers.get(&domain),
-                    /* NEVER introduce a new tenant here: Advisory GHSA-q746-m2wv-qh4v */
+                // Attempt to match a provider alias, but do not hold the providers
+                // mutex across the awaited alias lookup.
+                drop($providers);
+                let primary_domain = {
+                    let mut cfg = $hmp.config.lock().await;
+                    cfg.get_primary_domain_from_alias($domain).await
+                };
+
+                match primary_domain {
+                    Some(domain) => {
+                        /* NEVER introduce a new tenant here: Advisory GHSA-q746-m2wv-qh4v */
+                        $providers = $hmp.providers.lock().await;
+                        $providers.get(&domain)
+                    }
                     None => None,
                 }
             }
@@ -381,7 +390,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -420,7 +429,7 @@ impl IdProvider for HimmelblauMultiProvider {
             return empty;
         };
 
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let Ok(provider) = find_provider!(self, providers, domain, keystore) else {
             return empty;
         };
@@ -453,7 +462,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -480,7 +489,7 @@ impl IdProvider for HimmelblauMultiProvider {
         machine_key: &tpm::structures::StorageKey,
     ) -> Result<bool, IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -511,7 +520,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -541,7 +550,7 @@ impl IdProvider for HimmelblauMultiProvider {
         shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -592,7 +601,7 @@ impl IdProvider for HimmelblauMultiProvider {
         shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -639,7 +648,7 @@ impl IdProvider for HimmelblauMultiProvider {
         keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -668,7 +677,7 @@ impl IdProvider for HimmelblauMultiProvider {
         online_at_init: bool,
     ) -> Result<AuthResult, IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.lock().await;
+        let mut providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -721,7 +730,7 @@ impl IdProvider for HimmelblauMultiProvider {
         match account_id {
             Some(account_id) => match idp_get_domain_for_account!(self, account_id) {
                 Ok(domain) => {
-                    let providers = self.providers.lock().await;
+                    let mut providers = self.providers.lock().await;
                     match find_provider!(self, providers, domain, keystore) {
                         Ok(provider) => match provider {
                             Providers::Oidc(provider) => {

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -72,11 +72,12 @@ use reqwest;
 use reqwest::Url;
 use std::collections::HashMap;
 use std::ffi::CString;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::SystemTime;
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex};
 use totp_rs::{Algorithm, Secret, TOTP};
 use uuid::Uuid;
 use zeroize::Zeroizing;
@@ -168,8 +169,8 @@ enum Providers {
 }
 
 pub struct HimmelblauMultiProvider {
-    config: Arc<RwLock<HimmelblauConfig>>,
-    providers: Arc<RwLock<HashMap<String, Providers>>>,
+    config: Arc<Mutex<HimmelblauConfig>>,
+    providers: Arc<Mutex<HashMap<String, Providers>>>,
 }
 
 impl HimmelblauMultiProvider {
@@ -178,16 +179,16 @@ impl HimmelblauMultiProvider {
         keystore: &mut D,
     ) -> Result<Self> {
         let config = match HimmelblauConfig::new(Some(config_filename)) {
-            Ok(config) => Arc::new(RwLock::new(config)),
+            Ok(config) => Arc::new(Mutex::new(config)),
             Err(e) => return Err(anyhow!("{}", e)),
         };
         let idmap = match Idmap::new() {
-            Ok(idmap) => Arc::new(RwLock::new(idmap)),
+            Ok(idmap) => Arc::new(Mutex::new(idmap)),
             Err(e) => return Err(anyhow!("{:?}", e)),
         };
 
         let providers = HashMap::new();
-        let cfg = config.read().await;
+        let cfg = config.lock().await;
         let domains = cfg.get_configured_domains();
         if domains.is_empty() {
             warn!("No domains configured in himmelblau.conf.");
@@ -195,7 +196,7 @@ impl HimmelblauMultiProvider {
 
         let providers = HimmelblauMultiProvider {
             config: config.clone(),
-            providers: Arc::new(RwLock::new(providers)),
+            providers: Arc::new(Mutex::new(providers)),
         };
 
         if cfg.get_oidc_issuer_url().is_none() {
@@ -232,7 +233,7 @@ impl HimmelblauMultiProvider {
                     })?;
                 {
                     // A client write lock is required here.
-                    let mut client = provider.client.write().await;
+                    let mut client = provider.client.lock().await;
                     if let Ok(transport_key) =
                         provider.fetch_loadable_transport_key_from_keystore(keystore)
                     {
@@ -244,7 +245,7 @@ impl HimmelblauMultiProvider {
                 }
                 providers
                     .providers
-                    .write()
+                    .lock()
                     .await
                     .insert(domain.to_string(), Providers::Himmelblau(provider));
             }
@@ -257,11 +258,11 @@ impl HimmelblauMultiProvider {
 
             providers
                 .providers
-                .write()
+                .lock()
                 .await
                 .insert("oidc".to_string(), Providers::Oidc(provider));
         }
-        if providers.providers.read().await.len() == 0 {
+        if providers.providers.lock().await.len() == 0 {
             return Err(anyhow!("No provider was configured!"));
         }
 
@@ -270,12 +271,12 @@ impl HimmelblauMultiProvider {
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(12 * 60 * 60)).await;
-                let providers = providers_ref.read().await;
+                let providers = providers_ref.lock().await;
                 for (_, provider) in providers.iter() {
                     match provider {
                         Providers::Oidc(_) => {}
                         Providers::Himmelblau(provider) => {
-                            let app = provider.client.write().await;
+                            let app = provider.client.lock().await;
                             app.clear_cookies();
                         }
                     }
@@ -293,7 +294,7 @@ macro_rules! find_provider {
             Some(provider) => Some(provider),
             None => {
                 // Attempt to match a provider alias
-                let mut cfg = $hmp.config.write().await;
+                let mut cfg = $hmp.config.lock().await;
                 match cfg.get_primary_domain_from_alias($domain).await {
                     Some(domain) => $providers.get(&domain),
                     /* NEVER introduce a new tenant here: Advisory GHSA-q746-m2wv-qh4v */
@@ -310,7 +311,7 @@ macro_rules! find_provider {
 
 macro_rules! idp_get_domain_for_account {
     ($hmp:ident, $account_id:expr) => {{
-        let cfg = $hmp.config.read().await;
+        let cfg = $hmp.config.lock().await;
         if cfg.get_oidc_issuer_url().is_some() {
             Ok("oidc")
         } else {
@@ -331,7 +332,7 @@ macro_rules! idp_get_domain_for_account {
 #[async_trait]
 impl IdProvider for HimmelblauMultiProvider {
     async fn offline_break_glass(&self, ttl: Option<u64>) -> Result<(), IdpError> {
-        for (_domain, provider) in self.providers.read().await.iter() {
+        for (_domain, provider) in self.providers.lock().await.iter() {
             match provider {
                 Providers::Oidc(provider) => provider.offline_break_glass(ttl).await?,
                 Providers::Himmelblau(provider) => {
@@ -347,7 +348,7 @@ impl IdProvider for HimmelblauMultiProvider {
      * Currently we go offline if ANY provider is down, which could be
      * incorrect. */
     async fn check_online(&self, tpm: &mut tpm::provider::BoxedDynTpm, now: SystemTime) -> bool {
-        for (_domain, provider) in self.providers.read().await.iter() {
+        for (_domain, provider) in self.providers.lock().await.iter() {
             match provider {
                 Providers::Oidc(provider) => {
                     if !provider.check_online(tpm, now).await {
@@ -380,7 +381,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -419,7 +420,7 @@ impl IdProvider for HimmelblauMultiProvider {
             return empty;
         };
 
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let Ok(provider) = find_provider!(self, providers, domain, keystore) else {
             return empty;
         };
@@ -452,7 +453,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -479,7 +480,7 @@ impl IdProvider for HimmelblauMultiProvider {
         machine_key: &tpm::structures::StorageKey,
     ) -> Result<bool, IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -510,7 +511,7 @@ impl IdProvider for HimmelblauMultiProvider {
             None => id.to_string().clone(),
         };
         let domain = idp_get_domain_for_account!(self, &account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -540,7 +541,7 @@ impl IdProvider for HimmelblauMultiProvider {
         shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -591,7 +592,7 @@ impl IdProvider for HimmelblauMultiProvider {
         shutdown_rx: &broadcast::Receiver<()>,
     ) -> Result<(AuthResult, AuthCacheAction), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -638,7 +639,7 @@ impl IdProvider for HimmelblauMultiProvider {
         keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -667,7 +668,7 @@ impl IdProvider for HimmelblauMultiProvider {
         online_at_init: bool,
     ) -> Result<AuthResult, IdpError> {
         let domain = idp_get_domain_for_account!(self, account_id)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let provider = find_provider!(self, providers, domain, keystore)?;
 
         match provider {
@@ -720,7 +721,7 @@ impl IdProvider for HimmelblauMultiProvider {
         match account_id {
             Some(account_id) => match idp_get_domain_for_account!(self, account_id) {
                 Ok(domain) => {
-                    let providers = self.providers.read().await;
+                    let providers = self.providers.lock().await;
                     match find_provider!(self, providers, domain, keystore) {
                         Ok(provider) => match provider {
                             Providers::Oidc(provider) => {
@@ -736,7 +737,7 @@ impl IdProvider for HimmelblauMultiProvider {
                 Err(..) => return CacheState::Offline,
             },
             None => {
-                for (_domain, provider) in self.providers.read().await.iter() {
+                for (_domain, provider) in self.providers.lock().await.iter() {
                     match provider {
                         Providers::Oidc(provider) => {
                             match provider.get_cachestate(None, keystore).await {
@@ -764,7 +765,7 @@ impl IdProvider for HimmelblauMultiProvider {
     }
 
     async fn export_broker_prts(&self) -> Result<Vec<u8>, serde_json::Error> {
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         let mut all: HashMap<String, Vec<u8>> = HashMap::new();
         for (domain, provider) in providers.iter() {
             if let Providers::Himmelblau(p) = provider {
@@ -777,7 +778,7 @@ impl IdProvider for HimmelblauMultiProvider {
 
     async fn import_broker_prts(&self, data: &[u8]) -> Result<(), serde_json::Error> {
         let all: HashMap<String, Vec<u8>> = serde_json::from_slice(data)?;
-        let providers = self.providers.read().await;
+        let providers = self.providers.lock().await;
         for (domain, blob) in &all {
             if let Some(Providers::Himmelblau(p)) = providers.get(domain) {
                 if let Err(e) = p.import_broker_prts(blob).await {
@@ -794,33 +795,33 @@ const OFFLINE_NEXT_CHECK: Duration = Duration::from_secs(15);
 
 pub struct HimmelblauProvider {
     state: Mutex<CacheState>,
-    client: RwLock<BrokerClientApplication>,
-    config: Arc<RwLock<HimmelblauConfig>>,
+    client: Mutex<BrokerClientApplication>,
+    config: Arc<Mutex<HimmelblauConfig>>,
     domain: String,
     graph: Graph,
     refresh_cache: RefreshCache,
-    idmap: Arc<RwLock<Idmap>>,
-    init: RwLock<bool>,
+    idmap: Arc<Mutex<Idmap>>,
+    init: AtomicBool,
     bad_pin_counter: BadPinCounter,
 }
 
 impl HimmelblauProvider {
     pub fn new(
         client: BrokerClientApplication,
-        config: &Arc<RwLock<HimmelblauConfig>>,
+        config: &Arc<Mutex<HimmelblauConfig>>,
         domain: &str,
         graph: Graph,
-        idmap: &Arc<RwLock<Idmap>>,
+        idmap: &Arc<Mutex<Idmap>>,
     ) -> Result<Self, IdpError> {
         Ok(HimmelblauProvider {
             state: Mutex::new(CacheState::OfflineNextCheck(SystemTime::now())),
-            client: RwLock::new(client),
+            client: Mutex::new(client),
             config: config.clone(),
             domain: domain.to_string(),
             graph,
             refresh_cache: RefreshCache::new(),
             idmap: idmap.clone(),
-            init: RwLock::new(false),
+            init: AtomicBool::new(false),
             bad_pin_counter: BadPinCounter::new(),
         })
     }
@@ -936,7 +937,7 @@ impl IdProvider for HimmelblauProvider {
                 {
                     match self
                         .client
-                        .read()
+                        .lock()
                         .await
                         .exchange_prt_for_prt(&old_prt, tpm, machine_key, true)
                         .await
@@ -1021,25 +1022,25 @@ impl IdProvider for HimmelblauProvider {
         };
         let cloud_ccache = self
             .client
-            .read()
+            .lock()
             .await
             .fetch_cloud_tgt(&prt, tpm, machine_key)
             .ok();
         let ad_ccache = self
             .client
-            .read()
+            .lock()
             .await
             .fetch_ad_tgt(&prt, tpm, machine_key)
             .ok();
         let top_level_names = self
             .client
-            .read()
+            .lock()
             .await
             .unseal_prt_kerberos_top_level_names(&prt, tpm, machine_key)
             .ok();
         let tenant_id = match old_token {
             Some(t) => t.tenant_id.map(|u| u.to_string()),
-            None => match self.config.read().await.get_tenant_id(&self.domain) {
+            None => match self.config.lock().await.get_tenant_id(&self.domain) {
                 Some(t) => Some(t),
                 None => self.graph.tenant_id().await.ok(),
             },
@@ -1085,7 +1086,7 @@ impl IdProvider for HimmelblauProvider {
         };
 
         self.client
-            .read()
+            .lock()
             .await
             .acquire_prt_sso_cookie_with_nonce(&prt, sso_nonce, tpm, machine_key)
             .await
@@ -1184,7 +1185,7 @@ impl IdProvider for HimmelblauProvider {
 
         macro_rules! fetch_user_confidential_client {
             ($client_id:expr, $client_credential:expr) => {{
-                let cfg = self.config.read().await;
+                let cfg = self.config.lock().await;
                 let authority_host = cfg.get_authority_host(&self.domain);
                 let tenant_id = cfg.get_tenant_id(&self.domain).ok_or_else(|| {
                     error!("tenant_id not found");
@@ -1267,7 +1268,7 @@ impl IdProvider for HimmelblauProvider {
                         // Check if the user exists
                         let auth_init = net_down_check!(
                             self.client
-                                .read()
+                                .lock()
                                 .await
                                 .check_user_exists(&account_id, &[])
                                 .await,
@@ -1279,7 +1280,7 @@ impl IdProvider for HimmelblauProvider {
                         if auth_init.exists() {
                             // Generate a UserToken, with invalid uuid. We can
                             // only fetch this from an authenticated token.
-                            let config = self.config.read().await;
+                            let config = self.config.lock().await;
                             let (uid, gid) = match idmap_cache.get_user_by_name(&account_id) {
                                 Some(user) => {
                                     (user.uid, user.gid)
@@ -1288,7 +1289,7 @@ impl IdProvider for HimmelblauProvider {
                                     IdAttr::Uuid => {
                                         // Attempt to map the UPN to an Object Id.
                                         let sidtoname = self.client
-                                            .read()
+                                            .lock()
                                             .await
                                             .resolve_nametosid(
                                                 &account_id,
@@ -1300,7 +1301,7 @@ impl IdProvider for HimmelblauProvider {
                                                 error!("Failed mapping UPN to Object Id: {:?}", e);
                                                 IdpError::BadRequest
                                             })?;
-                                        let idmap = self.idmap.read().await;
+                                        let idmap = self.idmap.lock().await;
                                         let sid = AadSid::from_sid_str(&sidtoname.sid).map_err(|e| {
                                             error!("Failed parsing SID: {:?}", e);
                                             IdpError::BadRequest
@@ -1315,7 +1316,7 @@ impl IdProvider for HimmelblauProvider {
                                         (uid, uid)
                                     },
                                     IdAttr::Name | IdAttr::Rfc2307 => {
-                                        let idmap = self.idmap.read().await;
+                                        let idmap = self.idmap.lock().await;
                                         let gid = idmap.gen_to_unix(&self.graph.tenant_id().await.map_err(|e| {
                                             error!("{:?}", e);
                                             IdpError::BadRequest
@@ -1336,7 +1337,7 @@ impl IdProvider for HimmelblauProvider {
                                 uuid: fake_uuid,
                                 gidnumber: uid,
                             }];
-                            let config = self.config.read().await;
+                            let config = self.config.lock().await;
                             return Ok(UserTokenState::Update(UserToken {
                                 name: account_id.clone(),
                                 spn: account_id.clone(),
@@ -1370,7 +1371,7 @@ impl IdProvider for HimmelblauProvider {
         };
         // If an app_id is defined in the config, the app should have the
         // GroupMember.Read.All API permission.
-        let cfg = self.config.read().await;
+        let cfg = self.config.lock().await;
         let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
             (None, vec!["GroupMember.Read.All"])
         } else {
@@ -1383,7 +1384,7 @@ impl IdProvider for HimmelblauProvider {
             RefreshCacheEntry::Prt(prt) => {
                 let mtoken = self
                     .client
-                    .read()
+                    .lock()
                     .await
                     .exchange_prt_for_access_token(
                         &prt,
@@ -1402,7 +1403,7 @@ impl IdProvider for HimmelblauProvider {
                         sleep(Duration::from_millis(500));
                         net_down_check!(
                             self.client
-                                .read()
+                                .lock()
                                 .await
                                 .exchange_prt_for_access_token(&prt, scopes, None, client_id, tpm, machine_key, None)
                                 .await,
@@ -1427,7 +1428,7 @@ impl IdProvider for HimmelblauProvider {
                         );
                         match self
                             .client
-                            .read()
+                            .lock()
                             .await
                             .exchange_prt_for_access_token(
                                 &prt,
@@ -1462,7 +1463,7 @@ impl IdProvider for HimmelblauProvider {
                         );
                         match self
                             .client
-                            .read()
+                            .lock()
                             .await
                             .exchange_prt_for_access_token(
                                 &prt,
@@ -1494,7 +1495,7 @@ impl IdProvider for HimmelblauProvider {
                         );
                         match self
                             .client
-                            .read()
+                            .lock()
                             .await
                             .exchange_prt_for_access_token(
                                 &prt,
@@ -1619,7 +1620,7 @@ impl IdProvider for HimmelblauProvider {
         };
         let remote_services = self
             .config
-            .read()
+            .lock()
             .await
             .get_password_only_remote_services_deny_list();
         // Check if this is a remote service:
@@ -1630,12 +1631,12 @@ impl IdProvider for HimmelblauProvider {
                 .iter()
                 .any(|s| !s.is_empty() && service.contains(s));
         let hello_totp_enabled = check_hello_totp_enabled!(self);
-        let allow_remote_hello = self.config.read().await.get_allow_remote_hello();
+        let allow_remote_hello = self.config.lock().await.get_allow_remote_hello();
         // Skip Hello authentication if it is disabled by config
-        let hello_enabled = self.config.read().await.get_enable_hello();
-        let hello_pin_retry_count = self.config.read().await.get_hello_pin_retry_count();
+        let hello_enabled = self.config.lock().await.get_enable_hello();
+        let hello_pin_retry_count = self.config.lock().await.get_hello_pin_retry_count();
         let intune_enrollment_required =
-            self.config.read().await.get_apply_policy() && !self.is_intune_enrolled(keystore).await;
+            self.config.lock().await.get_apply_policy() && !self.is_intune_enrolled(keystore).await;
         if !self.is_domain_joined(keystore).await
             || hello_key.is_none()
             || !hello_enabled
@@ -1662,21 +1663,21 @@ impl IdProvider for HimmelblauProvider {
             // For local terminal authentication (GDM, etc.), don't force MFA
             // to allow natural passwordless flow without prematurely triggering
             // MFA notifications.
-            let console_password_only = self.config.read().await.get_allow_console_password_only();
+            let console_password_only = self.config.lock().await.get_allow_console_password_only();
             debug!(
                 "Service '{}' remote_service={} console_password_only={}",
                 service, is_remote_service, console_password_only
             );
-            if self.config.read().await.get_enable_experimental_mfa() {
+            if self.config.lock().await.get_enable_experimental_mfa() {
                 let mut auth_options = vec![];
-                if self.config.read().await.get_enable_passwordless() {
+                if self.config.lock().await.get_enable_passwordless() {
                     auth_options.push(AuthOption::Passwordless);
                 }
                 if !is_remote_service {
                     auth_options.push(AuthOption::Fido);
                     if self
                         .config
-                        .read()
+                        .lock()
                         .await
                         .get_enable_experimental_passwordless_fido()
                     {
@@ -1693,7 +1694,7 @@ impl IdProvider for HimmelblauProvider {
 
                 let auth_init = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .check_user_exists(account_id, &auth_options)
                         .await,
@@ -1745,14 +1746,14 @@ impl IdProvider for HimmelblauProvider {
                 } else {
                     let flow = net_down_check!(
                         self.client
-                            .read()
+                            .lock()
                             .await
                             .initiate_acquire_token_by_mfa_flow_for_device_enrollment(
                                 account_id,
                                 None,
                                 &auth_options,
                                 Some(auth_init),
-                                self.config.read().await.get_mfa_method().as_deref()
+                                self.config.lock().await.get_mfa_method().as_deref()
                             )
                             .await,
                         Err(MsalError::PasswordRequired) => {
@@ -1810,7 +1811,7 @@ impl IdProvider for HimmelblauProvider {
                 }
                 let resp = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .initiate_device_flow_for_device_enrollment(&auth_options)
                         .await,
@@ -1913,7 +1914,7 @@ impl IdProvider for HimmelblauProvider {
                     .await
                 {
                     Ok((intune_key, intune_device_id)) => {
-                        let mut config = self.config.write().await;
+                        let mut config = self.config.lock().await;
                         config.set(&self.domain, "intune_device_id", &intune_device_id);
                         if let Err(e) = config.write_server_config() {
                             error!(?e, "Failed to write Intune join configuration.");
@@ -1954,7 +1955,7 @@ impl IdProvider for HimmelblauProvider {
                 }
                 // If an app_id is defined in the config, the app should have the
                 // GroupMember.Read.All API permission.
-                let cfg = self.config.read().await;
+                let cfg = self.config.lock().await;
                 let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
                     (None, vec!["GroupMember.Read.All"])
                 } else {
@@ -1965,7 +1966,7 @@ impl IdProvider for HimmelblauProvider {
                 };
                 let mtoken2 = self
                     .client
-                    .read()
+                    .lock()
                     .await
                     .acquire_token_by_refresh_token(
                         &$token.refresh_token,
@@ -1991,7 +1992,7 @@ impl IdProvider for HimmelblauProvider {
                                     sleep(Duration::from_secs(5));
                                     net_down_check!(
                                         self.client
-                                            .read()
+                                            .lock()
                                             .await
                                             .acquire_token_by_refresh_token(
                                                 &$token.refresh_token,
@@ -2029,7 +2030,7 @@ impl IdProvider for HimmelblauProvider {
                                         err_resp.error_description
                                     );
                                     match self.client
-                                        .read()
+                                        .lock()
                                         .await
                                         .acquire_token_by_refresh_token(
                                             &$token.refresh_token,
@@ -2068,7 +2069,7 @@ impl IdProvider for HimmelblauProvider {
                                      Retrying with default app ID."
                                 );
                                 match self.client
-                                    .read()
+                                    .lock()
                                     .await
                                     .acquire_token_by_refresh_token(
                                         &$token.refresh_token,
@@ -2122,7 +2123,7 @@ impl IdProvider for HimmelblauProvider {
                     enable_passwordless,
                     mfa_method,
                 ) = {
-                    let cfg = self.config.read().await;
+                    let cfg = self.config.lock().await;
                     (
                         cfg.get_allow_console_password_only(),
                         cfg.get_password_only_remote_services_deny_list(),
@@ -2159,7 +2160,7 @@ impl IdProvider for HimmelblauProvider {
 
                     let flow = match self
                         .client
-                        .read()
+                        .lock()
                         .await
                         .initiate_acquire_token_by_mfa_flow_for_device_enrollment(
                             account_id,
@@ -2256,7 +2257,7 @@ impl IdProvider for HimmelblauProvider {
                     }
                     let resp = match self
                         .client
-                        .read()
+                        .lock()
                         .await
                         .initiate_device_flow_for_device_enrollment(&auth_options)
                         .await
@@ -2375,7 +2376,7 @@ impl IdProvider for HimmelblauProvider {
 
                 // If an app_id is defined in the config, the app should have the
                 // GroupMember.Read.All API permission.
-                let cfg = self.config.read().await;
+                let cfg = self.config.lock().await;
                 let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
                     (None, vec!["GroupMember.Read.All"])
                 } else {
@@ -2387,7 +2388,7 @@ impl IdProvider for HimmelblauProvider {
                 let token = if $keytype == KeyType::Hello {
                     match self
                         .client
-                        .read()
+                        .lock()
                         .await
                         .acquire_token_by_hello_for_business_key(
                             account_id,
@@ -2457,7 +2458,7 @@ impl IdProvider for HimmelblauProvider {
                                        Retrying authentication without Graph API scopes.");
                                 match self
                                     .client
-                                    .read()
+                                    .lock()
                                     .await
                                     .acquire_token_by_hello_for_business_key(
                                         account_id,
@@ -2500,7 +2501,7 @@ impl IdProvider for HimmelblauProvider {
                                 );
                                 match self
                                     .client
-                                    .read()
+                                    .lock()
                                     .await
                                     .acquire_token_by_hello_for_business_key(
                                         account_id,
@@ -2547,7 +2548,7 @@ impl IdProvider for HimmelblauProvider {
                             );
                             match self
                                 .client
-                                .read()
+                                .lock()
                                 .await
                                 .acquire_token_by_hello_for_business_key(
                                     account_id,
@@ -2601,7 +2602,7 @@ impl IdProvider for HimmelblauProvider {
                     let refresh_cache_entry = match keystore.get_tagged_hsm_key(&hello_prt_tag) {
                         Ok(Some(hello_prt)) => self
                             .client
-                            .read()
+                            .lock()
                             .await
                             .unseal_user_prt_with_hello_key(
                                 &hello_prt,
@@ -2646,7 +2647,7 @@ impl IdProvider for HimmelblauProvider {
                     if let Some(RefreshCacheEntry::Prt(prt)) = refresh_cache_entry {
                         match self
                             .client
-                            .read()
+                            .lock()
                             .await
                             .exchange_prt_for_access_token(
                                 &prt,
@@ -2662,7 +2663,7 @@ impl IdProvider for HimmelblauProvider {
                                     // the can down the road).
                                     if let Ok(new_prt) = self
                                         .client
-                                        .read()
+                                        .lock()
                                         .await
                                         .exchange_prt_for_prt(
                                             &prt,
@@ -2727,7 +2728,7 @@ impl IdProvider for HimmelblauProvider {
                                                Retrying token exchange without Graph API scopes.");
                                         match self
                                             .client
-                                            .read()
+                                            .lock()
                                             .await
                                             .exchange_prt_for_access_token(
                                                 &prt,
@@ -2741,7 +2742,7 @@ impl IdProvider for HimmelblauProvider {
                                                 Ok(mut token) => {
                                                     if let Ok(new_prt) = self
                                                         .client
-                                                        .read()
+                                                        .lock()
                                                         .await
                                                         .exchange_prt_for_prt(
                                                             &prt,
@@ -2870,7 +2871,7 @@ impl IdProvider for HimmelblauProvider {
 
                 // Cache the PRT to disk for offline auth SSO
                 if let Some(prt) = &token.prt {
-                    match self.client.read().await.seal_user_prt_with_hello_key(
+                    match self.client.lock().await.seal_user_prt_with_hello_key(
                         prt,
                         &$hello_key,
                         &$cred,
@@ -3012,7 +3013,7 @@ impl IdProvider for HimmelblauProvider {
                             extra_data: None,
                             reauth_hello_pin: reauth_hello_pin.clone(),
                         };
-                        let action = if self.config.read().await.get_offline_breakglass_enabled() {
+                        let action = if self.config.lock().await.get_offline_breakglass_enabled() {
                             AuthCacheAction::PasswordHashUpdate { $cred }
                         } else {
                             AuthCacheAction::None
@@ -3036,7 +3037,7 @@ impl IdProvider for HimmelblauProvider {
                             extra_data: None,
                             reauth_hello_pin: reauth_hello_pin.clone(),
                         };
-                        let action = if self.config.read().await.get_offline_breakglass_enabled() {
+                        let action = if self.config.lock().await.get_offline_breakglass_enabled() {
                             AuthCacheAction::PasswordHashUpdate { $cred }
                         } else {
                             AuthCacheAction::None
@@ -3058,7 +3059,7 @@ impl IdProvider for HimmelblauProvider {
                             extra_data: None,
                             reauth_hello_pin: reauth_hello_pin.clone(),
                         };
-                        let action = if self.config.read().await.get_offline_breakglass_enabled() {
+                        let action = if self.config.lock().await.get_offline_breakglass_enabled() {
                             AuthCacheAction::PasswordHashUpdate { $cred }
                         } else {
                             AuthCacheAction::None
@@ -3081,7 +3082,7 @@ impl IdProvider for HimmelblauProvider {
         macro_rules! maybe_prompt_setup_pin_after_password_only_success {
             ($enrollment_token:expr, $success_token:expr, $action:expr, $msg:expr) => {{
                 let action = $action;
-                let hello_enabled = self.config.read().await.get_enable_hello();
+                let hello_enabled = self.config.lock().await.get_enable_hello();
                 let hello_key_missing = self.fetch_hello_key(account_id, keystore).is_err();
                 if hello_enabled && !no_hello_pin && hello_key_missing {
                     info!($msg);
@@ -3121,7 +3122,7 @@ impl IdProvider for HimmelblauProvider {
                                 Ok(AuthResult::Success { token }) => {
                                     let action = if self
                                         .config
-                                        .read()
+                                        .lock()
                                         .await
                                         .get_offline_breakglass_enabled()
                                     {
@@ -3273,7 +3274,7 @@ impl IdProvider for HimmelblauProvider {
                     // Step 1: Validate password via ROPC (Resource Owner Password Credentials)
                     Some(
                         self.client
-                            .read()
+                            .lock()
                             .await
                             .acquire_token_by_username_password(
                                 account_id,
@@ -3305,7 +3306,7 @@ impl IdProvider for HimmelblauProvider {
                         return match self.token_validate(account_id, &token2, None).await {
                             Ok(AuthResult::Success { token }) => {
                                 let action =
-                                    if self.config.read().await.get_offline_breakglass_enabled() {
+                                    if self.config.lock().await.get_offline_breakglass_enabled() {
                                         AuthCacheAction::PasswordHashUpdate { cred }
                                     } else {
                                         AuthCacheAction::None
@@ -3401,14 +3402,14 @@ impl IdProvider for HimmelblauProvider {
                 // /oauth2/authorize request.
                 let flow = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .initiate_acquire_token_by_mfa_flow_for_device_enrollment(
                             account_id,
                             Some(&cred),
                             auth_options,
                             None,
-                            self.config.read().await.get_mfa_method().as_deref()
+                            self.config.lock().await.get_mfa_method().as_deref()
                         )
                         .await,
                     Ok(flow) => flow,
@@ -3420,14 +3421,14 @@ impl IdProvider for HimmelblauProvider {
                         }
                         net_down_check!(
                             self.client
-                                .read()
+                                .lock()
                                 .await
                                 .initiate_acquire_token_by_mfa_flow_for_device_enrollment(
                                     account_id,
                                     Some(&cred),
                                     auth_options,
                                     None,
-                                    self.config.read().await.get_mfa_method().as_deref()
+                                    self.config.lock().await.get_mfa_method().as_deref()
                                 )
                                 .await,
                             Ok(flow) => flow,
@@ -3467,7 +3468,7 @@ impl IdProvider for HimmelblauProvider {
                     // we'll make another run at it in a moment.
                     let _ = net_down_check!(
                         self.client
-                            .read()
+                            .lock()
                             .await
                             .handle_password_change(account_id, old_cred, &cred)
                             .await,
@@ -3483,7 +3484,7 @@ impl IdProvider for HimmelblauProvider {
                 // Prohibit Fido over a remote service (since it can't work)
                 let remote_services = self
                     .config
-                    .read()
+                    .lock()
                     .await
                     .get_password_only_remote_services_deny_list();
                 // Check if this is a remote service:
@@ -3496,12 +3497,12 @@ impl IdProvider for HimmelblauProvider {
                         .any(|s| !s.is_empty() && service.contains(s))
                     || service.to_lowercase().contains("ssh");
                 let console_password_only =
-                    self.config.read().await.get_allow_console_password_only();
+                    self.config.lock().await.get_allow_console_password_only();
                 if !is_remote_service {
                     opts.push(AuthOption::Fido);
                     if self
                         .config
-                        .read()
+                        .lock()
                         .await
                         .get_enable_experimental_passwordless_fido()
                     {
@@ -3521,7 +3522,7 @@ impl IdProvider for HimmelblauProvider {
                     debug!("Hello reauth password flow: disabling SFA fallback.");
                     false
                 } else {
-                    self.config.read().await.get_enable_sfa_fallback()
+                    self.config.lock().await.get_enable_sfa_fallback()
                 };
                 if sfa_enabled {
                     opts.push(AuthOption::NoDAGFallback);
@@ -3530,14 +3531,14 @@ impl IdProvider for HimmelblauProvider {
                 // Call the appropriate method based on whether mfa_method is configured
                 let mresp = self
                     .client
-                    .read()
+                    .lock()
                     .await
                     .initiate_acquire_token_by_mfa_flow_for_device_enrollment(
                         account_id,
                         Some(&cred),
                         &opts,
                         None,
-                        self.config.read().await.get_mfa_method().as_deref(),
+                        self.config.lock().await.get_mfa_method().as_deref(),
                     )
                     .await;
 
@@ -3573,7 +3574,7 @@ impl IdProvider for HimmelblauProvider {
                                 // will deadlock.
                                 let res = self
                                     .client
-                                    .read()
+                                    .lock()
                                     .await
                                     .acquire_token_by_username_password(
                                         account_id,
@@ -3651,7 +3652,7 @@ impl IdProvider for HimmelblauProvider {
                 let reauth_hello_pin = reauth_hello_pin.clone();
                 let token = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .acquire_token_by_mfa_flow(account_id, Some(&cred), None, &mut *flow)
                         .await,
@@ -3693,7 +3694,7 @@ impl IdProvider for HimmelblauProvider {
                         );
 
                         // Skip Hello enrollment if it is disabled by config
-                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        let hello_enabled = self.config.lock().await.get_enable_hello();
                         if !hello_enabled || no_hello_pin {
                             info!("Skipping Hello enrollment because it is disabled");
                             return Ok((
@@ -3751,7 +3752,7 @@ impl IdProvider for HimmelblauProvider {
                 }
                 let token = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .acquire_token_by_mfa_flow(account_id, None, Some(poll_attempt), &mut *flow)
                         .await,
@@ -3824,7 +3825,7 @@ impl IdProvider for HimmelblauProvider {
                         );
 
                         // Skip Hello enrollment if it is disabled by config
-                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        let hello_enabled = self.config.lock().await.get_enable_hello();
                         if !hello_enabled || no_hello_pin {
                             info!("Skipping Hello enrollment because it is disabled");
                             return Ok((
@@ -3872,7 +3873,7 @@ impl IdProvider for HimmelblauProvider {
                 let reauth_hello_pin = reauth_hello_pin.clone();
                 let token = net_down_check!(
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .acquire_token_by_mfa_flow(account_id, Some(&assertion), None, &mut *flow)
                         .await,
@@ -3914,7 +3915,7 @@ impl IdProvider for HimmelblauProvider {
                         );
 
                         // Skip Hello enrollment if it is disabled by config
-                        let hello_enabled = self.config.read().await.get_enable_hello();
+                        let hello_enabled = self.config.lock().await.get_enable_hello();
                         if !hello_enabled || no_hello_pin {
                             info!("Skipping Hello enrollment because it is disabled");
                             return Ok((
@@ -4042,7 +4043,7 @@ impl HimmelblauProvider {
         // possible. This permits the daemon to start, without requiring we be
         // connected to the internet. This way we can send messages to the user
         // via PAM indicating that the network is down.
-        let init = *self.init.read().await;
+        let init = self.init.load(Ordering::Acquire);
         if !init {
             // Send the federation provider request, if necessary. If these were
             // cached previously, then a network connection is not necessary at
@@ -4062,9 +4063,9 @@ impl HimmelblauProvider {
             })?;
 
             // Initialize the idmap range
-            let cfg = self.config.read().await;
+            let cfg = self.config.lock().await;
             let range = cfg.get_idmap_range(&self.domain);
-            let mut idmap = self.idmap.write().await;
+            let mut idmap = self.idmap.lock().await;
             idmap
                 .add_gen_domain(&self.domain, &tenant_id, range)
                 .map_err(|e| {
@@ -4077,7 +4078,7 @@ impl HimmelblauProvider {
             let authority_url = format!("https://{}/{}", authority_host, tenant_id);
             // A client write lock is required here.
             self.client
-                .write()
+                .lock()
                 .await
                 .set_authority(&authority_url)
                 .map_err(|e| {
@@ -4086,10 +4087,10 @@ impl HimmelblauProvider {
                 })?;
 
             // Mark the provider as initialized
-            *self.init.write().await = true;
+            self.init.store(true, Ordering::Release);
 
             // Cache the federation provider responses
-            let mut cfg = self.config.write().await;
+            let mut cfg = self.config.lock().await;
             cfg.set(&self.domain, "tenant_id", &tenant_id);
             debug!(
                 "Setting domain {} config tenant_id to {}",
@@ -4114,7 +4115,7 @@ impl HimmelblauProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn attempt_online(&self, _tpm: &mut tpm::provider::BoxedDynTpm, now: SystemTime) -> bool {
-        let cfg = self.config.read().await;
+        let cfg = self.config.lock().await;
         let authority_host = self
             .graph
             .authority_host()
@@ -4214,7 +4215,7 @@ impl HimmelblauProvider {
         };
 
         // Try PRT exchange to check sign-in frequency
-        let cfg = self.config.read().await;
+        let cfg = self.config.lock().await;
         let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
             (None, vec!["GroupMember.Read.All"])
         } else {
@@ -4225,7 +4226,7 @@ impl HimmelblauProvider {
         };
         let prt_result = self
             .client
-            .read()
+            .lock()
             .await
             .exchange_prt_for_access_token(&prt, scopes.clone(), None, client_id, tpm, machine_key, None)
             .await;
@@ -4237,7 +4238,7 @@ impl HimmelblauProvider {
                 );
                 sleep(Duration::from_millis(500));
                 self.client
-                    .read()
+                    .lock()
                     .await
                     .exchange_prt_for_access_token(&prt, scopes, None, client_id, tpm, machine_key, None)
                     .await
@@ -4253,7 +4254,7 @@ impl HimmelblauProvider {
                        Retrying token exchange without Graph API scopes."
                     );
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .exchange_prt_for_access_token(&prt, vec![], None, None, tpm, machine_key, None)
                         .await
@@ -4267,7 +4268,7 @@ impl HimmelblauProvider {
                         err_resp.error_description
                     );
                     self.client
-                        .read()
+                        .lock()
                         .await
                         .exchange_prt_for_access_token(
                             &prt,
@@ -4292,7 +4293,7 @@ impl HimmelblauProvider {
                      Retrying with default app ID."
                 );
                 self.client
-                    .read()
+                    .lock()
                     .await
                     .exchange_prt_for_access_token(
                         &prt,
@@ -4314,7 +4315,7 @@ impl HimmelblauProvider {
                 // Request a new PRT to refresh the cache
                 match self
                     .client
-                    .read()
+                    .lock()
                     .await
                     .exchange_prt_for_prt(&prt, tpm, machine_key, true)
                     .await
@@ -4376,7 +4377,7 @@ impl HimmelblauProvider {
                     /* Fixes bug#801: The authenticated user might have a mis-matched
                      * response because the domains are aliases of one another.
                      */
-                    let mut cfg = self.config.write().await;
+                    let mut cfg = self.config.lock().await;
                     let (_, domain1) = split_username(account_id).ok_or({
                         error!("Failed splitting account_id username");
                         IdpError::BadRequest
@@ -4435,7 +4436,7 @@ impl HimmelblauProvider {
         value: TokenOrObj,
         old_token: Option<&UserToken>,
     ) -> Result<UserToken, IdpError> {
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         let mut groups: Vec<GroupToken>;
         let posix_attrs: HashMap<String, String>;
         let spn = spn.to_lowercase();
@@ -4543,7 +4544,7 @@ impl HimmelblauProvider {
                 (pwd.pw_uid as u32, pwd.pw_gid as u32)
             }
             None => {
-                let idmap = self.idmap.read().await;
+                let idmap = self.idmap.lock().await;
                 let idmap_cache = StaticIdCache::new(ID_MAP_CACHE, false).map_err(|e| {
                     error!("Failed reading from the idmap cache: {:?}", e);
                     IdpError::BadRequest
@@ -4674,7 +4675,7 @@ impl HimmelblauProvider {
         &self,
         value: DirectoryObject,
     ) -> Result<GroupToken> {
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         let name = match value.display_name {
             Some(name) => name,
             None => value.id.clone(),
@@ -4690,7 +4691,7 @@ impl HimmelblauProvider {
         }
         let id =
             Uuid::parse_str(&value.id).map_err(|e| anyhow!("Failed parsing user uuid: {}", e))?;
-        let idmap = self.idmap.read().await;
+        let idmap = self.idmap.lock().await;
         let idmap_cache_entry = StaticIdCache::new(ID_MAP_CACHE, false)
             .ok()
             .and_then(|idmap_cache| idmap_cache.get_group_by_name(&id.to_string()));
@@ -4775,7 +4776,7 @@ impl HimmelblauProvider {
         keystore: &mut D,
         machine_key: &tpm::structures::StorageKey,
     ) -> Result<(), MsalError> {
-        let join_type = self.config.read().await.get_join_type();
+        let join_type = self.config.lock().await.get_join_type();
         /* If not already joined, join the domain now. */
         let attrs = EnrollAttrs::new(
             self.domain.clone(),
@@ -4787,7 +4788,7 @@ impl HimmelblauProvider {
         // A client write lock is required here.
         let res = self
             .client
-            .write()
+            .lock()
             .await
             .enroll_device(&token.refresh_token, attrs.clone(), tpm, machine_key)
             .await;
@@ -4838,7 +4839,7 @@ impl HimmelblauProvider {
                     }
                 };
 
-                let mut config = self.config.write().await;
+                let mut config = self.config.lock().await;
                 if let Some(intune_device_id) = intune_device_id {
                     config.set(&self.domain, "intune_device_id", &intune_device_id);
                 }
@@ -4869,11 +4870,11 @@ impl HimmelblauProvider {
         machine_key: &tpm::structures::StorageKey,
     ) -> Result<(LoadableMsDeviceEnrolmentKey, String), IdpError> {
         // Enrolling the device in Intune
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         if config.get_apply_policy() {
             let graph_token = match self
                 .client
-                .read()
+                .lock()
                 .await
                 .acquire_token_by_refresh_token(
                     &token.refresh_token,
@@ -4921,7 +4922,7 @@ impl HimmelblauProvider {
                 })?;
             match self
                 .client
-                .read()
+                .lock()
                 .await
                 .acquire_token_by_refresh_token(
                     &token.refresh_token,
@@ -4992,7 +4993,7 @@ impl HimmelblauProvider {
         }
         /* If we have access to tpm keys, and the domain device_id is
          * configured, we'll assume we are domain joined. */
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         if config.get(&self.domain, "device_id").is_none() {
             return false;
         }
@@ -5015,7 +5016,7 @@ impl HimmelblauProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn is_consumer_tenant(&self) -> bool {
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         let tenant_id = config
             .get(&self.domain, "tenant_id")
             .unwrap_or("".to_string());
@@ -5029,7 +5030,7 @@ impl HimmelblauProvider {
             // Pretend we are always enrolled for MSA accounts
             return true;
         }
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         if config.get(&self.domain, "intune_device_id").is_none() {
             return false;
         }

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -188,8 +188,7 @@ impl HimmelblauMultiProvider {
         };
 
         let providers = HashMap::new();
-        let cfg = config.lock().await;
-        let domains = cfg.get_configured_domains();
+        let domains = config.lock().await.get_configured_domains();
         if domains.is_empty() {
             warn!("No domains configured in himmelblau.conf.");
         }
@@ -199,14 +198,21 @@ impl HimmelblauMultiProvider {
             providers: Arc::new(Mutex::new(providers)),
         };
 
-        if cfg.get_oidc_issuer_url().is_none() {
+        let oidc_issuer_url = config.lock().await.get_oidc_issuer_url();
+        if oidc_issuer_url.is_none() {
             for domain in domains {
                 debug!("Adding provider for domain {}", domain);
-                let authority_host = cfg.get_authority_host(&domain);
-                let tenant_id = cfg.get_tenant_id(&domain);
-                let graph_url = cfg.get_graph_url(&domain);
+                let (authority_host, tenant_id, graph_url, odc_provider) = {
+                    let cfg = config.lock().await;
+                    (
+                        cfg.get_authority_host(&domain),
+                        cfg.get_tenant_id(&domain),
+                        cfg.get_graph_url(&domain),
+                        cfg.get_odc_provider(&domain),
+                    )
+                };
                 let graph = match Graph::new(
-                    &cfg.get_odc_provider(&domain),
+                    &odc_provider,
                     &domain,
                     Some(&authority_host),
                     tenant_id.as_deref(),
@@ -220,7 +226,7 @@ impl HimmelblauMultiProvider {
                         continue;
                     }
                 };
-                let app_id = cfg.get_app_id(&domain);
+                let app_id = config.lock().await.get_app_id(&domain);
                 let app = BrokerClientApplication::new(None, app_id.as_deref(), None, None)
                     .map_err(|e| {
                         error!("Failed initializing provider: {:?}", e);
@@ -320,8 +326,8 @@ macro_rules! find_provider {
 
 macro_rules! idp_get_domain_for_account {
     ($hmp:ident, $account_id:expr) => {{
-        let cfg = $hmp.config.lock().await;
-        if cfg.get_oidc_issuer_url().is_some() {
+        let oidc_issuer_url = $hmp.config.lock().await.get_oidc_issuer_url();
+        if oidc_issuer_url.is_some() {
             Ok("oidc")
         } else {
             match split_username($account_id) {
@@ -1194,12 +1200,15 @@ impl IdProvider for HimmelblauProvider {
 
         macro_rules! fetch_user_confidential_client {
             ($client_id:expr, $client_credential:expr) => {{
-                let cfg = self.config.lock().await;
-                let authority_host = cfg.get_authority_host(&self.domain);
-                let tenant_id = cfg.get_tenant_id(&self.domain).ok_or_else(|| {
-                    error!("tenant_id not found");
-                    IdpError::BadRequest
-                })?;
+                let (authority_host, tenant_id) = {
+                    let cfg = self.config.lock().await;
+                    let authority_host = cfg.get_authority_host(&self.domain);
+                    let tenant_id = cfg.get_tenant_id(&self.domain).ok_or_else(|| {
+                        error!("tenant_id not found");
+                        IdpError::BadRequest
+                    })?;
+                    (authority_host, tenant_id)
+                };
                 let authority = format!("https://{}/{}", authority_host, tenant_id);
                 let app = ConfidentialClientApplication::new(
                     $client_id,
@@ -1289,12 +1298,12 @@ impl IdProvider for HimmelblauProvider {
                         if auth_init.exists() {
                             // Generate a UserToken, with invalid uuid. We can
                             // only fetch this from an authenticated token.
-                            let config = self.config.lock().await;
+                            let id_attr_map = self.config.lock().await.get_id_attr_map();
                             let (uid, gid) = match idmap_cache.get_user_by_name(&account_id) {
                                 Some(user) => {
                                     (user.uid, user.gid)
                                 },
-                                None => match config.get_id_attr_map() {
+                                None => match id_attr_map {
                                     IdAttr::Uuid => {
                                         // Attempt to map the UPN to an Object Id.
                                         let sidtoname = self.client
@@ -1310,12 +1319,11 @@ impl IdProvider for HimmelblauProvider {
                                                 error!("Failed mapping UPN to Object Id: {:?}", e);
                                                 IdpError::BadRequest
                                             })?;
-                                        let idmap = self.idmap.lock().await;
                                         let sid = AadSid::from_sid_str(&sidtoname.sid).map_err(|e| {
                                             error!("Failed parsing SID: {:?}", e);
                                             IdpError::BadRequest
                                         })?;
-                                        let uid = idmap.object_id_to_unix_id(&self.graph.tenant_id().await.map_err(|e| {
+                                        let uid = self.idmap.lock().await.object_id_to_unix_id(&self.graph.tenant_id().await.map_err(|e| {
                                             error!("Failed fetching tenant id: {:?}", e);
                                             IdpError::BadRequest
                                         })?, &sid).map_err(|e| {
@@ -1325,8 +1333,7 @@ impl IdProvider for HimmelblauProvider {
                                         (uid, uid)
                                     },
                                     IdAttr::Name | IdAttr::Rfc2307 => {
-                                        let idmap = self.idmap.lock().await;
-                                        let gid = idmap.gen_to_unix(&self.graph.tenant_id().await.map_err(|e| {
+                                        let gid = self.idmap.lock().await.gen_to_unix(&self.graph.tenant_id().await.map_err(|e| {
                                             error!("{:?}", e);
                                             IdpError::BadRequest
                                         })?, &account_id).map_err(
@@ -1346,7 +1353,6 @@ impl IdProvider for HimmelblauProvider {
                                 uuid: fake_uuid,
                                 gidnumber: uid,
                             }];
-                            let config = self.config.lock().await;
                             return Ok(UserTokenState::Update(UserToken {
                                 name: account_id.clone(),
                                 spn: account_id.clone(),
@@ -1354,7 +1360,7 @@ impl IdProvider for HimmelblauProvider {
                                 real_gidnumber: Some(gid),
                                 gidnumber: uid,
                                 displayname: "".to_string(),
-                                shell: Some(config.get_shell(Some(&self.domain))),
+                                shell: Some(self.config.lock().await.get_shell(Some(&self.domain))),
                                 groups,
                                 tenant_id: Some(Uuid::parse_str(&self.graph.tenant_id().await.map_err(|e| {
                                         error!("{:?}", e);
@@ -1380,8 +1386,7 @@ impl IdProvider for HimmelblauProvider {
         };
         // If an app_id is defined in the config, the app should have the
         // GroupMember.Read.All API permission.
-        let cfg = self.config.lock().await;
-        let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
+        let (client_id, scopes) = if self.config.lock().await.get_app_id(&self.domain).is_some() {
             (None, vec!["GroupMember.Read.All"])
         } else {
             (
@@ -1923,14 +1928,16 @@ impl IdProvider for HimmelblauProvider {
                     .await
                 {
                     Ok((intune_key, intune_device_id)) => {
-                        let mut config = self.config.lock().await;
-                        config.set(&self.domain, "intune_device_id", &intune_device_id);
-                        if let Err(e) = config.write_server_config() {
-                            error!(?e, "Failed to write Intune join configuration.");
-                            return Ok((
-                                AuthResult::Denied("Failed to save device configuration. Please contact your administrator.".to_string()),
-                                AuthCacheAction::None,
-                            ));
+                        {
+                            let mut config = self.config.lock().await;
+                            config.set(&self.domain, "intune_device_id", &intune_device_id);
+                            if let Err(e) = config.write_server_config() {
+                                error!(?e, "Failed to write Intune join configuration.");
+                                return Ok((
+                                    AuthResult::Denied("Failed to save device configuration. Please contact your administrator.".to_string()),
+                                    AuthCacheAction::None,
+                                ));
+                            }
                         }
                         let intune_tag = self.fetch_intune_key_tag();
                         if let Err(e) = keystore.insert_tagged_hsm_key(&intune_tag, &intune_key) {
@@ -1964,8 +1971,7 @@ impl IdProvider for HimmelblauProvider {
                 }
                 // If an app_id is defined in the config, the app should have the
                 // GroupMember.Read.All API permission.
-                let cfg = self.config.lock().await;
-                let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
+                let (client_id, scopes) = if self.config.lock().await.get_app_id(&self.domain).is_some() {
                     (None, vec!["GroupMember.Read.All"])
                 } else {
                     (
@@ -2385,8 +2391,7 @@ impl IdProvider for HimmelblauProvider {
 
                 // If an app_id is defined in the config, the app should have the
                 // GroupMember.Read.All API permission.
-                let cfg = self.config.lock().await;
-                let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
+                let (client_id, scopes) = if self.config.lock().await.get_app_id(&self.domain).is_some() {
                     (None, vec!["GroupMember.Read.All"])
                 } else {
                     (
@@ -4072,8 +4077,7 @@ impl HimmelblauProvider {
             })?;
 
             // Initialize the idmap range
-            let cfg = self.config.lock().await;
-            let range = cfg.get_idmap_range(&self.domain);
+            let range = self.config.lock().await.get_idmap_range(&self.domain);
             let mut idmap = self.idmap.lock().await;
             idmap
                 .add_gen_domain(&self.domain, &tenant_id, range)
@@ -4081,7 +4085,7 @@ impl HimmelblauProvider {
                     error!("Failed adding the idmap domain: {}", e);
                     IdpError::BadRequest
                 })?;
-            drop(cfg);
+            drop(idmap);
 
             // Set the authority on the app
             let authority_url = format!("https://{}/{}", authority_host, tenant_id);
@@ -4124,12 +4128,11 @@ impl HimmelblauProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn attempt_online(&self, _tpm: &mut tpm::provider::BoxedDynTpm, now: SystemTime) -> bool {
-        let cfg = self.config.lock().await;
         let authority_host = self
             .graph
             .authority_host()
             .await
-            .unwrap_or(cfg.get_authority_host(&self.domain));
+            .unwrap_or(self.config.lock().await.get_authority_host(&self.domain));
         match reqwest::get(format!("https://{}", authority_host)).await {
             Ok(resp) => {
                 if resp.status().is_success() {
@@ -4224,8 +4227,7 @@ impl HimmelblauProvider {
         };
 
         // Try PRT exchange to check sign-in frequency
-        let cfg = self.config.lock().await;
-        let (client_id, scopes) = if cfg.get_app_id(&self.domain).is_some() {
+        let (client_id, scopes) = if self.config.lock().await.get_app_id(&self.domain).is_some() {
             (None, vec!["GroupMember.Read.All"])
         } else {
             (
@@ -4386,7 +4388,6 @@ impl HimmelblauProvider {
                     /* Fixes bug#801: The authenticated user might have a mis-matched
                      * response because the domains are aliases of one another.
                      */
-                    let mut cfg = self.config.lock().await;
                     let (_, domain1) = split_username(account_id).ok_or({
                         error!("Failed splitting account_id username");
                         IdpError::BadRequest
@@ -4395,7 +4396,13 @@ impl HimmelblauProvider {
                         error!("Failed splitting spn username");
                         IdpError::BadRequest
                     })?;
-                    if !cfg.domains_are_aliases(domain1, domain2).await {
+                    if !self
+                        .config
+                        .lock()
+                        .await
+                        .domains_are_aliases(domain1, domain2)
+                        .await
+                    {
                         let msg =
                             format!("Authenticated user {} does not match requested user", uuid);
                         error!(msg);
@@ -4445,7 +4452,6 @@ impl HimmelblauProvider {
         value: TokenOrObj,
         old_token: Option<&UserToken>,
     ) -> Result<UserToken, IdpError> {
-        let config = self.config.lock().await;
         let mut groups: Vec<GroupToken>;
         let posix_attrs: HashMap<String, String>;
         let spn = spn.to_lowercase();
@@ -4493,7 +4499,7 @@ impl HimmelblauProvider {
                         }
                     }
                 };
-                posix_attrs = if config.get_id_attr_map() == IdAttr::Rfc2307 {
+                posix_attrs = if self.config.lock().await.get_id_attr_map() == IdAttr::Rfc2307 {
                     match self
                         .graph
                         .fetch_user_extension_attributes_by_user_id(
@@ -4532,7 +4538,7 @@ impl HimmelblauProvider {
             }
         };
         let valid = true;
-        let user_map = UserMap::new(&config.get_user_map_file());
+        let user_map = UserMap::new(&self.config.lock().await.get_user_map_file());
         let (uidnumber, gidnumber) = match user_map.get_local_from_upn(&spn) {
             Some(user) => {
                 let pwd = unsafe {
@@ -4553,7 +4559,6 @@ impl HimmelblauProvider {
                 (pwd.pw_uid as u32, pwd.pw_gid as u32)
             }
             None => {
-                let idmap = self.idmap.lock().await;
                 let idmap_cache = StaticIdCache::new(ID_MAP_CACHE, false).map_err(|e| {
                     error!("Failed reading from the idmap cache: {:?}", e);
                     IdpError::BadRequest
@@ -4561,8 +4566,12 @@ impl HimmelblauProvider {
                 match idmap_cache.get_user_by_name(&spn) {
                     Some(user) => (user.uid, user.gid),
                     None => {
-                        let uidnumber = match config.get_id_attr_map() {
-                            IdAttr::Uuid => idmap
+                        let id_attr_map = self.config.lock().await.get_id_attr_map();
+                        let uidnumber = match id_attr_map {
+                            IdAttr::Uuid => self
+                                .idmap
+                                .lock()
+                                .await
                                 .object_id_to_unix_id(
                                     &self.graph.tenant_id().await.map_err(|e| {
                                         error!("{:?}", e);
@@ -4577,7 +4586,10 @@ impl HimmelblauProvider {
                                     error!("{:?}", e);
                                     IdpError::BadRequest
                                 })?,
-                            IdAttr::Name => idmap
+                            IdAttr::Name => self
+                                .idmap
+                                .lock()
+                                .await
                                 .gen_to_unix(
                                     &self.graph.tenant_id().await.map_err(|e| {
                                         error!("{:?}", e);
@@ -4645,7 +4657,7 @@ impl HimmelblauProvider {
 
         let shell = match posix_attrs.get("loginShell") {
             Some(login_shell) => login_shell.clone(),
-            None => config.get_shell(Some(&self.domain)),
+            None => self.config.lock().await.get_shell(Some(&self.domain)),
         };
 
         if posix_attrs.contains_key("unixHomeDirectory") {
@@ -4684,7 +4696,6 @@ impl HimmelblauProvider {
         &self,
         value: DirectoryObject,
     ) -> Result<GroupToken> {
-        let config = self.config.lock().await;
         let name = match value.display_name {
             Some(name) => name,
             None => value.id.clone(),
@@ -4700,14 +4711,18 @@ impl HimmelblauProvider {
         }
         let id =
             Uuid::parse_str(&value.id).map_err(|e| anyhow!("Failed parsing user uuid: {}", e))?;
-        let idmap = self.idmap.lock().await;
         let idmap_cache_entry = StaticIdCache::new(ID_MAP_CACHE, false)
             .ok()
             .and_then(|idmap_cache| idmap_cache.get_group_by_name(&id.to_string()));
+        let id_attr_map = self.config.lock().await.get_id_attr_map();
+        let rfc2307_group_fallback_map = self.config.lock().await.get_rfc2307_group_fallback_map();
         let gidnumber = match idmap_cache_entry {
             Some(group) => group.gid,
-            None => match config.get_id_attr_map() {
-                IdAttr::Uuid => idmap
+            None => match id_attr_map {
+                IdAttr::Uuid => self
+                    .idmap
+                    .lock()
+                    .await
                     .object_id_to_unix_id(
                         &self
                             .graph
@@ -4718,7 +4733,10 @@ impl HimmelblauProvider {
                             .map_err(|e| anyhow!("Failed parsing object id: {:?}", e))?,
                     )
                     .map_err(|e| anyhow!("Failed fetching gid for {}: {:?}", id, e))?,
-                IdAttr::Name => idmap
+                IdAttr::Name => self
+                    .idmap
+                    .lock()
+                    .await
                     .gen_to_unix(
                         &self
                             .graph
@@ -4736,8 +4754,11 @@ impl HimmelblauProvider {
                             e
                         )
                     })?,
-                    None => match config.get_rfc2307_group_fallback_map() {
-                        Some(IdAttr::Uuid) => idmap
+                    None => match rfc2307_group_fallback_map {
+                        Some(IdAttr::Uuid) => self
+                            .idmap
+                            .lock()
+                            .await
                             .object_id_to_unix_id(
                                 &self
                                     .graph
@@ -4748,7 +4769,10 @@ impl HimmelblauProvider {
                                     .map_err(|e| anyhow!("Failed parsing object id: {:?}", e))?,
                             )
                             .map_err(|e| anyhow!("Failed fetching gid for {}: {:?}", id, e))?,
-                        Some(IdAttr::Name) => idmap
+                        Some(IdAttr::Name) => self
+                            .idmap
+                            .lock()
+                            .await
                             .gen_to_unix(
                                 &self
                                     .graph
@@ -4879,8 +4903,8 @@ impl HimmelblauProvider {
         machine_key: &tpm::structures::StorageKey,
     ) -> Result<(LoadableMsDeviceEnrolmentKey, String), IdpError> {
         // Enrolling the device in Intune
-        let config = self.config.lock().await;
-        if config.get_apply_policy() {
+        let apply_policy = self.config.lock().await.get_apply_policy();
+        if apply_policy {
             let graph_token = match self
                 .client
                 .lock()
@@ -4957,10 +4981,15 @@ impl HimmelblauProvider {
                         })?;
                     let device_id = match device_id {
                         Some(v) => v.to_string(),
-                        None => config.get(&self.domain, "device_id").ok_or({
-                            error!("Device ID missing for Intune device enrollment.");
-                            IdpError::BadRequest
-                        })?,
+                        None => self
+                            .config
+                            .lock()
+                            .await
+                            .get(&self.domain, "device_id")
+                            .ok_or({
+                                error!("Device ID missing for Intune device enrollment.");
+                                IdpError::BadRequest
+                            })?,
                     };
                     let attrs = attrs.cloned().unwrap_or(
                         EnrollAttrs::new(self.domain.clone(), None, None, None, None).map_err(
@@ -5002,8 +5031,13 @@ impl HimmelblauProvider {
         }
         /* If we have access to tpm keys, and the domain device_id is
          * configured, we'll assume we are domain joined. */
-        let config = self.config.lock().await;
-        if config.get(&self.domain, "device_id").is_none() {
+        if self
+            .config
+            .lock()
+            .await
+            .get(&self.domain, "device_id")
+            .is_none()
+        {
             return false;
         }
         let transport_key = match self.fetch_loadable_transport_key_from_keystore(keystore) {
@@ -5025,8 +5059,10 @@ impl HimmelblauProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn is_consumer_tenant(&self) -> bool {
-        let config = self.config.lock().await;
-        let tenant_id = config
+        let tenant_id = self
+            .config
+            .lock()
+            .await
             .get(&self.domain, "tenant_id")
             .unwrap_or("".to_string());
         tenant_id == "9188040d-6c67-4c5b-b112-36a304b66dad"
@@ -5039,8 +5075,13 @@ impl HimmelblauProvider {
             // Pretend we are always enrolled for MSA accounts
             return true;
         }
-        let config = self.config.lock().await;
-        if config.get(&self.domain, "intune_device_id").is_none() {
+        if self
+            .config
+            .lock()
+            .await
+            .get(&self.domain, "intune_device_id")
+            .is_none()
+        {
             return false;
         }
         let intune_tag = self.fetch_intune_key_tag();

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -72,12 +72,11 @@ use reqwest;
 use reqwest::Url;
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 use std::time::SystemTime;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, OnceCell};
 use totp_rs::{Algorithm, Secret, TOTP};
 use uuid::Uuid;
 use zeroize::Zeroizing;
@@ -816,7 +815,7 @@ pub struct HimmelblauProvider {
     graph: Graph,
     refresh_cache: RefreshCache,
     idmap: Arc<Mutex<Idmap>>,
-    init: AtomicBool,
+    init: OnceCell<()>,
     bad_pin_counter: BadPinCounter,
 }
 
@@ -836,7 +835,7 @@ impl HimmelblauProvider {
             graph,
             refresh_cache: RefreshCache::new(),
             idmap: idmap.clone(),
-            init: AtomicBool::new(false),
+            init: OnceCell::new(),
             bad_pin_counter: BadPinCounter::new(),
         })
     }
@@ -4057,72 +4056,72 @@ impl HimmelblauProvider {
         // possible. This permits the daemon to start, without requiring we be
         // connected to the internet. This way we can send messages to the user
         // via PAM indicating that the network is down.
-        let init = self.init.load(Ordering::Acquire);
-        if !init {
-            // Send the federation provider request, if necessary. If these were
-            // cached previously, then a network connection is not necessary at
-            // this moment. If they were not cached, and supplied to the graph
-            // object, then we require a network connection now.
-            let tenant_id = self.graph.tenant_id().await.map_err(|e| {
-                error!("Failed discovering the tenant_id: {}", e);
-                IdpError::BadRequest
-            })?;
-            let authority_host = self.graph.authority_host().await.map_err(|e| {
-                error!("Failed discovering the authority_host: {}", e);
-                IdpError::BadRequest
-            })?;
-            let graph_url = self.graph.graph_url().await.map_err(|e| {
-                error!("Failed discovering the graph_url: {}", e);
-                IdpError::BadRequest
-            })?;
-
-            // Initialize the idmap range
-            let range = self.config.lock().await.get_idmap_range(&self.domain);
-            let mut idmap = self.idmap.lock().await;
-            idmap
-                .add_gen_domain(&self.domain, &tenant_id, range)
-                .map_err(|e| {
-                    error!("Failed adding the idmap domain: {}", e);
+        self.init
+            .get_or_try_init(|| async {
+                // Send the federation provider request, if necessary. If these were
+                // cached previously, then a network connection is not necessary at
+                // this moment. If they were not cached, and supplied to the graph
+                // object, then we require a network connection now.
+                let tenant_id = self.graph.tenant_id().await.map_err(|e| {
+                    error!("Failed discovering the tenant_id: {}", e);
                     IdpError::BadRequest
                 })?;
-            drop(idmap);
-
-            // Set the authority on the app
-            let authority_url = format!("https://{}/{}", authority_host, tenant_id);
-            // A client write lock is required here.
-            self.client
-                .lock()
-                .await
-                .set_authority(&authority_url)
-                .map_err(|e| {
-                    error!("Failed setting the authority_url: {}", e);
+                let authority_host = self.graph.authority_host().await.map_err(|e| {
+                    error!("Failed discovering the authority_host: {}", e);
+                    IdpError::BadRequest
+                })?;
+                let graph_url = self.graph.graph_url().await.map_err(|e| {
+                    error!("Failed discovering the graph_url: {}", e);
                     IdpError::BadRequest
                 })?;
 
-            // Mark the provider as initialized
-            self.init.store(true, Ordering::Release);
+                // Initialize the idmap range
+                let range = self.config.lock().await.get_idmap_range(&self.domain);
+                let mut idmap = self.idmap.lock().await;
+                idmap
+                    .add_gen_domain(&self.domain, &tenant_id, range)
+                    .map_err(|e| {
+                        error!("Failed adding the idmap domain: {}", e);
+                        IdpError::BadRequest
+                    })?;
+                drop(idmap);
 
-            // Cache the federation provider responses
-            let mut cfg = self.config.lock().await;
-            cfg.set(&self.domain, "tenant_id", &tenant_id);
-            debug!(
-                "Setting domain {} config tenant_id to {}",
-                self.domain, tenant_id
-            );
-            cfg.set(&self.domain, "authority_host", &authority_host);
-            debug!(
-                "Setting domain {} config authority_host to {}",
-                self.domain, authority_host
-            );
-            cfg.set(&self.domain, "graph_url", &graph_url);
-            debug!(
-                "Setting domain {} config graph_url to {}",
-                self.domain, graph_url
-            );
-            if let Err(e) = cfg.write_server_config() {
-                error!("Failed to write federation provider configuration: {:?}", e);
-            }
-        }
+                // Set the authority on the app
+                let authority_url = format!("https://{}/{}", authority_host, tenant_id);
+                // A client write lock is required here.
+                self.client
+                    .lock()
+                    .await
+                    .set_authority(&authority_url)
+                    .map_err(|e| {
+                        error!("Failed setting the authority_url: {}", e);
+                        IdpError::BadRequest
+                    })?;
+
+                // Cache the federation provider responses
+                let mut cfg = self.config.lock().await;
+                cfg.set(&self.domain, "tenant_id", &tenant_id);
+                debug!(
+                    "Setting domain {} config tenant_id to {}",
+                    self.domain, tenant_id
+                );
+                cfg.set(&self.domain, "authority_host", &authority_host);
+                debug!(
+                    "Setting domain {} config authority_host to {}",
+                    self.domain, authority_host
+                );
+                cfg.set(&self.domain, "graph_url", &graph_url);
+                debug!(
+                    "Setting domain {} config graph_url to {}",
+                    self.domain, graph_url
+                );
+                if let Err(e) = cfg.write_server_config() {
+                    error!("Failed to write federation provider configuration: {:?}", e);
+                }
+
+                Ok(())
+            })
+            .await?;
         Ok(())
     }
 

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -700,8 +700,8 @@ impl OidcApplication {
     async fn user_token_from_oidc(
         &self,
         token: &openidconnect::core::CoreTokenResponse,
-        config: &HimmelblauConfig,
-        idmap: &Idmap,
+        shell: String,
+        idmap: &Mutex<Idmap>,
         tenant_id: &Uuid,
     ) -> Result<UserToken, IdpError> {
         let access_token = token.access_token();
@@ -744,6 +744,7 @@ impl OidcApplication {
         let (uid, gid) = match idmap_cache.get_user_by_name(&account_id) {
             Some(user) => (user.uid, user.gid),
             None => {
+                let idmap = idmap.lock().await;
                 let gid = idmap
                     .gen_to_unix(&tenant_id.to_string(), &account_id)
                     .map_err(|e| {
@@ -769,7 +770,7 @@ impl OidcApplication {
             real_gidnumber: Some(uid),
             gidnumber: gid,
             displayname,
-            shell: Some(config.get_shell(None)),
+            shell: Some(shell),
             groups: vec![GroupToken {
                 name: account_id.to_string(),
                 spn: account_id.to_string(),
@@ -912,10 +913,9 @@ impl OidcProvider {
         // via PAM indicating that the network is down.
         let init = self.client.client.lock().await.is_some();
         if !init {
-            let cfg = self.config.lock().await;
-
             // Initialize the idmap range
             let tenant_id = self.tenant_id().await?.to_string();
+            let cfg = self.config.lock().await;
             let range = cfg.get_idmap_range(&self.domain);
             let mut idmap = self.idmap.lock().await;
             idmap
@@ -938,13 +938,15 @@ impl OidcProvider {
         account_id: &str,
         token: &OidcTokenResponse,
     ) -> Result<AuthResult, IdpError> {
+        let tenant_id = self.tenant_id().await?;
+        let shell = self.config.lock().await.get_shell(None);
         let token2 = self
             .client
             .user_token_from_oidc(
                 token,
-                &*self.config.lock().await,
-                &*self.idmap.lock().await,
-                &self.tenant_id().await?,
+                shell,
+                self.idmap.as_ref(),
+                &tenant_id,
             )
             .await?;
         if account_id.to_string().to_lowercase() != token2.name.to_string().to_lowercase() {
@@ -1360,11 +1362,13 @@ impl IdProvider for OidcProvider {
                         ));
                     }
                 };
+                let tenant_id = self.tenant_id().await?;
+                let shell = self.config.lock().await.get_shell(None);
                 let token2 = self.client.user_token_from_oidc(
                     &token,
-                    &*self.config.lock().await,
-                    &*self.idmap.lock().await,
-                    &self.tenant_id().await?,
+                    shell,
+                    self.idmap.as_ref(),
+                    &tenant_id,
                 ).await?;
                 tpm.seal_data(&win_hello_storage_key, refresh_token_zeroizing)
                     .map_err(|e| {

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -68,7 +68,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex};
 use totp_rs::{Algorithm, Secret, TOTP};
 use uuid::Uuid;
 use zeroize::Zeroizing;
@@ -312,14 +312,14 @@ struct OidcDelayedInit {
 }
 
 pub struct OidcApplication {
-    client: RwLock<Option<OidcDelayedInit>>,
+    client: Mutex<Option<OidcDelayedInit>>,
 }
 
 impl OidcApplication {
     #[instrument(level = "debug", skip_all)]
     pub fn new() -> Self {
         Self {
-            client: RwLock::new(None),
+            client: Mutex::new(None),
         }
     }
 
@@ -332,7 +332,7 @@ impl OidcApplication {
 
     #[instrument(level = "debug", skip_all)]
     async fn delayed_init(&self, config: &HimmelblauConfig, domain: &str) -> Result<(), IdpError> {
-        let init = self.client.read().await.is_some();
+        let init = self.client.lock().await.is_some();
         if !init {
             let client_id = ClientId::new(config.get_app_id(domain).ok_or_else(|| {
                 error!(
@@ -388,7 +388,7 @@ impl OidcApplication {
                 .set_auth_type(AuthType::RequestBody);
 
             // Store provider initialization
-            self.client.write().await.replace(OidcDelayedInit {
+            self.client.lock().await.replace(OidcDelayedInit {
                 client,
                 http_client,
                 authorization_endpoint,
@@ -396,11 +396,6 @@ impl OidcApplication {
             });
         }
         Ok(())
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    async fn read(&self) -> tokio::sync::RwLockReadGuard<'_, Option<OidcDelayedInit>> {
-        self.client.read().await
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -413,7 +408,7 @@ impl OidcApplication {
             Scope::new("email".to_string()),
             Scope::new("offline_access".to_string()),
         ];
-        if let Some(delayed_init) = &*self.client.read().await {
+        if let Some(delayed_init) = &*self.client.lock().await {
             let details = delayed_init
                 .client
                 .exchange_device_code()
@@ -444,7 +439,7 @@ impl OidcApplication {
         &self,
         flow: &DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>,
     ) -> Result<OidcTokenResponse, MsalError> {
-        if let Some(delayed_init) = &*self.client.read().await {
+        if let Some(delayed_init) = &*self.client.lock().await {
             // Try to get the token endpoint URL from the oauth2 Client
             let token_url = delayed_init
                 .client
@@ -574,7 +569,7 @@ impl OidcApplication {
         refresh_token: &str,
         scopes: Vec<&str>,
     ) -> Result<OidcTokenResponse, MsalError> {
-        if let Some(delayed_init) = &*self.client.read().await {
+        if let Some(delayed_init) = &*self.client.lock().await {
             // Token endpoint
             let token_url = delayed_init
                 .client
@@ -710,7 +705,7 @@ impl OidcApplication {
         tenant_id: &Uuid,
     ) -> Result<UserToken, IdpError> {
         let access_token = token.access_token();
-        let userinfo: CoreUserInfoClaims = if let Some(delayed_init) = &*self.client.read().await {
+        let userinfo: CoreUserInfoClaims = if let Some(delayed_init) = &*self.client.lock().await {
             delayed_init
                 .client
                 .user_info(access_token.clone(), None)
@@ -794,8 +789,8 @@ impl Default for OidcApplication {
 }
 
 pub struct OidcProvider {
-    config: Arc<RwLock<HimmelblauConfig>>,
-    idmap: Arc<RwLock<Idmap>>,
+    config: Arc<Mutex<HimmelblauConfig>>,
+    idmap: Arc<Mutex<Idmap>>,
     state: Mutex<CacheState>,
     client: OidcApplication,
     refresh_cache: RefreshCache,
@@ -806,9 +801,9 @@ pub struct OidcProvider {
 impl OidcProvider {
     #[instrument(level = "debug", skip_all)]
     pub fn new(
-        cfg: &Arc<RwLock<HimmelblauConfig>>,
+        cfg: &Arc<Mutex<HimmelblauConfig>>,
         domain: &str,
-        idmap: &Arc<RwLock<Idmap>>,
+        idmap: &Arc<Mutex<Idmap>>,
     ) -> Result<Self, IdpError> {
         Ok(Self {
             config: cfg.clone(),
@@ -823,7 +818,7 @@ impl OidcProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn tenant_id(&self) -> Result<Uuid, IdpError> {
-        let config = self.config.read().await;
+        let config = self.config.lock().await;
         let issuer = config.get_oidc_issuer_url().ok_or_else(|| {
             error!("Missing OIDC issuer URL in config");
             IdpError::BadRequest
@@ -842,7 +837,7 @@ impl OidcProvider {
             return false;
         }
         let (authorization_endpoint, openid_configuration_url) =
-            match self.client.read().await.as_ref() {
+            match self.client.client.lock().await.as_ref() {
                 Some(init) => (
                     init.authorization_endpoint.clone(),
                     init.openid_configuration_url.clone(),
@@ -915,14 +910,14 @@ impl OidcProvider {
         // possible. This permits the daemon to start, without requiring we be
         // connected to the internet. This way we can send messages to the user
         // via PAM indicating that the network is down.
-        let init = self.client.read().await.is_some();
+        let init = self.client.client.lock().await.is_some();
         if !init {
-            let cfg = self.config.read().await;
+            let cfg = self.config.lock().await;
 
             // Initialize the idmap range
             let tenant_id = self.tenant_id().await?.to_string();
             let range = cfg.get_idmap_range(&self.domain);
-            let mut idmap = self.idmap.write().await;
+            let mut idmap = self.idmap.lock().await;
             idmap
                 .add_gen_domain(&self.domain, &tenant_id, range)
                 .map_err(|e| {
@@ -947,8 +942,8 @@ impl OidcProvider {
             .client
             .user_token_from_oidc(
                 token,
-                &*self.config.read().await,
-                &*self.idmap.read().await,
+                &*self.config.lock().await,
+                &*self.idmap.lock().await,
                 &self.tenant_id().await?,
             )
             .await?;
@@ -1034,7 +1029,7 @@ impl IdProvider for OidcProvider {
         let (uid, gid) = match idmap_cache.get_user_by_name(account_id) {
             Some(user) => (user.uid, user.gid),
             None => {
-                let idmap = self.idmap.read().await;
+                let idmap = self.idmap.lock().await;
                 let gid = idmap
                     .gen_to_unix(&tenant_id.to_string(), account_id)
                     .map_err(|e| {
@@ -1052,7 +1047,7 @@ impl IdProvider for OidcProvider {
             real_gidnumber: Some(uid),
             gidnumber: gid,
             displayname,
-            shell: Some(self.config.read().await.get_shell(None)),
+            shell: Some(self.config.lock().await.get_shell(None)),
             groups: vec![GroupToken {
                 name: account_id.to_string(),
                 spn: account_id.to_string(),
@@ -1097,7 +1092,7 @@ impl IdProvider for OidcProvider {
         };
         let remote_services = self
             .config
-            .read()
+            .lock()
             .await
             .get_password_only_remote_services_deny_list();
         // Check if this is a remote service:
@@ -1108,10 +1103,10 @@ impl IdProvider for OidcProvider {
                 .iter()
                 .any(|s| !s.is_empty() && service.contains(s));
         let hello_totp_enabled = check_hello_totp_enabled!(self);
-        let allow_remote_hello = self.config.read().await.get_allow_remote_hello();
+        let allow_remote_hello = self.config.lock().await.get_allow_remote_hello();
         // Skip Hello authentication if it is disabled by config
-        let hello_enabled = self.config.read().await.get_enable_hello();
-        let hello_pin_retry_count = self.config.read().await.get_hello_pin_retry_count();
+        let hello_enabled = self.config.lock().await.get_enable_hello();
+        let hello_pin_retry_count = self.config.lock().await.get_hello_pin_retry_count();
         if hello_key.is_none()
             || !hello_enabled
             || (is_remote_service && !hello_totp_enabled && !allow_remote_hello)
@@ -1367,8 +1362,8 @@ impl IdProvider for OidcProvider {
                 };
                 let token2 = self.client.user_token_from_oidc(
                     &token,
-                    &*self.config.read().await,
-                    &*self.idmap.read().await,
+                    &*self.config.lock().await,
+                    &*self.idmap.lock().await,
                     &self.tenant_id().await?,
                 ).await?;
                 tpm.seal_data(&win_hello_storage_key, refresh_token_zeroizing)
@@ -1517,7 +1512,7 @@ impl IdProvider for OidcProvider {
                     Ok(token) => match self.token_validate(account_id, &token).await {
                         Ok(AuthResult::Success { token: token2 }) => {
                             // Skip Hello enrollment if it is disabled by config
-                            let hello_enabled = self.config.read().await.get_enable_hello();
+                            let hello_enabled = self.config.lock().await.get_enable_hello();
                             if !hello_enabled || no_hello_pin {
                                 info!("Skipping Hello enrollment because it is disabled");
                                 return Ok((

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -326,33 +326,39 @@ impl OidcApplication {
     #[instrument(level = "debug", skip_all)]
     pub async fn with_init(config: &HimmelblauConfig, domain: &str) -> Result<Self, IdpError> {
         let app = Self::new();
-        app.delayed_init(config, domain).await?;
+        app.delayed_init(&Mutex::new(config.clone()), domain).await?;
         Ok(app)
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn delayed_init(&self, config: &HimmelblauConfig, domain: &str) -> Result<(), IdpError> {
+    async fn delayed_init(&self, config: &Mutex<HimmelblauConfig>, domain: &str) -> Result<(), IdpError> {
         let init = self.client.lock().await.is_some();
         if !init {
-            let client_id = ClientId::new(config.get_app_id(domain).ok_or_else(|| {
-                error!(
-                    "Missing OIDC client ID in config: `[global] app_id` required for OIDC auth"
-                );
-                IdpError::BadRequest
-            })?);
+            let client_id = {
+                let config = config.lock().await;
+                ClientId::new(config.get_app_id(domain).ok_or_else(|| {
+                    error!(
+                        "Missing OIDC client ID in config: `[global] app_id` required for OIDC auth"
+                    );
+                    IdpError::BadRequest
+                })?)
+            };
 
-            let issuer_url = IssuerUrl::new(config.get_oidc_issuer_url().ok_or_else(|| {
-                error!("Missing OIDC issuer URL in config");
-                IdpError::BadRequest
-            })?)
-            .map_err(|e| {
-                error!(
-                    ?e,
-                    "Invalid OIDC issuer URL: {:?}",
-                    config.get_oidc_issuer_url()
-                );
-                IdpError::BadRequest
-            })?;
+            let issuer_url = {
+                let config = config.lock().await;
+                IssuerUrl::new(config.get_oidc_issuer_url().ok_or_else(|| {
+                    error!("Missing OIDC issuer URL in config");
+                    IdpError::BadRequest
+                })?)
+                .map_err(|e| {
+                    error!(
+                        ?e,
+                        "Invalid OIDC issuer URL: {:?}",
+                        config.get_oidc_issuer_url()
+                    );
+                    IdpError::BadRequest
+                })?
+            };
 
             let http_client = reqwest::ClientBuilder::new()
                 .redirect(reqwest::redirect::Policy::none())
@@ -819,11 +825,15 @@ impl OidcProvider {
 
     #[instrument(level = "debug", skip_all)]
     async fn tenant_id(&self) -> Result<Uuid, IdpError> {
-        let config = self.config.lock().await;
-        let issuer = config.get_oidc_issuer_url().ok_or_else(|| {
-            error!("Missing OIDC issuer URL in config");
-            IdpError::BadRequest
-        })?;
+        let issuer = self
+            .config
+            .lock()
+            .await
+            .get_oidc_issuer_url()
+            .ok_or_else(|| {
+                error!("Missing OIDC issuer URL in config");
+                IdpError::BadRequest
+            })?;
         Ok(Uuid::new_v5(&HIMMELBLAU_OIDC_NAMESPACE, issuer.as_bytes()))
     }
 
@@ -915,8 +925,7 @@ impl OidcProvider {
         if !init {
             // Initialize the idmap range
             let tenant_id = self.tenant_id().await?.to_string();
-            let cfg = self.config.lock().await;
-            let range = cfg.get_idmap_range(&self.domain);
+            let range = self.config.lock().await.get_idmap_range(&self.domain);
             let mut idmap = self.idmap.lock().await;
             idmap
                 .add_gen_domain(&self.domain, &tenant_id, range)
@@ -924,8 +933,9 @@ impl OidcProvider {
                     error!("Failed adding the idmap domain: {}", e);
                     IdpError::BadRequest
                 })?;
+            drop(idmap);
 
-            self.client.delayed_init(&cfg, &self.domain).await?;
+            self.client.delayed_init(&self.config, &self.domain).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
himmelblaud uses `tokio::main(flavor = "current_thread")` with `tokio::sync::RwLock` on `config`, `client`, `idmap`, `providers`, and `init` in the provider layer. Multiple code paths hold `.read()` guards across `.await` points (HTTP requests to login.microsoftonline.com, odc.officeapps.live.com, etc.), while other paths need `.write()` on the same locks. In the single-threaded runtime this deadlocks permanently:

- Tasks B/C/D hold `config.read()` across HTTP `.await`s
- Task A (e.g. `delayed_init`) needs `config.write()`, which waits for all readers
- Those readers are blocked on `hsm` or `db` locks that Task A holds
- Circular wait, daemon never responds

Using `strace`, the signature is: 2 HTTPS connections succeed (Graph discovery), then the daemon idles in `epoll_wait` forever. The client socket never gets a response.

Similar problems were described in some other issues:

- #882 are somewhat identical symptoms, the reporter confirmed a deadlock via GDB, closed with a workaround that avoided the triggering code path, with the summary being "I suspect there's still a deadlock somewhere."
- #1234 The `get_primary_domain_from_alias()` path calls `request_federation_provider()` (HTTP) while the caller holds `config.write()` via `find_provider!`. Same root cause.
- PR #11 from 2023, "the daemon hangs when trying to create the PublicClientApplication..."

In order to address the underlying issue, I'm replacing `RwLock` with `Mutex` for `config`, `client`, `idmap`, and `providers` in `HimmelblauMultiProvider` / `HimmelblauProvider`, and `init: RwLock<bool>` with `AtomicBool`. `RwLock` allows N concurrent readers, and a single writer must wait for all N to release. `Mutex` allows only one holder at a time, which eliminates the reader-pileup deadlock. Performance impact is negligible since the runtime is single-threaded anyway, there's no real parallelism to lose.

The `init` flag is a simple bool that doesn't need async locking at all, so `AtomicBool` is a good fit.

The broader pattern of holding any lock across HTTP `.await` points is still not ideal, but that's not something you can fix easily with a single PR, so I'm just addressing the deadlock with this one.

Locally, I could reliably reproduce this by running `aad-tool auth-test --name user` (with user mapping) against a freshly started `himmelblaud` where `tenant_id` / `authority_host` are not yet cached. The `delayed_init()` path makes Graph discovery HTTP calls and deadlocks at `client.write()`.

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [ ] I manually tested this change on a test VM and confirmed it works as intended.
- [ ] I listed exactly what testing I performed (commands/steps and observed results).
- [ ] I listed which distro(s) and version(s) I tested on.
- [ ] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->