### PR TITLE
Add IP version selection via himmelblau.conf

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -339,7 +339,7 @@ rec {
           {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
-            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" ];
+            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" ];
           }
           {
             name = "reqwest";
@@ -6829,7 +6829,7 @@ rec {
           {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
-            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" ];
+            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" ];
           }
           {
             name = "os-release";
@@ -6970,7 +6970,7 @@ rec {
           {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
-            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" ];
+            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" ];
           }
           {
             name = "libkrimes";
@@ -7163,7 +7163,7 @@ rec {
           {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
-            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" ];
+            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" ];
           }
           {
             name = "libkrimes";
@@ -9585,7 +9585,7 @@ rec {
           "redirect_uri" = [ "broker" ];
           "tpm" = [ "broker" "kanidm-hsm-crypto/tpm" ];
         };
-        resolvedDefaultFeatures = [ "broker" "changepassword" "default" "intune_portal_vers_selection" "mfa_method_selection" "on_behalf_of" "optional_mfa" "pop_support" "redirect_uri" "tpm" ];
+        resolvedDefaultFeatures = [ "broker" "changepassword" "default" "intune_portal_vers_selection" "ipvers" "mfa_method_selection" "on_behalf_of" "optional_mfa" "pop_support" "redirect_uri" "tpm" ];
       };
       "libkrimes" = rec {
         crateName = "libkrimes";
@@ -12135,7 +12135,7 @@ rec {
           {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
-            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" ];
+            features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" ];
           }
           {
             name = "tokio";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "^1.0.149"
 tracing-subscriber = "^0.3.23"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.8.18", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support"] }
+libhimmelblau = { version = "0.8.18", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support", "ipvers"] }
 clap = { version = "^4.6", features = ["derive", "env"] }
 clap_complete = "^4.6.0"
 reqwest = { version = "^0.12.24", features = ["json"] }

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -1,4 +1,4 @@
-.TH HIMMELBLAU.CONF "5" "March 2026" "Himmelblau Configuration" "File Formats"
+.TH HIMMELBLAU.CONF "5" "April 2026" "Himmelblau Configuration" "File Formats"
 .SH NAME
 himmelblau.conf \- Configuration file for Himmelblau, enabling Azure Entra ID authentication on Linux.
 
@@ -677,6 +677,17 @@ Default: /var/run/himmelblaud/broker_sock
 Example: broker_socket_path = /tmp/broker.sock
 
 .TP
+.B enable_passwordless
+.RE
+A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
+
+.P
+Default: true
+
+.P
+Example: enable_passwordless = false
+
+.TP
 .B home_prefix
 .RE
 The prefix to use for user home directories.
@@ -724,17 +735,6 @@ Default: spn
 
 .P
 Example: home_alias = SPN
-
-.TP
-.B enable_passwordless
-.RE
-A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
-
-.P
-Default: true
-
-.P
-Example: enable_passwordless = false
 
 .TP
 .B shell
@@ -868,6 +868,27 @@ Default: /etc/himmelblau/user-map
 
 .P
 Example: user_map_file = /path/to/user_map
+
+.TP
+.B ip_version
+.RE
+Controls which IP version family Himmelblau should use for outbound network connections.
+
+Supported values are:
+.RS
+.IP \(bu 2
+ipv4-only \(em use only IPv4 sockets
+.IP \(bu 2
+ipv6-only \(em use only IPv6 sockets
+.IP \(bu 2
+both \(em allow both IPv4 and IPv6 (default)
+.RE
+
+.P
+Default: both
+
+.P
+Example: ip_version = ipv4-only
 
 .SH OFFLINE BREAKGLASS CONFIGURATION
 The

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -549,7 +549,7 @@ in
       type = types.nullOr (types.str);
       default = "/var/run/himmelblaud/socket";
       description = ''
-        The path to the socket file for communication between the pam and nss modules and the Himmelblau daemon.
+        The path to the socket file for communication between the pam and nss modules and the Himmelblau daemon. If this is changed, also add a drop-in to override ListenStream= in the himmelblaud.socket unit to keep the paths in sync.
       '';
       example = "/tmp/himmelblaud.sock";
     };
@@ -558,7 +558,7 @@ in
       type = types.nullOr (types.str);
       default = "/var/run/himmelblaud/task_sock";
       description = ''
-        The path to the socket file for communication with the task daemon.
+        The path to the socket file for communication with the task daemon. If this is changed, also add a drop-in to override ListenStream= in the himmelblaud-tasks.socket unit to keep the paths in sync.
       '';
       example = "/tmp/task.sock";
     };
@@ -567,9 +567,18 @@ in
       type = types.nullOr (types.str);
       default = "/var/run/himmelblaud/broker_sock";
       description = ''
-        The path to the socket file for communication with the broker DBus service.
+        The path to the socket file for communication with the broker DBus service. If this is changed, also add a drop-in to override ListenStream= in the himmelblaud-broker.socket unit to keep the paths in sync.
       '';
       example = "/tmp/broker.sock";
+    };
+
+    enable_passwordless = mkOption {
+      type = types.nullOr (types.bool);
+      default = true;
+      description = ''
+        A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
+      '';
+      example = false;
     };
 
     home_prefix = mkOption {
@@ -609,15 +618,6 @@ in
         - CN
       '';
       example = "SPN";
-    };
-
-    enable_passwordless = mkOption {
-      type = types.nullOr (types.bool);
-      default = true;
-      description = ''
-        A boolean option that controls whether passwordless authentication (Microsoft Authenticator app approval without a password) is offered during Azure Entra ID authentication. When enabled, Himmelblau will include the passwordless option in authentication requests, allowing Entra ID to offer a passwordless flow. When disabled, users will be prompted for a password followed by MFA instead.
-      '';
-      example = false;
     };
 
     shell = mkOption {
@@ -727,6 +727,23 @@ in
         svcuser:service.account@tenant.local
       '';
       example = "/path/to/user_map";
+    };
+
+    ip_version = mkOption {
+      type = types.nullOr (types.enum [ "ipv4-only" "ipv6-only" "both" ]);
+      default = "both";
+      description = ''
+        Controls which IP version family Himmelblau should use for outbound network connections.
+        
+        Supported values are:
+        
+        - ipv4-only -- use only IPv4 sockets
+        
+        - ipv6-only -- use only IPv6 sockets
+        
+        - both -- allow both IPv4 and IPv6 (default)
+      '';
+      example = "ipv4-only";
     };
 
     # [offline_breakglass] section options

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -564,11 +564,13 @@ async fn confidential_client_access_token(
             None => "common".to_string(),
         };
         let authority = format!("https://{}/{}", authority_host, tenant_id);
+        let ip_versions = cfg.get_ip_versions();
 
         let app = match ConfidentialClientApplication::new(
             &cred_client_id,
             Some(&authority),
             client_creds,
+            &ip_versions,
         ) {
             Ok(app) => app,
             Err(e) => {
@@ -734,7 +736,8 @@ async fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             };
 
-            let graph = match Graph::new(DEFAULT_ODC_PROVIDER, &domain, None, None, None).await {
+            let ip_versions = $cfg.get_ip_versions();
+            let graph = match Graph::new(DEFAULT_ODC_PROVIDER, &domain, None, None, None, &ip_versions).await {
                 Ok(graph) => graph,
                 Err(e) => {
                     error!("Failed discovering tenant: {:?}", e);
@@ -819,8 +822,15 @@ async fn main() -> ExitCode {
     }
 
     macro_rules! client {
-        ($authority:expr, $transport_key:expr, $cert_key:expr) => {{
-            match BrokerClientApplication::new(Some(&$authority), None, $transport_key, $cert_key) {
+        ($cfg:expr, $authority:expr, $transport_key:expr, $cert_key:expr) => {{
+            let ip_versions = $cfg.get_ip_versions();
+            match BrokerClientApplication::new(
+                Some(&$authority),
+                None,
+                $transport_key,
+                $cert_key,
+                &ip_versions,
+            ) {
                 Ok(app) => app,
                 Err(e) => {
                     error!("Failed creating app: {:?}", e);
@@ -862,7 +872,15 @@ async fn main() -> ExitCode {
                 if let Some((domain, access_token)) = confidential_client_access_token(
                     $client_id.clone(), $account_id.clone(), None
                 ).await {
-                    if let Ok(graph) = Graph::new(DEFAULT_ODC_PROVIDER, &domain, None, None, None).await {
+                    let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
+                        Ok(c) => c,
+                        Err(_e) => {
+                            error!("Failed to parse {}", DEFAULT_CONFIG_PATH);
+                            return ExitCode::FAILURE;
+                        }
+                    };
+                    let ip_versions = cfg.get_ip_versions();
+                    if let Ok(graph) = Graph::new(DEFAULT_ODC_PROVIDER, &domain, None, None, None, &ip_versions).await {
                         result = Some((graph, access_token));
                     }
                 }
@@ -931,7 +949,12 @@ async fn main() -> ExitCode {
                             let (graph, domain, authority) = init!(cfg, Some(account_id.clone()), None);
                             let (mut tpm, loadable_transport_key, loadable_cert_key, machine_key) =
                                 obtain_host_data!(domain, cfg);
-                            let app = client!(authority, Some(loadable_transport_key), Some(loadable_cert_key));
+                            let app = client!(
+                                cfg,
+                                authority,
+                                Some(loadable_transport_key),
+                                Some(loadable_cert_key)
+                            );
                             let user_token = auth(&app, &account_id).await;
                             if let Some(user_token) = &user_token {
                                 let token = on_behalf_of_token!(

--- a/src/common/docs-xml/himmelblauconf/base/ip_version.xml
+++ b/src/common/docs-xml/himmelblauconf/base/ip_version.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="ip_version"
+           section="global"
+           type="enum"
+           rust_type="IpVersionSelection"
+           documented="true"
+           domain_specific="false"
+           order="51">
+<description>
+Controls which IP version family Himmelblau should use for outbound network connections.
+
+Supported values are:
+.RS
+.IP \(bu 2
+ipv4-only \(em use only IPv4 sockets
+.IP \(bu 2
+ipv6-only \(em use only IPv6 sockets
+.IP \(bu 2
+both \(em allow both IPv4 and IPv6 (default)
+.RE
+</description>
+<default>both</default>
+<default_const>IpVersionSelection::Both</default_const>
+<example>ip_version = ipv4-only</example>
+<enum_values>
+  <value rust="IpVersionSelection::Ipv4Only">ipv4-only</value>
+  <value rust="IpVersionSelection::Ipv6Only">ipv6-only</value>
+  <value rust="IpVersionSelection::Both">both</value>
+</enum_values>
+</parameter>

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -41,6 +41,7 @@ use crate::constants::{
 };
 use crate::mapping::{MappedNameCache, Mode};
 use crate::unix_config::{HomeAttr, HsmType};
+use himmelblau::auth::IpVersion;
 use himmelblau::error::MsalError;
 use idmap::{DEFAULT_IDMAP_RANGE, DEFAULT_SUBID_RANGE};
 use reqwest::Url;
@@ -58,6 +59,13 @@ pub enum IdAttr {
 pub enum JoinType {
     Join,
     Register,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum IpVersionSelection {
+    Both,
+    Ipv4Only,
+    Ipv6Only,
 }
 
 impl From<JoinType> for u32 {
@@ -838,6 +846,16 @@ impl HimmelblauConfig {
 // Generated getter methods from XML parameter definitions.
 include!(concat!(env!("OUT_DIR"), "/config_gen.rs"));
 
+impl HimmelblauConfig {
+    pub fn get_ip_versions(&self) -> Vec<IpVersion> {
+        match self.get_ip_version() {
+            IpVersionSelection::Ipv4Only => vec![IpVersion::V4],
+            IpVersionSelection::Ipv6Only => vec![IpVersion::V6],
+            IpVersionSelection::Both => vec![IpVersion::V4, IpVersion::V6],
+        }
+    }
+}
+
 impl fmt::Debug for HimmelblauConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.config)
@@ -1019,6 +1037,35 @@ mod tests {
         let temp_file = create_temp_config(config_data);
         let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
         assert_eq!(config.get_join_type(), JoinType::Join);
+    }
+
+    #[test]
+    fn test_get_ip_version() {
+        let config_data = r#"
+        [global]
+        ip_version = ipv4-only
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+        assert_eq!(config.get_ip_version(), IpVersionSelection::Ipv4Only);
+        assert_eq!(config.get_ip_versions(), vec![IpVersion::V4]);
+
+        let config_data = r#"
+        [global]
+        ip_version = ipv6-only
+        "#;
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+        assert_eq!(config.get_ip_version(), IpVersionSelection::Ipv6Only);
+        assert_eq!(config.get_ip_versions(), vec![IpVersion::V6]);
+
+        let config_empty = create_empty_config();
+        assert_eq!(config_empty.get_ip_version(), IpVersionSelection::Both);
+        assert_eq!(
+            config_empty.get_ip_versions(),
+            vec![IpVersion::V4, IpVersion::V6]
+        );
     }
 
     #[test]

--- a/src/common/src/idprovider/common.rs
+++ b/src/common/src/idprovider/common.rs
@@ -700,10 +700,13 @@ macro_rules! no_op_prt_token_fetch {
 #[macro_export]
 macro_rules! entra_id_refresh_token_token_fetch {
     ($self:ident, $refresh_token:ident, $scopes:ident) => {{
-        let client = PublicClientApplication::new(BROKER_APP_ID, None).map_err(|e| {
-            error!("Failed to create public client application: {:?}", e);
-            IdpError::BadRequest
-        })?;
+        let ip_versions = $self.config.lock().await.get_ip_versions();
+        let client =
+            PublicClientApplication::new(BROKER_APP_ID, None, &ip_versions)
+                .map_err(|e| {
+                    error!("Failed to create public client application: {:?}", e);
+                    IdpError::BadRequest
+                })?;
         let scopes = if $self.is_consumer_tenant().await {
             // Remove "https://graph.microsoft.com/.default" from the
             // scopes for consumer tenants. This is the default scope

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -201,13 +201,15 @@ impl HimmelblauMultiProvider {
         if oidc_issuer_url.is_none() {
             for domain in domains {
                 debug!("Adding provider for domain {}", domain);
-                let (authority_host, tenant_id, graph_url, odc_provider) = {
+                let (authority_host, tenant_id, graph_url, odc_provider, app_id, ip_versions) = {
                     let cfg = config.lock().await;
                     (
                         cfg.get_authority_host(&domain),
                         cfg.get_tenant_id(&domain),
                         cfg.get_graph_url(&domain),
                         cfg.get_odc_provider(&domain),
+                        cfg.get_app_id(&domain),
+                        cfg.get_ip_versions(),
                     )
                 };
                 let graph = match Graph::new(
@@ -216,6 +218,7 @@ impl HimmelblauMultiProvider {
                     Some(&authority_host),
                     tenant_id.as_deref(),
                     graph_url.as_deref(),
+                    &ip_versions,
                 )
                 .await
                 {
@@ -225,12 +228,17 @@ impl HimmelblauMultiProvider {
                         continue;
                     }
                 };
-                let app_id = config.lock().await.get_app_id(&domain);
-                let app = BrokerClientApplication::new(None, app_id.as_deref(), None, None)
-                    .map_err(|e| {
-                        error!("Failed initializing provider: {:?}", e);
-                        anyhow!("{:?}", e)
-                    })?;
+                let app = BrokerClientApplication::new(
+                    None,
+                    app_id.as_deref(),
+                    None,
+                    None,
+                    &ip_versions,
+                )
+                .map_err(|e| {
+                    error!("Failed initializing provider: {:?}", e);
+                    anyhow!("{:?}", e)
+                })?;
                 let provider = HimmelblauProvider::new(app, &config, &domain, graph, &idmap)
                     .map_err(|e| {
                         error!("Failed to initialize the provider: {:?}", e);
@@ -1202,20 +1210,22 @@ impl IdProvider for HimmelblauProvider {
 
         macro_rules! fetch_user_confidential_client {
             ($client_id:expr, $client_credential:expr) => {{
-                let (authority_host, tenant_id) = {
+                let (authority_host, tenant_id, ip_versions) = {
                     let cfg = self.config.lock().await;
                     let authority_host = cfg.get_authority_host(&self.domain);
                     let tenant_id = cfg.get_tenant_id(&self.domain).ok_or_else(|| {
                         error!("tenant_id not found");
                         IdpError::BadRequest
                     })?;
-                    (authority_host, tenant_id)
+                    let ip_versions = cfg.get_ip_versions();
+                    (authority_host, tenant_id, ip_versions)
                 };
                 let authority = format!("https://{}/{}", authority_host, tenant_id);
                 let app = ConfidentialClientApplication::new(
                     $client_id,
                     Some(&authority),
                     $client_credential,
+                    &ip_versions,
                 )
                 .map_err(|e| {
                     error!(?e, "Failed initializing confidential client");
@@ -1546,10 +1556,13 @@ impl IdProvider for HimmelblauProvider {
                 }
             }
             RefreshCacheEntry::RefreshToken(refresh_token) => {
-                let client = PublicClientApplication::new(BROKER_APP_ID, None).map_err(|e| {
-                    error!("Failed to create public client application: {:?}", e);
-                    IdpError::BadRequest
-                })?;
+                let ip_versions = self.config.lock().await.get_ip_versions();
+                let client =
+                    PublicClientApplication::new(BROKER_APP_ID, None, &ip_versions)
+                        .map_err(|e| {
+                            error!("Failed to create public client application: {:?}", e);
+                            IdpError::BadRequest
+                        })?;
                 let mtoken = client
                     .acquire_token_by_refresh_token(&refresh_token, vec![])
                     .await;
@@ -2823,7 +2836,12 @@ impl IdProvider for HimmelblauProvider {
                             }
                     } else if let Some(RefreshCacheEntry::RefreshToken(refresh_token)) = refresh_cache_entry {
                         // We have a refresh token, exchange that for an access token
-                        let app = match PublicClientApplication::new(BROKER_APP_ID, None) {
+                        let ip_versions = self.config.lock().await.get_ip_versions();
+                        let app = match PublicClientApplication::new(
+                            BROKER_APP_ID,
+                            None,
+                            &ip_versions,
+                        ) {
                             Ok(app) => app,
                             Err(e) => {
                                 error!("Failed to create PublicClientApplication: {:?}", e);
@@ -5000,7 +5018,8 @@ impl HimmelblauProvider {
                     if vers.is_empty() {
                         vers = vec!["1.2511.11".to_string()];
                     }
-                    let intune = IntuneForLinux::new(endpoints, Some(&vers[vers.len() - 1]))
+                    let ip_versions = self.config.lock().await.get_ip_versions();
+                    let intune = IntuneForLinux::new(endpoints, Some(&vers[vers.len() - 1]), &ip_versions)
                         .map_err(|e| {
                             error!(?e, "Intune device enrollment failed.");
                             IdpError::BadRequest

--- a/src/daemon/src/tasks_daemon.rs
+++ b/src/daemon/src/tasks_daemon.rs
@@ -661,12 +661,14 @@ async fn handle_tasks(stream: UnixStream, cfg: &HimmelblauConfig) {
                                 let authority_host = cfg.get_authority_host(domain);
                                 let tenant_id = cfg.get_tenant_id(domain);
                                 let graph_url = cfg.get_graph_url(domain);
+                                let ip_versions = cfg.get_ip_versions();
                                 if let Ok(graph) = Graph::new(
                                     &cfg.get_odc_provider(domain),
                                     domain,
                                     Some(&authority_host),
                                     tenant_id.as_deref(),
                                     graph_url.as_deref(),
+                                    &ip_versions,
                                 )
                                 .await
                                 {

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -636,7 +636,12 @@ impl PamHooks for PamKanidm {
             None => "common".to_string(),
         };
         let authority = format!("https://{}/{}", cfg.get_authority_host(domain), tenant_id);
-        let app = match PublicClientApplication::new(BROKER_APP_ID, Some(&authority)) {
+        let ip_versions = cfg.get_ip_versions();
+        let app = match PublicClientApplication::new(
+            BROKER_APP_ID,
+            Some(&authority),
+            &ip_versions,
+        ) {
             Ok(app) => app,
             Err(e) => {
                 error!(err = ?e, "PublicClientApplication");

--- a/src/policies/src/policies.rs
+++ b/src/policies/src/policies.rs
@@ -50,7 +50,8 @@ pub async fn apply_intune_policy(
         "Applying policies for user and device"
     );
 
-    let graph = Graph::new(&config.get_odc_provider(domain), domain, None, None, None)
+    let ip_versions = config.get_ip_versions();
+    let graph = Graph::new(&config.get_odc_provider(domain), domain, None, None, None, &ip_versions)
         .await
         .map_err(|e| anyhow!(e))?;
 
@@ -69,7 +70,7 @@ pub async fn apply_intune_policy(
         vers = vec!["1.2511.11".to_string()];
     }
     let intune =
-        IntuneForLinux::new(endpoints, Some(&vers[vers.len() - 1])).map_err(|e| anyhow!(e))?;
+        IntuneForLinux::new(endpoints, Some(&vers[vers.len() - 1]), &ip_versions).map_err(|e| anyhow!(e))?;
 
     let token = UserToken {
         token_type: String::new(),


### PR DESCRIPTION
This allows users to manually disable ipv6 usage,
for example.

Fixes #1297 and possibly #895

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [ ] I manually tested this change on a test VM and confirmed it works as intended.
- [ ] I listed exactly what testing I performed (commands/steps and observed results).
- [ ] I listed which distro(s) and version(s) I tested on.
- [ ] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->