### PR TITLE
RPM pam-himmelblau, fix authselect and only amend PAM on install

### DIFF
--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -54,11 +54,20 @@ if [ ! -e /lib64/security/pam_himmelblau.so ]; then
     ln -s /usr/lib64/security/pam_himmelblau.so /lib64/security/pam_himmelblau.so
 fi
 
+# Skip PAM configuration on upgrade ($1 >= 2) so admin customizations to
+# /etc/pam.d/*, authselect profiles, or pam-config state aren't reset by
+# a package update. Only the initial install wires PAM up.
+if [ "${1:-1}" -le 1 ]; then
+
 # 1) authselect first (if available)
+authselect_ok=0
 if command -v authselect >/dev/null 2>&1; then
-    feats="$(authselect current 2>/dev/null | awk '"'"'/Enabled features:/{f=1;next} f && /^-/{print $2}'"'"')"
-    authselect select himmelblau $feats --force >/dev/null 2>&1 || :
-    authselect apply-changes >/dev/null 2>&1 || :
+    feats="$(authselect current 2>/dev/null | awk '/Enabled features:/{f=1;next} f && /^-/{print $2}')"
+    if authselect select himmelblau $feats --force >/dev/null 2>&1; then
+        if authselect apply-changes >/dev/null 2>&1; then
+            authselect_ok=1
+        fi
+    fi
 fi
 
 # Helper: validate/fix pam-config account line for pam_himmelblau
@@ -124,16 +133,17 @@ pamconfig_optout_self_managed_common() {
 }
 
 # 3) Final fallback: aad-tool configure-pam --really
-# Only do this if pam-config wasn't used successfully.
-if [ "$pam_config_ok" -ne 1 ]; then
+# Only do this if neither authselect nor pam-config was used successfully.
+if [ "$authselect_ok" -ne 1 ] && [ "$pam_config_ok" -ne 1 ]; then
     if command -v aad-tool >/dev/null 2>&1; then
         # Opt out of pam-config-managed common-*-pc so future pam-config runs
         # don’t overwrite the configuration we’re about to install.
         pamconfig_optout_self_managed_common >/dev/null 2>&1 || :
-
         aad-tool configure-pam --really >/dev/null 2>&1 || :
     fi
 fi
+
+fi  # end upgrade guard
 
 # If GDM is present, ensure keyring consumes the auth token so the keyring unlocks
 # like a normal password login.
@@ -160,7 +170,7 @@ if command -v authselect >/dev/null 2>&1; then
         if   [ -d /usr/share/authselect/default/local   ]; then base=local
         elif [ -d /usr/share/authselect/default/minimal ]; then base=minimal
         else base=sssd; fi
-        feats="$(authselect current 2>/dev/null | awk '"'"'/Enabled features:/{f=1;next} f && /^-/{print $2}'"'"')"
+        feats="$(authselect current 2>/dev/null | awk '/Enabled features:/{f=1;next} f && /^-/{print $2}')"
         authselect select "$base" $feats --force >/dev/null 2>&1 || :
         authselect apply-changes >/dev/null 2>&1 || :
     fi


### PR DESCRIPTION
Fixes #
- awk pattern for getting the authselect features was incorrect, so the select command would error trying to swap it to select himmelblau
- Whether authselect ran or not, the `aad-tool configure-pam` would always run, and make changes to the PAM config, so that now only runs if `authselect` or `pam-config` couldn't be used.
- I also then made it so it only does the PAM configuration on the initial rpm package install, this means when the system administrator makes changes to their PAM config after pam-himmelblau is installed, upgrading the package won't keep reverting them

Changes have been tested on a fresh install of Fedora 43

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [x] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
I don't believe I need to change any documentation here?
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->