### PR TITLE
qr-greeter: support GNOME Shell 50

### DIFF
--- a/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/metadata.json
+++ b/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/metadata.json
@@ -3,7 +3,7 @@
   "name": "Himmelblau QR Greeter",
   "description": "Adds a QR code to authentication prompts when a URL is detected.",
   "version": 1,
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "session-modes": ["gdm", "unlock-dialog"],
   "donations": { "opencollective" : "himmelblau" }
 }


### PR DESCRIPTION
Ubuntu 26.04 ships GNOME Shell 50.1. Without 50 in shell-version, the extension fails to load on the greeter — message prefixes like [FIDO_TOUCH] are not stripped and SVG security-key images are not rendered.

Fixes #

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [ ] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [ ] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [ ] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [ ] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->