### PR TITLE
deb/rpm: downgrade nss-himmelblau from recommends to suggests

### DIFF
--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -59,7 +59,8 @@ libkrimes = { workspace = true }
 name = "himmelblau"
 maintainer = "David Mulder <dmulder@suse.com>"
 depends = ["$auto"]
-recommends = ["nss-himmelblau", "pam-himmelblau", "krb5-user", "cron", "tpm2-tools"]
+recommends = ["pam-himmelblau", "krb5-user", "cron", "tpm2-tools"]
+suggests = ["nss-himmelblau"]
 assets = [
   ["../../platform/debian/himmelblau.conf.example", "etc/himmelblau/himmelblau.conf", "644"],
   ["../../src/config/gdm3_service_override.conf", "usr/lib/systemd/system/gdm3.service.d/himmelblau-override.conf", "644"],
@@ -108,7 +109,6 @@ pre_uninstall_script = "scripts/prerm"
 post_uninstall_script = "scripts/postrm"
 
 [package.metadata.generate-rpm.recommends]
-nss-himmelblau = "*"
 pam-himmelblau = "*"
 himmelblau-selinux = "*"
 krb5 = "*"
@@ -126,6 +126,7 @@ authd-msentraid = ""
 
 [package.metadata.generate-rpm.suggests]
 himmelblau-sso = ""
+nss-himmelblau = ""
 
 [package.metadata.generate-rpm.requires]
 man = ""


### PR DESCRIPTION
When a mapped user is used, the himmelblau nss module breaks PAM as it tries to resolve a user that doesn't exist in Entra on every login.

Given it's useful only when the logged in user is the Entra user, downgrade from recommends to suggests so that it is not installed by default, unless specifically selected.

Tested by building and installing deb13 packages

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [x] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->