### PR TITLE
Partially reapply "Add socket units for himmelblaud"

### DIFF
--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -24,6 +24,7 @@ use std::fs::metadata;
 use std::io;
 use std::io::{Error as IoError, ErrorKind};
 use std::os::unix::fs::MetadataExt;
+use std::os::unix::io::FromRawFd;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -71,7 +72,7 @@ use notify_debouncer_full::{new_debouncer, notify::RecursiveMode};
 
 mod broker;
 use broker::Broker;
-use identity_dbus_broker::himmelblau_broker_serve;
+use identity_dbus_broker::himmelblau_broker_serve_with_listener;
 
 mod prt_memfd;
 
@@ -1168,10 +1169,22 @@ async fn main() -> ExitCode {
             let task_socket_path = cfg.get_task_socket_path();
             let broker_socket_path = cfg.get_broker_socket_path();
 
-            debug!("🧹 Cleaning up sockets from previous invocations");
-            rm_if_exist(&socket_path);
-            rm_if_exist(&task_socket_path);
-            rm_if_exist(&broker_socket_path);
+            // Collect all file descriptors passed by systemd (socket
+            // activation + FD store) in one shot, before anything
+            // else consumes the LISTEN_* environment variables.
+            let mut systemd_fds = prt_memfd::collect_systemd_fds();
+
+            // Only clean up sockets that were NOT passed via socket
+            // activation, as those are owned by systemd.
+            if systemd_fds.main_socket.is_none() {
+                rm_if_exist(&socket_path);
+            }
+            if systemd_fds.task_socket.is_none() {
+                rm_if_exist(&task_socket_path);
+            }
+            if systemd_fds.broker_socket.is_none() {
+                rm_if_exist(&broker_socket_path);
+            }
 
 
             // Check the db path will be okay.
@@ -1316,20 +1329,14 @@ async fn main() -> ExitCode {
             }
 
             // Restore broker PRTs from systemd FileDescriptorStore
-            match prt_memfd::restore_prts_from_fdstore() {
-                Ok(Some(data)) => {
-                    if let Err(e) = idprovider.import_broker_prts(&data).await {
-                        error!("Failed to import PRTs from FD store: {:?}", e);
-                    } else {
-                        info!("Restored broker PRTs from FileDescriptorStore");
-                    }
+            if let Some(data) = prt_memfd::restore_prts(&mut systemd_fds) {
+                if let Err(e) = idprovider.import_broker_prts(&data).await {
+                    error!("Failed to import PRTs from FD store: {:?}", e);
+                } else {
+                    info!("Restored broker PRTs from FileDescriptorStore");
                 }
-                Ok(None) => {
-                    debug!("No broker PRTs in FileDescriptorStore (fresh boot or first start)");
-                }
-                Err(e) => {
-                    error!("Error reading FD store: {:?}", e);
-                }
+            } else {
+                debug!("No broker PRTs in FileDescriptorStore (fresh boot or first start)");
             }
 
             // Setup the tasks socket first.
@@ -1365,17 +1372,38 @@ async fn main() -> ExitCode {
 
             let cachelayer = Arc::new(cl_inner);
 
-            // Setup the root-only socket. Take away all other access bits.
-            let before = unsafe { umask(0o0077) };
-            let task_listener = match UnixListener::bind(task_socket_path.clone()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket {}", task_socket_path);
+            // Setup the root-only task socket.
+            // Prefer a socket-activated fd from systemd; fall back to
+            // manual bind.
+            let task_listener = if let Some(fd) = systemd_fds.task_socket.take() {
+                // SAFETY: fd is valid and owned by this process, passed
+                // by systemd via socket activation.
+                let std_listener = unsafe {
+                    std::os::unix::net::UnixListener::from_raw_fd(fd)
+                };
+                if let Err(e) = std_listener.set_nonblocking(true) {
+                    error!("Failed to set task socket non-blocking: {}", e);
                     return ExitCode::FAILURE
                 }
+                match UnixListener::from_std(std_listener) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        error!("Failed to convert task socket: {}", e);
+                        return ExitCode::FAILURE
+                    }
+                }
+            } else {
+                let before = unsafe { umask(0o0077) };
+                let listener = match UnixListener::bind(task_socket_path.clone()) {
+                    Ok(l) => l,
+                    Err(_e) => {
+                        error!("Failed to bind UNIX socket {}", task_socket_path);
+                        return ExitCode::FAILURE
+                    }
+                };
+                let _ = unsafe { umask(before) };
+                listener
             };
-            // Undo umask changes.
-            let _ = unsafe { umask(before) };
 
             // Pre-process /etc/passwd and /etc/group for nxset
             if process_etc_passwd_group(&cachelayer).await.is_err() {
@@ -1481,13 +1509,34 @@ async fn main() -> ExitCode {
                 info!("Stopped inotify watcher");
             });
 
-            // Spawn the himmelblau dbus broker
+            // Spawn the himmelblau dbus broker.
+            // Prefer a socket-activated fd from systemd; fall back to
+            // manual bind inside himmelblau_broker_serve_with_listener.
+            let broker_listener = if let Some(fd) = systemd_fds.broker_socket.take() {
+                let std_listener = unsafe {
+                    std::os::unix::net::UnixListener::from_raw_fd(fd)
+                };
+                if let Err(e) = std_listener.set_nonblocking(true) {
+                    error!("Failed to set broker socket non-blocking: {}", e);
+                    return ExitCode::FAILURE
+                }
+                match UnixListener::from_std(std_listener) {
+                    Ok(l) => Some(l),
+                    Err(e) => {
+                        error!("Failed to convert broker socket: {}", e);
+                        return ExitCode::FAILURE
+                    }
+                }
+            } else {
+                None
+            };
             let dbus_cachelayer = cachelayer.clone();
             let e_broadcast_rx = broadcast_tx.subscribe();
-            let task_d = match himmelblau_broker_serve::<Broker>(
+            let task_d = match himmelblau_broker_serve_with_listener::<Broker>(
                 Broker { cachelayer: dbus_cachelayer },
-                &broker_socket_path,
-                e_broadcast_rx
+                if broker_listener.is_some() { None } else { Some(broker_socket_path.as_str()) },
+                e_broadcast_rx,
+                broker_listener,
             ).await {
                 Ok(task_d) => task_d,
                 Err(e) => {
@@ -1496,17 +1545,38 @@ async fn main() -> ExitCode {
                 },
             };
 
-            // Set the umask while we open the path for most clients.
-            let before = unsafe { umask(0) };
-            let listener = match UnixListener::bind(socket_path.clone()) {
-                Ok(l) => l,
-                Err(_e) => {
-                    error!("Failed to bind UNIX socket at {}", socket_path);
+            // Setup the main daemon socket.
+            // Prefer a socket-activated fd from systemd; fall back to
+            // manual bind.
+            let listener = if let Some(fd) = systemd_fds.main_socket.take() {
+                // SAFETY: fd is valid and owned by this process, passed
+                // by systemd via socket activation.
+                let std_listener = unsafe {
+                    std::os::unix::net::UnixListener::from_raw_fd(fd)
+                };
+                if let Err(e) = std_listener.set_nonblocking(true) {
+                    error!("Failed to set main socket non-blocking: {}", e);
                     return ExitCode::FAILURE
                 }
+                match UnixListener::from_std(std_listener) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        error!("Failed to convert main socket: {}", e);
+                        return ExitCode::FAILURE
+                    }
+                }
+            } else {
+                let before = unsafe { umask(0) };
+                let listener = match UnixListener::bind(socket_path.clone()) {
+                    Ok(l) => l,
+                    Err(_e) => {
+                        error!("Failed to bind UNIX socket at {}", socket_path);
+                        return ExitCode::FAILURE
+                    }
+                };
+                let _ = unsafe { umask(before) };
+                listener
             };
-            // Undo umask changes.
-            let _ = unsafe { umask(before) };
 
             // Keep a reference for PRT FD store persistence on service shutdown.
             let shutdown_cachelayer = cachelayer.clone();

--- a/src/daemon/src/prt_memfd.rs
+++ b/src/daemon/src/prt_memfd.rs
@@ -15,6 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+use libc;
 use memfd::{FileSeal, MemfdOptions};
 use sd_notify::NotifyState;
 use std::io::{self, Read, Seek, SeekFrom, Write};
@@ -24,6 +25,100 @@ use tracing::{debug, warn};
 
 /// The FDNAME we use when storing/retrieving the PRT memfd.
 const PRT_FDNAME: &str = "broker-prt";
+
+/// Well-known FileDescriptorName values for socket-activated sockets.
+pub const FDNAME_MAIN_SOCKET: &str = "himmelblaud";
+pub const FDNAME_TASK_SOCKET: &str = "himmelblaud-task";
+pub const FDNAME_BROKER_SOCKET: &str = "himmelblaud-broker";
+
+/// File descriptors passed by systemd at startup.
+///
+/// Collected once via `listen_fds_with_names()` so that both socket
+/// activation and FD-store restoration share one call.
+pub struct SystemdFds {
+    /// The main daemon socket (PAM/NSS/CLI), if passed via socket activation.
+    pub main_socket: Option<RawFd>,
+    /// The task socket (root-only IPC), if passed via socket activation.
+    pub task_socket: Option<RawFd>,
+    /// The broker socket, if passed via socket activation.
+    pub broker_socket: Option<RawFd>,
+    /// PRT data restored from the FileDescriptorStore, if any.
+    pub prt_data: Option<Vec<u8>>,
+}
+
+/// Collect all file descriptors passed by systemd and classify them.
+///
+/// Must be called exactly once, early in daemon startup.  Returns
+/// socket-activation FDs (by well-known name) and PRT memfd data.
+pub fn collect_systemd_fds() -> SystemdFds {
+    let fds = match sd_notify::listen_fds_with_names() {
+        Ok(fds) => fds,
+        Err(e) => {
+            debug!(
+                "listen_fds_with_names returned error (not under systemd?): {}",
+                e
+            );
+            return SystemdFds {
+                main_socket: None,
+                task_socket: None,
+                broker_socket: None,
+                prt_data: None,
+            };
+        }
+    };
+
+    let mut result = SystemdFds {
+        main_socket: None,
+        task_socket: None,
+        broker_socket: None,
+        prt_data: None,
+    };
+
+    for (fd, name) in fds {
+        match name.as_str() {
+            FDNAME_MAIN_SOCKET => {
+                if result.main_socket.is_some() {
+                    warn!("Duplicate main socket fd={}, closing", fd);
+                    unsafe { libc::close(fd) };
+                } else {
+                    debug!("Received main socket fd={} from systemd", fd);
+                    result.main_socket = Some(fd);
+                }
+            }
+            FDNAME_TASK_SOCKET => {
+                if result.task_socket.is_some() {
+                    warn!("Duplicate task socket fd={}, closing", fd);
+                    unsafe { libc::close(fd) };
+                } else {
+                    debug!("Received task socket fd={} from systemd", fd);
+                    result.task_socket = Some(fd);
+                }
+            }
+            FDNAME_BROKER_SOCKET => {
+                if result.broker_socket.is_some() {
+                    warn!("Duplicate broker socket fd={}, closing", fd);
+                    unsafe { libc::close(fd) };
+                } else {
+                    debug!("Received broker socket fd={} from systemd", fd);
+                    result.broker_socket = Some(fd);
+                }
+            }
+            PRT_FDNAME => {
+                debug!("Found PRT memfd (fd={}) in FileDescriptorStore", fd);
+                match read_fd_contents(fd) {
+                    Ok(data) => result.prt_data = Some(data),
+                    Err(e) => warn!("Failed to read PRT memfd: {}", e),
+                }
+            }
+            _ => {
+                warn!("Closing unknown systemd fd={} name={}", fd, name);
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+
+    result
+}
 
 /// Create a sealed memfd containing `data` and store it in systemd's
 /// FileDescriptorStore.
@@ -71,33 +166,12 @@ pub fn store_prts_to_fdstore(data: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-/// Retrieve PRT data from systemd's FileDescriptorStore.
+/// Retrieve PRT data from a pre-collected `SystemdFds`.
 ///
-/// On daemon restart systemd passes back the stored fds via the
-/// `LISTEN_FDS` / `LISTEN_FDNAMES` protocol.  We look for our
-/// well-known name and read the contents.
-pub fn restore_prts_from_fdstore() -> io::Result<Option<Vec<u8>>> {
-    let fds = match sd_notify::listen_fds_with_names() {
-        Ok(fds) => fds,
-        Err(e) => {
-            // Not an error, may not be running under systemd or no fds passed.
-            debug!(
-                "listen_fds_with_names returned error (not under systemd?): {}",
-                e
-            );
-            return Ok(None);
-        }
-    };
-
-    for (fd, name) in fds {
-        if name == PRT_FDNAME {
-            debug!("Found PRT memfd (fd={}) in FileDescriptorStore", fd);
-            return read_fd_contents(fd).map(Some);
-        }
-    }
-
-    debug!("No PRT memfd found in FileDescriptorStore");
-    Ok(None)
+/// This is a convenience wrapper; the actual collection happens in
+/// `collect_systemd_fds()`.
+pub fn restore_prts(fds: &mut SystemdFds) -> Option<Vec<u8>> {
+    fds.prt_data.take()
 }
 
 /// Read the full contents of a file descriptor into a `Vec<u8>`.


### PR DESCRIPTION
The code implementing socket activation was dropped together with the configuration enabling it, but that's unnecessary and makes it harder to test it.
Reapply the code changes alone. Without configuration changes in the units, they will not be used by default. We can then change the unit files locally to test them and triage the reported issue.

This reverts commit be73b12ecc5351082f7ef96cf1dacfe5d0656e1d.

The feature with the sockets added locally works on my debian 13 laptop.

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [x] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->