### PR TITLE
nss/pam: bail out early when SYSTEMD_ACTIVATION_UNIT points to himmelblau and implement initgroups_dyn

### DIFF
--- a/src/common/src/client_sync.rs
+++ b/src/common/src/client_sync.rs
@@ -15,6 +15,28 @@ use std::time::{Duration, SystemTime};
 
 use crate::unix_proto::{ClientRequest, ClientResponse};
 
+/// Check if the current process is being started by systemd as the
+/// himmelblaud daemon or its tasks helper.  During service startup
+/// sd-executor resolves DynamicUser= and SupplementaryGroups= via NSS
+/// and may also call into PAM.  If himmelblau is listed in nsswitch.conf
+/// or the PAM stack, contacting the himmelblaud socket at that point
+/// would deadlock: the socket-activated socket is listening but the
+/// daemon (this very process) hasn't exec'd yet.
+///
+/// Both the NSS and PAM modules should call this before attempting to
+/// connect to the daemon and bail out immediately when it returns true.
+pub fn should_skip_daemon_call() -> bool {
+    use std::sync::OnceLock;
+
+    static SKIP: OnceLock<bool> = OnceLock::new();
+    *SKIP.get_or_init(|| {
+        matches!(
+            std::env::var_os("SYSTEMD_ACTIVATION_UNIT").as_deref(),
+            Some(v) if v == "himmelblaud.service" || v == "himmelblaud-tasks.service"
+        )
+    })
+}
+
 pub struct DaemonClientBlocking {
     stream: UnixStream,
 }

--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -1054,6 +1054,11 @@ where
         self.get_nssgroup(Id::Gid(gid)).await
     }
 
