### PR TITLE
Fix broker expiresOn unit conversion (seconds added to milliseconds)

### DIFF
--- a/src/daemon/src/broker.rs
+++ b/src/daemon/src/broker.rs
@@ -180,7 +180,7 @@ impl HimmelblauBroker for Broker {
                     .ok_or("Failed to fetch access token")?,
                 "accessTokenType": 0,
                 "clientInfo": URL_SAFE_NO_PAD.encode(json!(&token.client_info).to_string()),
-                "expiresOn": (token.expires_in as u128) + now.as_millis(),
+                "expiresOn": now.as_millis() + u128::from(token.expires_in) * 1000,
                 "extendedExpiresOn": (token.ext_expires_in as u64) + now.as_secs(),
                 "grantedScopes": token.scope.clone()
                     .ok_or("Failed to fetch scopes")?,


### PR DESCRIPTION
## What this fixes

`expiresOn` in `acquire_token_silently` is computed as:

```rust
"expiresOn": (token.expires_in as u128) + now.as_millis(),
```

`token.expires_in` is OAuth 2.0 seconds (RFC 6749 §5.1), but it's added to milliseconds. A one-hour token (`expires_in = 3600`) ends up at `now + 3600 ms ≈ now + 3.6 seconds` instead of `now + 1 hour`.

This PR multiplies `expires_in` by 1000 before adding it to `now.as_millis()`.

## How I encountered this

I'm a downstream user of the broker D-Bus API. While testing himmelblau as a replacement broker on NixOS, my own client (a Go-based daemon that caches access tokens by `(clientId, scopes)`) was hitting the broker on every call instead of caching tokens. After logging the returned `expiresOn`, I saw values like `2026-05-06T15:08:39-07:00` while the current time was `2026-05-06T15:08:34-07:00` — exactly 5 seconds in the future for a token that should have been valid for an hour. My client's 5-minute pre-expiry refresh buffer treated every token as already expired, so it never reused a cached token.

I worked around it on my side by parsing the JWT's `exp` claim, but that doesn't help other broker clients.

## Why I think this is the fix

OAuth 2.0 `expires_in` is documented as seconds. Inside this repo, `src/broker-client/src/lib.rs` parses `expiresOn` as milliseconds:

```rust
expires_in: (($token
    .get("expiresOn")
    .and_then(|v| v.as_u64())
    .unwrap_or(0)
    / 1000)               // ← divides by 1000 before comparing to seconds
    .saturating_sub(now.as_secs())) as u32,
```

So himmelblau's own broker-client helper expects `expiresOn` as ms-since-epoch. External consumers I checked (sso-mib, linux-entra-sso mock) also treat it as ms. The current daemon code therefore produces a value that conflicts with himmelblau's own consumer.

I did not change `extendedExpiresOn` because the unit there is less obvious — the same `broker-client` file treats it as seconds (no divide-by-1000), but external consumers seem to expect ms. I'd rather leave that alone unless a maintainer can confirm the intended schema; happy to send a separate PR if needed.

## Manual test steps

Distro: NixOS unstable (kernel 6.12), running the himmelblau flake from main plus this patch.

1. Authenticate the host normally (`aad-tool auth-test --name <upn>`).
2. Make a D-Bus `acquireTokenSilently` call from a small client.
3. Log the value of the returned `expiresOn` field and the current time at the moment of the call.

Before the patch:
- `now ≈ 1778104714000` ms
- returned `expiresOn ≈ 1778104717600` ms (≈ 3.6 seconds in the future)
- `expiresOn - now ≈ 3600` (matches the seconds-as-ms hypothesis)

After the patch:
- `now ≈ 1778104714000` ms
- returned `expiresOn ≈ 1778108314000` ms (≈ 1 hour in the future)
- `expiresOn - now ≈ 3_600_000`

Cross-checked the JWT's `exp` claim against the post-patch `expiresOn` — they agree within a couple of seconds.

## Packaging / runtime impact

None expected. The change only affects the value emitted in the `brokerTokenResponse.expiresOn` field. Existing in-tree consumers (`broker-client`) already divide by 1000, so the new value is what they were always trying to get. External consumers that parsed the broken value as ms were getting `now + 3.6 seconds` and would have re-requested tokens immediately — fixing the value should reduce broker traffic, not break callers.

## Automated checks

- `cargo build --package broker-client` — clean (dev-shell rustc was older than the workspace MSRV so I couldn't build the full workspace via plain cargo).
- `cargo test --package broker-client` — passes (0 tests in that package).
- `nix build .#daemon` against the patched tree — builds clean. This is the package that actually contains the fix.

I did not run `make test-selinux` because I'm on NixOS without an SELinux-enabled test target.

## Disclosure

I'm not very familiar with Rust, so an AI coding assistant helped me draft this patch. I reviewed every changed line and verified the behavior with the manual test above. Please flag anything non-idiomatic — specifically the `u128::from(...)` vs `as u128` style and whether the repo prefers a different conversion idiom for `Duration`-like math.

## Related

I could not find an existing issue for this. Closest hit was #895 (NixOS Intune policies) but that's a different bug. Happy to open a tracking issue if preferred.

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [x] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [x] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [x] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->
