### PR TITLE
Backport to 2.x: 1 commit(s) + 1 dependency update(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "serde_json",
  "zbus",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-fuzz"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "arbitrary",
  "himmelblau_unix_common",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "bindgen",
  "cc",
@@ -3147,7 +3147,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "o365"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "anyhow",
  "reqwest 0.12.24",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "2.3.10"
+version = "2.3.11"
 
 [[package]]
 name = "quinn"
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "2.3.10"
+version = "2.3.11"
 
 [[package]]
 name = "semver"
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "2.3.10"
+version = "2.3.11"
 
 [[package]]
 name = "sshkey-attest"
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "sso"
-version = "2.3.10"
+version = "2.3.11"
 dependencies = [
  "broker-client",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -522,9 +522,9 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "base64urlsafedata"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f7f6be94fa637132933fd0a68b9140bcb60e3d46164cb68e82a2bb8d102b3a"
+checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
 dependencies = [
  "base64 0.21.7",
  "pastey 0.1.1",
@@ -542,29 +542,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -578,9 +555,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -604,14 +581,14 @@ dependencies = [
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
 
 [[package]]
 name = "bitflags"
@@ -632,7 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -760,16 +737,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -840,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -862,23 +839,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1185,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1220,15 +1197,15 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "futures-channel",
  "futures-util",
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1283,7 +1260,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1294,7 +1271,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1314,7 +1291,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1334,7 +1311,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1379,7 +1356,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1492,7 +1469,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1739,7 +1716,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1775,7 +1752,7 @@ dependencies = [
 name = "fxhash"
 version = "0.2.1"
 dependencies = [
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1915,6 +1892,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2014,7 +1997,7 @@ dependencies = [
  "csv",
  "der 0.7.10",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "idmap",
  "kanidm-hsm-crypto",
  "kanidm_lib_crypto",
@@ -2103,15 +2086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3fd4dc94c318c1ede8a2a48341c250d6ddecd3ba793da2820301a9f92417ad9"
 dependencies = [
  "digest 0.11.0-rc.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2435,7 +2409,7 @@ dependencies = [
 name = "idmap"
 version = "2.3.10"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "libc",
  "tracing",
@@ -2596,9 +2570,9 @@ dependencies = [
 
 [[package]]
 name = "kanidm-hsm-crypto"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cafdd63d3c246fd7a7318de64e35d2c744ebb2c5a51a407a2985ad6fe29908"
+checksum = "bfb9c43ea17ed7eafbb4af596fa366aad5d1dcfb5e0b5a0c8603797d37ee43f9"
 dependencies = [
  "crypto-glue",
  "serde",
@@ -2627,7 +2601,7 @@ dependencies = [
  "md4",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "serde",
  "sha-crypt",
@@ -2720,12 +2694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lber"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,9 +2728,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -2801,8 +2769,8 @@ dependencies = [
  "os-release",
  "paste",
  "percent-encoding",
- "picky-asn1 0.10.1",
- "picky-asn1-der 0.5.4",
+ "picky-asn1",
+ "picky-asn1-der",
  "picky-krb",
  "regex",
  "reqwest 0.13.2",
@@ -2847,7 +2815,7 @@ dependencies = [
  "md5",
  "num_enum",
  "pbkdf2",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde-binary",
  "sha1",
@@ -2967,11 +2935,11 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3222,13 +3190,13 @@ checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -3280,7 +3248,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3320,15 +3288,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3341,7 +3308,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3358,9 +3325,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3559,7 +3526,7 @@ dependencies = [
 name = "paste"
 version = "1.0.15"
 dependencies = [
- "pastey 0.2.1",
+ "pastey 0.2.2",
 ]
 
 [[package]]
@@ -3570,9 +3537,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"
@@ -3583,12 +3550,6 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "peg"
@@ -3683,7 +3644,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3693,17 +3654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "picky-asn1"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295eea0f33c16be21e2a98b908fdd4d73c04dd48c8480991b76dbcf0cb58b212"
-dependencies = [
- "oid",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -3719,37 +3669,13 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-der"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df7873a9e36d42dadb393bea5e211fe83d793c172afad5fb4ec846ec582793f"
-dependencies = [
- "picky-asn1 0.8.0",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-der"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b491eb61603cba1ad5c6be0269883538f8d74136c35e3641a840fb0fbcd41efc"
 dependencies = [
- "picky-asn1 0.10.1",
+ "picky-asn1",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "picky-asn1-x509"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f20f71a68499ff32310f418a6fad8816eac1a2859ed3f0c5c741389dd6208"
-dependencies = [
- "base64 0.21.7",
- "oid",
- "picky-asn1 0.8.0",
- "picky-asn1-der 0.4.1",
- "serde",
 ]
 
 [[package]]
@@ -3773,7 +3699,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3816,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -3884,7 +3810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3944,7 +3870,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3957,7 +3883,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4000,7 +3926,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2 0.5.9",
  "thiserror 2.0.17",
@@ -4019,9 +3945,9 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4073,9 +3999,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4284,13 +4210,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4346,12 +4272,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -4384,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4582,7 +4502,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -4593,9 +4513,9 @@ version = "2.3.10"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4661,7 +4581,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4685,7 +4605,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4940,17 +4860,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4977,7 +4886,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5067,7 +4976,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5078,7 +4987,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5165,7 +5074,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5194,7 +5103,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5253,7 +5162,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5279,7 +5188,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.1",
  "toml_datetime 0.6.11",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5288,7 +5197,7 @@ version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -5455,7 +5364,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5537,36 +5446,40 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tss-esapi"
-version = "8.0.0-alpha"
+version = "8.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1617a46161846de3a3d3e407cd30cb345599bc5e440c3907a59b34b75a2731"
+checksum = "5c1751ea94b699404cd8c52fe2f1cb6ba811b8a7d26151298b946b3b8424468e"
 dependencies = [
  "bitfield",
  "cfg-if",
+ "digest 0.10.7",
+ "ecdsa",
+ "elliptic-curve",
  "enumflags2",
+ "getrandom 0.2.16",
  "hostname-validator",
  "log",
  "malloced",
  "num-derive",
  "num-traits",
- "oid",
  "paste",
- "picky-asn1 0.8.0",
- "picky-asn1-x509",
+ "pkcs8",
  "regex",
  "semver",
  "serde",
+ "signature",
  "tss-esapi-sys",
+ "x509-cert",
  "zeroize",
 ]
 
 [[package]]
 name = "tss-esapi-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535cd192581c2ec4d5f82e670b1d3fbba6a23ccce8c85de387642051d7cad5b5"
+checksum = "a7f972672926a3d3d18ecc04524720e4d20b7d1664a3fb73dbf7d4274196dbd9"
 dependencies = [
- "bindgen 0.66.1",
+ "bindgen",
  "pkg-config",
  "target-lexicon",
 ]
@@ -5666,9 +5579,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -5778,7 +5691,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5813,7 +5726,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5921,18 +5834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5984,7 +5885,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5995,7 +5896,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6279,6 +6180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6317,7 +6227,7 @@ dependencies = [
  "heck",
  "indexmap 2.12.1",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6333,7 +6243,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6415,15 +6325,15 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6448,7 +6358,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6456,14 +6366,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6471,12 +6381,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
@@ -6497,7 +6407,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6517,7 +6427,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6539,7 +6449,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6572,7 +6482,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6583,40 +6493,40 @@ checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
- "winnow",
+ "syn",
+ "winnow 1.0.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbcc01a40eef77694c1a063b463e581162c92dca5732864d809d2b19c13cd1e"
+checksum = "4331d6c174da030b21bb2bf7dde3ea49d9cea3a08cd99007a008f65a64059ae8"
 dependencies = [
  "base64 0.22.1",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ homepage = "https://github.com/himmelblau-idm/himmelblau"
 repository = "https://github.com/himmelblau-idm/himmelblau"
 
 [workspace.dependencies]
-libc = "^0.2.184"
-pkg-config = "^0.3.32"
+libc = "^0.2.186"
+pkg-config = "^0.3.33"
 lazy_static = "^1.4.0"
 paste = "^1.0.12"
 serde = { version = "^1.0.228", features = ["derive"] }
@@ -55,7 +55,7 @@ tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
 libhimmelblau = { version = "0.8.14", features = ["broker", "changepassword", "on_behalf_of", "intune_portal_vers_selection"] }
 clap = { version = "^4.6", features = ["derive", "env"] }
-clap_complete = "^4.6.0"
+clap_complete = "^4.6.3"
 reqwest = { version = "^0.12.24", features = ["json"] }
 anyhow = "^1.0.102"
 tokio = { version = "^1.50.0", features = ["rt", "macros", "sync", "time", "net", "io-util", "signal", "rt-multi-thread"] }
@@ -78,7 +78,7 @@ libkrimes = { version = "0.1.0", features = ["keyring"] }
 argon2 = { version = "0.5.2", features = ["alloc"] }
 base32 = "^0.5.0"
 base64 = "^0.22.0"
-base64urlsafedata = "0.5.0"
+base64urlsafedata = "0.5.5"
 hex = "^0.4.3"
 num_enum = "^0.7.6"
 scim_proto = "^1.6.4"
@@ -86,18 +86,18 @@ serde_with = "3.16.1"
 time = { version = "^0.3.47", features = ["formatting", "local-offset"] }
 url = "^2.4.0"
 urlencoding = "2.1.3"
-uuid = { version = "^1.23.0", features = ["v4"] }
+uuid = { version = "^1.23.1", features = ["v4"] }
 webauthn-rs-proto = "0.5.0"
 kanidm_proto = "1.7.4"
 openssl-sys = "^0.9"
-openssl = "^0.10.76"
-rand = "^0.9.2"
+openssl = "^0.10.79"
+rand = "^0.9.4"
 tss-esapi = "^7.2.0"
 sketching = "~1.7.4"
 tracing-forest = "^0.1.6"
 rusqlite = "^0.37.0"
-hashbrown = { version = "0.16.1", features = ["serde", "inline-more"] }
-lru = "^0.16.3"
+hashbrown = { version = "0.17.0", features = ["serde", "inline-more"] }
+lru = "^0.18.0"
 kanidm_lib_crypto = "1.7.4"
 kanidm_utils_users = "~1.7.4"
 walkdir = "2"
@@ -120,7 +120,7 @@ tracing-opentelemetry = "0.28.0"
 tracing-core = "0.1.34"
 tonic = "0.14.5"
 compact_jwt = { version = "0.5.3-dev", features = ["msextensions"] }
-kanidm-hsm-crypto = { version = "^0.3.5" }
+kanidm-hsm-crypto = { version = "^0.3.6" }
 whoami = "1.6.1"
 kanidm_lib_file_permissions = "~1.7.4"
 md4 = "0.10.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ kanidm_build_profiles = { path = "src/kanidm_build_profiles" }
 picky-krb = { path = "src/picky-krb" }
 
 [workspace.package]
-version = "2.3.10"
+version = "2.3.11"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ himmelblau_unix_common = { workspace = true }
 idmap = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 tempfile = "3.27.0"
-uuid = "1.23.0"
+uuid = "1.23.1"
 
 [[bin]]
 name = "config"

--- a/src/broker-client/Cargo.toml
+++ b/src/broker-client/Cargo.toml
@@ -10,4 +10,4 @@ repository.workspace = true
 
 [dependencies]
 serde_json.workspace = true
-zbus = "^5.14"
+zbus = "^5.15"

--- a/src/broker/Cargo.toml
+++ b/src/broker/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-dbus = "0.9.10"
+dbus = "0.9.11"
 himmelblau_unix_common.workspace = true
 identity_dbus_broker.workspace = true
 tokio.workspace = true

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -25,7 +25,7 @@ clap_complete = { workspace = true }
 anyhow = { workspace = true }
 uzers = "^0.12.2"
 sketching = { workspace = true }
-rpassword = "^7.4.0"
+rpassword = "^7.5.2"
 libc.workspace = true
 libhimmelblau.workspace = true
 kanidm-hsm-crypto.workspace = true

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -53,5 +53,5 @@ regex = "1.12.2"
 sha2 = "0.11.0-rc"
 base64.workspace = true
 authenticator = { version = "0.5.0", default-features = false, features = ["crypto_openssl"] }
-rpassword = "7.4.0"
+rpassword = "7.5.2"
 der = "0.7.10"

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -3043,17 +3043,22 @@ impl HimmelblauProvider {
                 if account_id.to_string().to_lowercase() != spn.to_string().to_lowercase() {
                     /* Fixes bug#801: The authenticated user might have a mis-matched
                      * response because the domains are aliases of one another.
+                     * Both the local part AND the domains must match — otherwise a
+                     * different user authenticating in the same tenant would be
+                     * silently accepted (e.g. user2 unlocking user1's locked screen
+                     * via a passkey QR scan).
                      */
                     let mut cfg = self.config.write().await;
-                    let (_, domain1) = split_username(account_id).ok_or({
+                    let (local1, domain1) = split_username(account_id).ok_or_else(|| {
                         error!("Failed splitting account_id username");
                         IdpError::BadRequest
                     })?;
-                    let (_, domain2) = split_username(&spn).ok_or({
+                    let (local2, domain2) = split_username(&spn).ok_or_else(|| {
                         error!("Failed splitting spn username");
                         IdpError::BadRequest
                     })?;
-                    if !cfg.domains_are_aliases(domain1, domain2).await {
+                    let domains_match = cfg.domains_are_aliases(domain1, domain2).await;
+                    if local1.to_lowercase() != local2.to_lowercase() || !domains_match {
                         let msg =
                             format!("Authenticated user {} does not match requested user", uuid);
                         error!(msg);

--- a/src/idmap/Cargo.toml
+++ b/src/idmap/Cargo.toml
@@ -19,5 +19,5 @@ tracing.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-cc = "1.2.58"
+cc = "1.2.61"
 bindgen = "0.72.1"

--- a/src/paste/Cargo.toml
+++ b/src/paste/Cargo.toml
@@ -14,4 +14,4 @@ repository.workspace = true
 #proc-macro = true
 
 [dependencies]
-pastey = "0.2.1"
+pastey = "0.2.2"

--- a/src/policies/Cargo.toml
+++ b/src/policies/Cargo.toml
@@ -25,7 +25,7 @@ base64.workspace = true
 tokio.workspace = true
 himmelblau_unix_common = { workspace = true }
 os-release = "0.1.0"
-semver = "1.0.27"
+semver = "1.0.28"
 libhimmelblau.workspace = true
 uuid.workspace = true
 libc.workspace = true

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -459,6 +459,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.1 -> 0.2.0"
 
+[[audits.pastey]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+
 [[audits.pbkdf2]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -376,10 +376,6 @@ criteria = "safe-to-deploy"
 version = "1.0.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.lazycell]]
-version = "1.3.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.libdbus-sys]]
 version = "0.2.7"
 criteria = "safe-to-deploy"
@@ -517,19 +513,11 @@ version = "0.8.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.picky-asn1]]
-version = "0.8.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.picky-asn1]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.picky-asn1-der]]
 version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.picky-asn1-x509]]
-version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pin-project]]
@@ -766,10 +754,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.webpki-roots]]
 version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.which]]
-version = "4.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,7 +3,7 @@
 
 [[unpublished.sshkey-attest]]
 version = "0.5.999"
-audited_as = "0.5.4"
+audited_as = "0.5.5"
 
 [[publisher.aho-corasick]]
 version = "1.1.3"
@@ -76,8 +76,8 @@ user-login = "jschanck"
 user-name = "John Schanck"
 
 [[publisher.base64urlsafedata]]
-version = "0.5.4"
-when = "2025-12-10"
+version = "0.5.5"
+when = "2026-04-30"
 user-id = 31100
 user-login = "Firstyear"
 user-name = "Firstyear"
@@ -104,8 +104,8 @@ user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
 [[publisher.clap]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.1"
+when = "2026-04-15"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -118,15 +118,15 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_complete]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.3"
+when = "2026-04-27"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_derive]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.1"
+when = "2026-04-15"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -308,6 +308,12 @@ when = "2025-11-20"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.hashbrown]]
+version = "0.17.0"
+when = "2026-04-09"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.http]]
 version = "1.3.1"
 when = "2025-03-11"
@@ -392,8 +398,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.kanidm-hsm-crypto]]
-version = "0.3.5"
-when = "2025-11-21"
+version = "0.3.6"
+when = "2026-04-30"
 user-id = 31100
 user-login = "Firstyear"
 user-name = "Firstyear"
@@ -427,8 +433,8 @@ user-login = "yaleman"
 user-name = "James Hodgkinson"
 
 [[publisher.libc]]
-version = "0.2.184"
-when = "2026-04-01"
+version = "0.2.186"
+when = "2026-04-23"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -440,8 +446,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.libhimmelblau]]
-version = "0.8.18"
-when = "2026-04-08"
+version = "0.8.19"
+when = "2026-05-06"
 user-id = 247655
 user-login = "dmulder"
 user-name = "David Mulder"
@@ -642,8 +648,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.rustls]]
-version = "0.23.34"
-when = "2025-10-22"
+version = "0.23.38"
+when = "2026-04-12"
 user-id = 4556
 user-login = "djc"
 user-name = "Dirkjan Ochtman"
@@ -761,18 +767,11 @@ user-login = "Thomasdezeeuw"
 user-name = "Thomas de Zeeuw"
 
 [[publisher.sshkey-attest]]
-version = "0.5.4"
-when = "2025-12-11"
+version = "0.5.5"
+when = "2026-04-30"
 user-id = 31100
 user-login = "Firstyear"
 user-name = "Firstyear"
-
-[[publisher.syn]]
-version = "1.0.109"
-when = "2023-02-24"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
 
 [[publisher.syn]]
 version = "2.0.117"
@@ -1262,6 +1261,13 @@ user-name = "Kenny Kerr"
 [[publisher.winnow]]
 version = "0.7.13"
 when = "2025-08-22"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.winnow]]
+version = "1.0.2"
+when = "2026-04-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -1803,12 +1809,6 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 notes = "No unsafe code."
 
-[[audits.bytecode-alliance.audits.peeking_take_while]]
-who = "Nick Fitzgerald <fitzgen@gmail.com>"
-criteria = "safe-to-deploy"
-version = "1.0.0"
-notes = "I am the author of this crate."
-
 [[audits.bytecode-alliance.audits.pem-rfc7468]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
@@ -1850,6 +1850,12 @@ change.
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.32"
+
+[[audits.bytecode-alliance.audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.9.4"
+notes = "Minor bugfix release"
 
 [[audits.bytecode-alliance.audits.sha1]]
 who = "Andrew Brown <andrew.brown@intel.com>"
@@ -2820,6 +2826,11 @@ See https://crrev.com/c/6323349 for more audit notes.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.himmelblau.audits.bitfield]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.13.2 -> 0.17.0"
+
 [[audits.himmelblau.audits.cc]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -2829,6 +2840,16 @@ delta = "1.2.55 -> 1.2.56"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.2.56 -> 1.2.59"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.2.59 -> 1.2.60"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.2.60 -> 1.2.61"
 
 [[audits.himmelblau.audits.cesu8]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2844,6 +2865,11 @@ delta = "0.4.43 -> 0.4.44"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.9.10"
+
+[[audits.himmelblau.audits.dbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.10 -> 0.9.11"
 
 [[audits.himmelblau.audits.der]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2930,6 +2956,16 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.16.2 -> 0.16.3"
 
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.16.3 -> 0.16.4"
+
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.16.4 -> 0.18.0"
+
 [[audits.himmelblau.audits.markup5ever]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -2955,6 +2991,16 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.75 -> 0.10.76"
 
+[[audits.himmelblau.audits.openssl]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.76 -> 0.10.77"
+
+[[audits.himmelblau.audits.openssl]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.77 -> 0.10.79"
+
 [[audits.himmelblau.audits.openssl-probe]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -2965,15 +3011,35 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.111 -> 0.9.112"
 
+[[audits.himmelblau.audits.openssl-sys]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.112 -> 0.9.113"
+
+[[audits.himmelblau.audits.openssl-sys]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.113 -> 0.9.115"
+
 [[audits.himmelblau.audits.picky-asn1-der]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.5.4"
 
+[[audits.himmelblau.audits.pkg-config]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
 [[audits.himmelblau.audits.reqwest_cookie_store]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.10.0"
+
+[[audits.himmelblau.audits.rpassword]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "7.4.0 -> 7.5.2"
 
 [[audits.himmelblau.audits.rustc-hash]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2983,12 +3049,7 @@ delta = "2.1.1 -> 2.1.2"
 [[audits.himmelblau.audits.rustls]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
-delta = "0.23.34 -> 0.23.36"
-
-[[audits.himmelblau.audits.rustls]]
-who = "David Mulder <dmulder@samba.org>"
-criteria = "safe-to-deploy"
-delta = "0.23.36 -> 0.23.37"
+delta = "0.23.38 -> 0.23.40"
 
 [[audits.himmelblau.audits.rustls-native-certs]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3029,6 +3090,11 @@ version = "2.15.0"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.26.0 -> 0.33.0"
+
+[[audits.himmelblau.audits.semver]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.27 -> 1.0.28"
 
 [[audits.himmelblau.audits.servo_arc]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3095,6 +3161,16 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.22 -> 0.3.23"
 
+[[audits.himmelblau.audits.tss-esapi]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "8.0.0-alpha -> 8.0.0-alpha.2"
+
+[[audits.himmelblau.audits.tss-esapi-sys]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.6.0"
+
 [[audits.himmelblau.audits.uuid]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3104,6 +3180,11 @@ delta = "1.20.0 -> 1.21.0"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.21.0 -> 1.23.0"
+
+[[audits.himmelblau.audits.uuid]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.23.0 -> 1.23.1"
 
 [[audits.himmelblau.audits.uzers]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3125,12 +3206,37 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.13.2 -> 5.14.0"
 
+[[audits.himmelblau.audits.zbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.14.0 -> 5.15.0"
+
 [[audits.himmelblau.audits.zbus_macros]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.13.2 -> 5.14.0"
 
+[[audits.himmelblau.audits.zbus_macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.14.0 -> 5.15.0"
+
+[[audits.himmelblau.audits.zbus_names]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "4.3.1 -> 4.3.2"
+
 [[audits.himmelblau.audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.9.2 -> 5.10.0"
+
+[[audits.himmelblau.audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.10.0 -> 5.11.0"
+
+[[audits.himmelblau.audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.9.2 -> 5.10.0"
@@ -3138,7 +3244,12 @@ delta = "5.9.2 -> 5.10.0"
 [[audits.himmelblau.audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
-delta = "5.9.2 -> 5.10.0"
+delta = "5.10.0 -> 5.11.0"
+
+[[audits.himmelblau.audits.zvariant_utils]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.3.0 -> 3.3.1"
 
 [[audits.isrg.audits.base64]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
@@ -3873,23 +3984,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.home]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "0.5.3"
-notes = """
-Crate with straightforward code for determining the user's HOME directory. Only
-unsafe code is used to invoke the Windows SHGetFolderPathW API to get the
-profile directory when the USERPROFILE environment variable is unavailable.
-"""
-aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.home]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.3 -> 0.5.11"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.iana-time-zone]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
@@ -4050,6 +4144,18 @@ version = "0.3.3"
 notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-derive]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.once_cell]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -4085,13 +4191,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "1.20.3 -> 1.21.1"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.peeking_take_while]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.0 -> 0.1.2"
-notes = "Small refactor of some simple iterator logic, no unsafe code or capabilities."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.percent-encoding]]
@@ -4981,22 +5080,5 @@ delta = "0.3.0 -> 0.3.1"
 notes = """
 Migrates to `try-lock 0.2.4` to replace some unsafe APIs that were not marked
 `unsafe` (but that were being used safely).
-"""
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.which]]
-who = "Jack Grigg <jack@z.cash>"
-criteria = "safe-to-deploy"
-delta = "4.3.0 -> 4.4.0"
-notes = "New APIs are remixes of existing code."
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.which]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "4.4.0 -> 4.4.2"
-notes = """
-Crate now has `#![forbid(unsafe_code)]`, replacing its last `unsafe` block with a
-dependency on the `rustix` crate.
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"


### PR DESCRIPTION
## Summary
Backport commits to stable-2.x:

- 87ca6189: Reject auth when token spn local part differs from requested account_id

### Dependabot Updates Included
- deps(rust): bump the all-cargo-updates group with 19 updates (#1369)


## Test plan
- [ ] Build succeeds
- [ ] `make vet` passes
- [ ] Basic functionality tested

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [ ] I manually tested this change on a test VM and confirmed it works as intended.
- [ ] I listed exactly what testing I performed (commands/steps and observed results).
- [ ] I listed which distro(s) and version(s) I tested on.
- [ ] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->