### PR TITLE
3.1.4: ubuntu26.04 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "serde_json",
  "zbus",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-fuzz"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "arbitrary",
  "himmelblau_unix_common",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -3289,7 +3289,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "o365"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "anyhow",
  "reqwest 0.12.24",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "3.1.3"
+version = "3.1.4"
 
 [[package]]
 name = "qrcodegen"
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "3.1.3"
+version = "3.1.4"
 
 [[package]]
 name = "semver"
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "3.1.3"
+version = "3.1.4"
 
 [[package]]
 name = "sshkey-attest"
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "sso"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "broker-client",
  "clap",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "sso-policies"
-version = "3.1.3"
+version = "3.1.4"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ kanidm_build_profiles = { path = "src/kanidm_build_profiles" }
 picky-krb = { path = "src/picky-krb" }
 
 [workspace.package]
-version = "3.1.3"
+version = "3.1.4"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	      22.04*) TARGET="ubuntu22.04" ;; \
 	      24.04*) TARGET="ubuntu24.04" ;; \
 	      25.10*) TARGET="ubuntu25.10" ;; \
+	      26.04*) TARGET="ubuntu26.04" ;; \
 	    esac ;; \
 	  linuxmint) \
 	    case "$$VER" in \
@@ -115,7 +116,7 @@ nix: .packaging ## Build Nix packages into ./packaging/
 		$(NIX) --extra-experimental-features 'nix-command flakes' build ".#$$v" --out-link ./packaging/nix-$$v-result; \
 	done
 
-DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 debian12 debian13
+DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 ubuntu26.04 debian12 debian13
 RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora42 fedora43 amzn2023
 SLE_TARGETS := sle15sp6 sle15sp7 sle16
 GENTOO_TARGETS := gentoo

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -1,4 +1,4 @@
-.TH HIMMELBLAU.CONF "5" "February 2026" "Himmelblau Configuration" "File Formats"
+.TH HIMMELBLAU.CONF "5" "April 2026" "Himmelblau Configuration" "File Formats"
 .SH NAME
 himmelblau.conf \- Configuration file for Himmelblau, enabling Azure Entra ID authentication on Linux.
 

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -213,6 +213,11 @@ DISTS = {
         "image": "ubuntu:25.10",
         "tpm": True,
     },
+    "ubuntu26.04": {
+        "family": "deb",
+        "image": "ubuntu:26.04",
+        "tpm": True,
+    },
     "test": {
         "family": "deb",
         "image": "ubuntu:24.04",


### PR DESCRIPTION
Adds ubuntu26.04

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [ ] I manually tested this change on a test VM and confirmed it works as intended.
- [ ] I listed exactly what testing I performed (commands/steps and observed results).
- [ ] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->