### PR TITLE
Add Ubuntu 26.04 target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	      22.04*) TARGET="ubuntu22.04" ;; \
 	      24.04*) TARGET="ubuntu24.04" ;; \
 	      25.10*) TARGET="ubuntu25.10" ;; \
+	      26.04*) TARGET="ubuntu26.04" ;; \
 	    esac ;; \
 	  linuxmint) \
 	    case "$$VER" in \
@@ -116,7 +117,7 @@ nix: .packaging ## Build Nix packages into ./packaging/
 		$(NIX) --extra-experimental-features 'nix-command flakes' build ".#$$v" --out-link ./packaging/nix-$$v-result; \
 	done
 
-DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 debian12 debian13
+DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 ubuntu26.04 debian12 debian13
 RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora42 fedora43 amzn2023
 SLE_TARGETS := sle15sp6 sle15sp7 sle16
 GENTOO_TARGETS := gentoo

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -213,6 +213,11 @@ DISTS = {
         "image": "ubuntu:25.10",
         "tpm": True,
     },
+    "ubuntu26.04": {
+        "family": "deb",
+        "image": "ubuntu:26.04",
+        "tpm": True,
+    },
     "test": {
         "family": "deb",
         "image": "ubuntu:24.04",

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -540,10 +540,11 @@ UBUNTU_CODENAMES = {
     "ubuntu:22.04": "jammy",
     "ubuntu:24.04": "noble",
     "ubuntu:25.10": "plucky",
+    "ubuntu:26.04": "resolute",
 }
 
 # Ubuntu 24.04+ uses DEB822 format (.sources files)
-UBUNTU_DEB822_VERSIONS = {"ubuntu:24.04", "ubuntu:25.10"}
+UBUNTU_DEB822_VERSIONS = {"ubuntu:24.04", "ubuntu:25.10", "ubuntu:26.04"}
 
 
 def build_multiarch_sources(dist_cfg):


### PR DESCRIPTION
prep for the soon to be released 26.04 , basically i just added the target, tried build main - was successful

additionally i built tag 3.1.1 for ubuntu 26.04 and tested himmelblau in a vm which was installed by using https://cdimage.ubuntu.com/daily-live/current/resolute-desktop-amd64.iso => everything worx

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->