+    pub async fn get_initgroups(&self, account_id: &str) -> Result<Option<Vec<u32>>, ()> {
+        let token = self.get_usertoken(Id::Name(account_id.to_string())).await?;
+        Ok(token.map(|tok| tok.groups.iter().map(|g| g.gidnumber).collect()))
+    }
+
     pub async fn pam_account_allowed(&self, account_id: &str) -> Result<Option<bool>, ()> {
         let token = self.get_usertoken(Id::Name(account_id.to_string())).await?;
 

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -90,6 +90,7 @@ pub enum ClientRequest {
     NssGroups,
     NssGroupByGid(u32),
     NssGroupByName(String),
+    NssInitgroups(String),
     PamAuthenticateInit(String, String, bool, bool),
     PamAuthenticateStep(PamAuthRequest),
     PamAccountAllowed(String),
@@ -112,6 +113,7 @@ impl ClientRequest {
             ClientRequest::NssGroups => "NssGroups".to_string(),
             ClientRequest::NssGroupByGid(id) => format!("NssGroupByGid({})", id),
             ClientRequest::NssGroupByName(id) => format!("NssGroupByName({})", id),
+            ClientRequest::NssInitgroups(id) => format!("NssInitgroups({})", id),
             ClientRequest::PamAuthenticateInit(id, service, no_hello_pin, force_reauth) => {
                 format!(
                     "PamAuthenticateInit({}, {}, no_hello_pin: {}, force_reauth: {})",
@@ -143,6 +145,7 @@ pub enum ClientResponse {
     NssAccount(Option<NssUser>),
     NssGroups(Vec<NssGroup>),
     NssGroup(Option<NssGroup>),
+    NssInitgroups(Option<Vec<u32>>),
 
     PamStatus(Option<bool>),
     PamAuthenticateStepResponse(PamAuthResponse),

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -308,6 +308,18 @@ async fn handle_client(
                         ClientResponse::NssGroup(None)
                     })
             }
+            ClientRequest::NssInitgroups(account_id) => {
+                let account_id = account_id.to_lowercase();
+                trace!("nssinitgroups req");
+                cachelayer
+                    .get_initgroups(account_id.as_str())
+                    .await
+                    .map(ClientResponse::NssInitgroups)
+                    .unwrap_or_else(|_| {
+                        error!("unable to load initgroups.");
+                        ClientResponse::Error
+                    })
+            }
             ClientRequest::PamAuthenticateInit(account_id, service, no_hello_pin, force_reauth) => {
                 let account_id = account_id.to_lowercase();
                 let span = span!(Level::INFO, "pam authenticate init");

--- a/src/nss/src/implementation.rs
+++ b/src/nss/src/implementation.rs
@@ -471,6 +471,148 @@ fn group_from_nssgroup(ng: NssGroup) -> Group {
     }
 }
 
+/// Implement the glibc "initgroups_dyn" NSS interface.
+///
+/// When glibc needs the supplementary groups for a user (e.g. via
+/// initgroups()), it prefers calling _nss_MODULE_initgroups_dyn() if
+/// the module exports it. Otherwise it falls back to enumerating all
+/// groups via getgrent_r(), which can be very slow for Entra ID users
+/// who may belong to hundreds of groups.
+///
+/// This function sends a single targeted "NssInitgroups" request to the
+/// daemon and populates the GID array directly.
+///
+/// # Safety
+///
+/// Called by glibc's NSS machinery. All pointer arguments must be valid
+/// and writable. The "groupsp" array may be realloc'd.
+#[no_mangle]
+pub unsafe extern "C" fn _nss_himmelblau_initgroups_dyn(
+    user: *const libc::c_char,
+    primary_gid: libc::gid_t,
+    start: *mut libc::c_long,
+    size: *mut libc::c_long,
+    groupsp: *mut *mut libc::gid_t,
+    limit: libc::c_long,
+    errnop: *mut libc::c_int,
+) -> libc::c_int {
+    // NSS status codes (from <nss.h>)
+    const NSS_STATUS_SUCCESS: libc::c_int = 1;
+    const NSS_STATUS_NOTFOUND: libc::c_int = 0;
+    const NSS_STATUS_UNAVAIL: libc::c_int = -1;
+    const NSS_STATUS_TRYAGAIN: libc::c_int = -2;
+
+    // Validate all pointer arguments before any dereference.
+    if user.is_null()
+        || start.is_null()
+        || size.is_null()
+        || groupsp.is_null()
+        || errnop.is_null()
+    {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    if should_skip_daemon_call() {
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    let c_user = match std::ffi::CStr::from_ptr(user).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            *errnop = libc::EINVAL;
+            return NSS_STATUS_UNAVAIL;
+        }
+    };
+
+    let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
+        Ok(c) => c,
+        Err(_) => return NSS_STATUS_UNAVAIL,
+    };
+
+    let user_map = UserMap::new(&cfg.get_user_map_file());
+    let account_id = match user_map.get_upn_from_local(c_user) {
+        Some(upn) => upn,
+        None => cfg.map_name_to_upn(c_user),
+    };
+    let req = ClientRequest::NssInitgroups(account_id);
+
+    let mut daemon_client = match DaemonClientBlocking::new(cfg.get_socket_path().as_str()) {
+        Ok(dc) => dc,
+        Err(_) => return NSS_STATUS_UNAVAIL,
+    };
+
+    let gids = match daemon_client.call_and_wait(&req, cfg.get_unix_sock_timeout()) {
+        Ok(ClientResponse::NssInitgroups(Some(g))) => g,
+        // User not found in himmelblau: let glibc try the next
+        // nsswitch source so that local groups are preserved.
+        Ok(ClientResponse::NssInitgroups(None)) => return NSS_STATUS_NOTFOUND,
+        Ok(_) | Err(_) => return NSS_STATUS_UNAVAIL,
+    };
+
+    let mut cur_start = *start;
+    let mut cur_size = *size;
+    let mut groups = *groupsp;
+    if cur_start < 0 || cur_size < 0 || cur_start > cur_size || (cur_size > 0 && groups.is_null())
+    {
+        *errnop = libc::EINVAL;
+        return NSS_STATUS_UNAVAIL;
+    }
+
+    for gid in gids {
+        // Skip primary GID, glibc already includes it
+        if gid == primary_gid {
+            continue;
+        }
+        // Skip duplicates already in the array
+        let already_present = (0..cur_start).any(|i| *groups.offset(i as isize) == gid);
+        if already_present {
+            continue;
+        }
+        // Hard cap reached, stop adding, don't signal an error, like
+        // glibc's add_group() does.
+        if limit > 0 && cur_start >= limit {
+            break;
+        }
+        // Grow the array if needed
+        if cur_start >= cur_size {
+            let new_size = if limit > 0 {
+                std::cmp::min(limit, std::cmp::max(16, cur_size.saturating_mul(2)))
+            } else {
+                std::cmp::max(16, cur_size.saturating_mul(2))
+            };
+            let alloc_bytes = match usize::try_from(new_size)
+                .ok()
+                .and_then(|n| n.checked_mul(std::mem::size_of::<libc::gid_t>()))
+            {
+                Some(b) if b > 0 => b,
+                _ => {
+                    *errnop = libc::ENOMEM;
+                    *start = cur_start;
+                    return NSS_STATUS_TRYAGAIN;
+                }
+            };
+            let new_groups = libc::realloc(
+                groups as *mut libc::c_void,
+                alloc_bytes,
+            ) as *mut libc::gid_t;
+            if new_groups.is_null() {
+                *errnop = libc::ENOMEM;
+                *start = cur_start;
+                return NSS_STATUS_TRYAGAIN;
+            }
+            groups = new_groups;
+            *groupsp = groups;
+            cur_size = new_size;
+            *size = cur_size;
+        }
+        *groups.offset(cur_start as isize) = gid;
+        cur_start += 1;
+    }
+
+    *start = cur_start;
+    NSS_STATUS_SUCCESS
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nss/src/implementation.rs
+++ b/src/nss/src/implementation.rs
@@ -7,7 +7,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use himmelblau_unix_common::client_sync::DaemonClientBlocking;
+use himmelblau_unix_common::client_sync::{should_skip_daemon_call, DaemonClientBlocking};
 use himmelblau_unix_common::config::HimmelblauConfig;
 use himmelblau_unix_common::constants::{DEFAULT_CONFIG_PATH, NSS_CACHE};
 use himmelblau_unix_common::idprovider::interface::Id;
@@ -108,6 +108,9 @@ macro_rules! fetch_all_cached_users {
 
 impl PasswdHooks for HimmelblauPasswd {
     fn get_all_entries() -> Response<Vec<Passwd>> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {
@@ -157,6 +160,9 @@ impl PasswdHooks for HimmelblauPasswd {
     }
 
     fn get_entry_by_uid(uid: libc::uid_t) -> Response<Passwd> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {
@@ -195,6 +201,9 @@ impl PasswdHooks for HimmelblauPasswd {
     }
 
     fn get_entry_by_name(name: String) -> Response<Passwd> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {
@@ -275,6 +284,9 @@ libnss_group_hooks!(himmelblau, HimmelblauGroup);
 
 impl GroupHooks for HimmelblauGroup {
     fn get_all_entries() -> Response<Vec<Group>> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {
@@ -312,6 +324,9 @@ impl GroupHooks for HimmelblauGroup {
     }
 
     fn get_entry_by_gid(gid: libc::gid_t) -> Response<Group> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {
@@ -347,6 +362,9 @@ impl GroupHooks for HimmelblauGroup {
     }
 
     fn get_entry_by_name(name: String) -> Response<Group> {
+        if should_skip_daemon_call() {
+            return Response::Unavail;
+        }
         let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
             Ok(c) => c,
             Err(_) => {

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -62,7 +62,7 @@ use std::ffi::CStr;
 use himmelblau::error::MsalError;
 use himmelblau::{AuthOption, PublicClientApplication};
 use himmelblau_unix_common::auth_handle_mfa_resp;
-use himmelblau_unix_common::client_sync::DaemonClientBlocking;
+use himmelblau_unix_common::client_sync::{should_skip_daemon_call, DaemonClientBlocking};
 use himmelblau_unix_common::config::{split_username, HimmelblauConfig};
 use himmelblau_unix_common::constants::BROKER_APP_ID;
 use himmelblau_unix_common::constants::DEFAULT_CONFIG_PATH;
@@ -235,6 +235,9 @@ impl MessagePrinter for KeyringCaptureMessagePrinter {
 impl PamHooks for PamKanidm {
     #[instrument(skip(pamh, args, _flags))]
     fn acct_mgmt(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,
@@ -309,6 +312,9 @@ impl PamHooks for PamKanidm {
 
     #[instrument(skip(pamh, args, _flags))]
     fn sm_authenticate(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,
@@ -457,6 +463,9 @@ impl PamHooks for PamKanidm {
 
     #[instrument(skip(pamh, args, flags))]
     fn sm_chauthtok(pamh: &PamHandle, args: Vec<&CStr>, flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,
@@ -942,6 +951,9 @@ impl PamHooks for PamKanidm {
 
     #[instrument(skip(_pamh, args, _flags))]
     fn sm_close_session(_pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,
@@ -956,6 +968,9 @@ impl PamHooks for PamKanidm {
 
     #[instrument(skip(pamh, args, _flags))]
     fn sm_open_session(pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,
@@ -1007,6 +1022,9 @@ impl PamHooks for PamKanidm {
 
     #[instrument(skip(_pamh, args, _flags))]
     fn sm_setcred(_pamh: &PamHandle, args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
+        if should_skip_daemon_call() {
+            return PamResultCode::PAM_IGNORE;
+        }
         let opts = match Options::try_from(&args) {
             Ok(o) => o,
             Err(_) => return PamResultCode::PAM_SERVICE_ERR,


### PR DESCRIPTION
systemd's sd-executor resolves DynamicUser= and SupplementaryGroups= in the child
process that will eventually exec a service. If that service is himmelblaud
itself, then glibc may load the NSS module or systemd may call into PAM,
either of which will try to contact himmelblaud, which hasn’t started yet,
resulting in a deadlock.

Check the environment variable at the top of every NSS/PAM hook and return
immediately when it is set and points to one of the himmelblau system
services.

Secondly, when glibc needs supplementary groups for a user (e.g. initgroups()
during GDM session setup), it prefers calling _nss_MODULE_initgroups_dyn
if the module exports it.  Without this function, glibc falls back to
enumerating all groups via getgrent_r() (the NssGroups request), which
for Entra ID users can return hundreds of groups and take many seconds
while the daemon fetches them from the network, forcing the user to
experience long delays at the login screen.

Implement _nss_himmelblau_initgroups_dyn as a raw C FFI export that
sends a single targeted NssInitgroups request to the daemon, receiving
only the GID list for the specific user from the cached UserToken.
This replaces the O(all_groups) enumeration with an O(user_groups)
lookup that returns instantly from cache.

With these changes I am no longer experiencing long lockups with a mapped user and NSS enabled. Tested on Debian 13 with mapped user.

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [x] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->