### PR TITLE
Add support for Fedora 44 and remove Fedora 42

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ Common targets:
 
 Per-distro targets (build only one):
 `make ubuntu22.04`, `ubuntu24.04`, `debian12`, `debian13`, `rocky8`, `rocky9`, `rocky10`,
-`tumbleweed`, `rawhide`, `fedora42`, `fedora43`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`.
+`tumbleweed`, `rawhide`, `fedora43`, `fedora44`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`.
 
 Tips / conventions:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Common targets:
 
 Per-distro targets (build only one):
 `make ubuntu22.04`, `ubuntu24.04`, `debian12`, `debian13`, `rocky8`, `rocky9`, `rocky10`,
-`tumbleweed`, `rawhide`, `fedora42`, `fedora43`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`.
+`tumbleweed`, `rawhide`, `fedora43`, `fedora44`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`.
 
 Tips / conventions:
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	    esac ;; \
 	  fedora) \
 	    case "$$VER" in \
-	      42*) TARGET="fedora42" ;; \
 	      43*) TARGET="fedora43" ;; \
+	      44*) TARGET="fedora44" ;; \
 	      *) TARGET="rawhide" ;; \
 	    esac ;; \
 	  sles|sled|sle_micro|suse|suse-linux-enterprise) \
@@ -77,7 +77,7 @@ test: dockerfiles ## Run cargo tests in a container
                 himmelblau-test-build
 
 test-selinux: ## Test the SELinux policy to ensure it builds
-	./scripts/test_selinux_policy.py --fix -v --distros rocky8,rocky9,rocky10,fedora42,fedora43,tumbleweed,sle16
+	./scripts/test_selinux_policy.py --fix -v --distros rocky8,rocky9,rocky10,fedora43,fedora44,tumbleweed,sle16
 
 clean: ## Remove cargo build artifacts
 	cargo clean
@@ -121,7 +121,7 @@ nix: .packaging ## Build Nix packages into ./packaging/
 	done
 
 DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 ubuntu26.04 debian12 debian13
-RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora42 fedora43 amzn2023
+RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora43 fedora44 amzn2023
 SLE_TARGETS := sle15sp6 sle15sp7 sle16
 GENTOO_TARGETS := gentoo
 ALL_PACKAGE_TARGETS := $(DEB_TARGETS) $(RPM_TARGETS) $(SLE_TARGETS) $(GENTOO_TARGETS)

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ You can also target specific distros explicitly.
 Available targets (as of now):
 
 - **DEB:** `ubuntu22.04` `ubuntu24.04` `ubuntu26.04` `debian12` `debian13`
-- **RHEL family:** `rocky8` `rocky9` `rocky10` `fedora41` `fedora42` `fedora43` `rawhide`
+- **RHEL family:** `rocky8` `rocky9` `rocky10` `fedora43` `fedora44` `rawhide`
 - **SUSE:** `sle15sp6` `sle15sp7` `sle16` `tumbleweed`
 
 Examples:

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -225,15 +225,15 @@ DISTS = {
         "extra_pkgs": ["nodejs"],
     },
     # ---- Fedora family ----
-    "fedora42": {
-        "family": "rpm",
-        "image": "fedora:42",
-        "tpm": True,
-        "selinux": True,
-    },
     "fedora43": {
         "family": "rpm",
         "image": "fedora:43",
+        "tpm": True,
+        "selinux": True,
+    },
+    "fedora44": {
+        "family": "rpm",
+        "image": "fedora:44",
         "tpm": True,
         "selinux": True,
     },

--- a/scripts/test_selinux_policy.py
+++ b/scripts/test_selinux_policy.py
@@ -75,15 +75,15 @@ SELINUX_DISTROS = {
         "extra_setup": "dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb && sed -i -e 's|$rltype||g' /etc/yum.repos.d/rocky*.repo",
         "requires_scc": False,
     },
-    "fedora42": {
-        "base_image": "fedora:42",
+    "fedora43": {
+        "base_image": "fedora:43",
         "pkg_manager": "dnf",
         "selinux_pkgs": ["policycoreutils", "selinux-policy-targeted", "selinux-policy-devel", "policycoreutils-devel"],
         "extra_setup": None,
         "requires_scc": False,
     },
-    "fedora43": {
-        "base_image": "fedora:43",
+    "fedora44": {
+        "base_image": "fedora:44",
         "pkg_manager": "dnf",
         "selinux_pkgs": ["policycoreutils", "selinux-policy-targeted", "selinux-policy-devel", "policycoreutils-devel"],
         "extra_setup": None,

--- a/scripts/test_selinux_policy.py
+++ b/scripts/test_selinux_policy.py
@@ -10,7 +10,7 @@ Usage:
     ./test_selinux_policy.py
 
     # Test specific distros
-    ./test_selinux_policy.py --distros rocky10,fedora42
+    ./test_selinux_policy.py --distros rocky10,fedora44
 
     # Build policy from source and test
     ./test_selinux_policy.py --build
@@ -656,7 +656,7 @@ Examples:
   %(prog)s
 
   # Test specific distros
-  %(prog)s --distros rocky10,fedora42
+  %(prog)s --distros rocky10,fedora44
 
   # Test with verbose output
   %(prog)s --verbose


### PR DESCRIPTION
Fedora 44 was released on [the 28th of April and 42 was EoL on the 13th of May](https://fedorapeople.org/groups/schedule/f-44/f-44-key-tasks.html).

Both the fedora 43 and 44 version works well on Fedora 44, so I assume it's not necessary with any changes to build process.

Tested on Fedora 44. I built the package on my machine and installed it into a test VM. Since it already had Himmelblau installed, I did not perform the register step and only tested authentication.
I built the package for Fedora 44 with `make fedora44`.
I've run `make test` and `make test-selinux`

<!-- himmelblau-review-checklist:start -->
## Required Before Review

Please complete this checklist. **PRs will be ignored until these steps are completed.**

- [x] I manually tested this change on a test VM and confirmed it works as intended.
- [X] I listed exactly what testing I performed (commands/steps and observed results).
- [x] I listed which distro(s) and version(s) I tested on.
- [X] I ran relevant automated checks (for example `make test`, distro package build target, and `make test-selinux` when applicable) or explained why a check was not run.
- [X] If this change affects system integration (systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials), I documented the packaging/runtime impact and any generator/template sources updated.
- [x] I linked the related issue/enhancement/discussion and confirmed the PR scope is focused and reviewable.
<!-- himmelblau-review-checklist:end -->