### PR TITLE
nss: reject non-directory names before GetCredentialType probe

### DIFF
--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1609,7 +1609,13 @@ async fn main() -> ExitCode {
             };
 
             // Map the name
-            let account_id = cfg.map_name_to_upn(&account_id);
+            let account_id = match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => {
+                    error!("'{}' is not a valid directory user", account_id);
+                    return ExitCode::FAILURE;
+                }
+            };
 
             let opts = Options {
                 force_reauth,

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -38,7 +38,7 @@ use crate::constants::{
     DEFAULT_POLICIES_DB_DIR, DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX,
     DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
     DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE, DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE,
-    SERVER_CONFIG_PATH,
+    NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX, SERVER_CONFIG_PATH,
 };
 use crate::mapping::{MappedNameCache, Mode};
 use crate::unix_config::{HomeAttr, HsmType};
@@ -707,17 +707,26 @@ impl HimmelblauConfig {
         None
     }
 
-    /// This function attempts to convert a username to a valid UPN. On failure it
-    /// will leave the name as-is, and respond with the original input. Himmelblau
-    /// will reject the authentication attempt if the username isn't a valid UPN.
-    pub fn map_name_to_upn(&self, account_id: &str) -> String {
+    /// Convert a login name to a UPN, or `None` if it cannot be a directory user
+    /// (empty, or a known local-only name). Callers treat `None` as user-unknown
+    /// and must not look it up against Entra. See himmelblau-idm/himmelblau#1392.
+    pub fn map_name_to_upn(&self, account_id: &str) -> Option<String> {
+        self.map_name_to_upn_impl(account_id, "/etc/passwd")
+    }
+
+    /// Inner impl with an injectable passwd path for hermetic unit tests.
+    fn map_name_to_upn_impl(&self, account_id: &str, passwd_path: &str) -> Option<String> {
         let name_mapping_script = self.get_name_mapping_script();
         let cn_name_mapping = self.get_cn_name_mapping();
         let domains = self.get_configured_domains();
 
+        if account_id.trim().is_empty() {
+            return None;
+        }
+
         // Make sure this account_id isn't a local user
         let mut contents = vec![];
-        if let Ok(mut file) = File::open("/etc/passwd") {
+        if let Ok(mut file) = File::open(passwd_path) {
             let _ = file.read_to_end(&mut contents);
         }
         let local_users = parse_etc_passwd(contents.as_slice()).unwrap_or_default();
@@ -727,11 +736,19 @@ impl HimmelblauConfig {
             .collect::<Vec<String>>()
             .contains(&account_id.to_string())
         {
-            return account_id.to_string();
+            return Some(account_id.to_string());
         }
 
-        // The name mapping script is expected to convert the input name to a UPN
-        // if a name is supplied, or to a name if the UPN is supplied.
+        // Local-only names probed by systemd/GDM at boot; never directory users.
+        if NSS_IGNORE_EXACT.contains(&account_id)
+            || NSS_IGNORE_PREFIX
+                .iter()
+                .any(|prefix| account_id.starts_with(prefix))
+        {
+            return None;
+        }
+
+        // Empty script output signals "not a directory user" -> None.
         if !account_id.contains('@') {
             if let Some(name_mapping_script) = &name_mapping_script {
                 let name_cache = MappedNameCache::new(MAPPED_NAME_CACHE, &Mode::ReadWrite).ok();
@@ -742,6 +759,9 @@ impl HimmelblauConfig {
                     Ok(output) => {
                         if output.status.success() {
                             let upn = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                            if upn.is_empty() {
+                                return None;
+                            }
                             if let Some(name_cache) = &name_cache {
                                 // Failing to insert a name map is not a critical failure.
                                 if let Err(e) = name_cache.insert_mapping(&upn, account_id) {
@@ -751,7 +771,7 @@ impl HimmelblauConfig {
                                     );
                                 }
                             }
-                            return upn;
+                            return Some(upn);
                         } else {
                             error!("Script execution failed with error: {:?}", output.status);
                         }
@@ -773,9 +793,9 @@ impl HimmelblauConfig {
             }
         }
         if cn_name_mapping && !account_id.contains('@') && !domains.is_empty() {
-            return format!("{}@{}", account_id, domains[0]);
+            return Some(format!("{}@{}", account_id, domains[0]));
         }
-        account_id.to_string()
+        Some(account_id.to_string())
     }
 
     /// This function maps a UPN to a mapped name. If a mapping script is
@@ -878,6 +898,13 @@ mod tests {
     fn create_temp_config(contents: &str) -> String {
         let file_path = format!("/tmp/himmelblau_test_config_{}.ini", uuid::Uuid::new_v4());
         fs::write(&file_path, contents).expect("Failed to write temporary config file");
+        file_path
+    }
+
+    // Throwaway passwd file so map_name_to_upn_impl can be tested hermetically.
+    fn create_temp_passwd(contents: &str) -> String {
+        let file_path = format!("/tmp/himmelblau_test_passwd_{}", uuid::Uuid::new_v4());
+        fs::write(&file_path, contents).expect("Failed to write temporary passwd file");
         file_path
     }
 
@@ -1757,74 +1784,153 @@ mod tests {
         assert_eq!(config_missing.get_name_mapping_script(), None);
     }
 
+    const PASSWD_MINIMAL: &str = "root:x:0:0:root:/root:/bin/bash\n";
+
     #[test]
     fn test_map_name_to_upn_script_execution_success() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
         name_mapping_script = ../../scripts/test_script_echo.sh
         domains = example.com
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-        let expected_output = "user";
-
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
         assert_eq!(
-            config.map_name_to_upn(account_id),
-            expected_output.to_string()
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user".to_string())
         );
     }
 
     #[test]
     fn test_map_name_to_upn_local_user() {
-        // Simulate a local user in /etc/passwd
-        let account_id = "localuser";
-
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
-        "#;
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(&format!(
+            "{}localuser:x:1000:1000::/home/localuser:/bin/bash\n",
+            PASSWD_MINIMAL
+        ));
+        assert_eq!(
+            config.map_name_to_upn_impl("localuser", &passwd),
+            Some("localuser".to_string())
+        );
+    }
 
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        // Simulating presence of local user
-        assert_eq!(config.map_name_to_upn(account_id), account_id.to_string());
+    #[test]
+    fn test_map_name_to_upn_local_user_wins_over_ignore_list() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(&format!(
+            "{}systemd-coredump:x:999:999::/run/systemd:/usr/sbin/nologin\n",
+            PASSWD_MINIMAL
+        ));
+        assert_eq!(
+            config.map_name_to_upn_impl("systemd-coredump", &passwd),
+            Some("systemd-coredump".to_string())
+        );
     }
 
     #[test]
     fn test_map_name_to_upn_add_domain() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
         cn_to_upn_mapping = true
         domains = example.com
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-        let expected_output = "user@example.com";
-
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
         assert_eq!(
-            config.map_name_to_upn(account_id),
-            expected_output.to_string()
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_map_name_to_upn_empty_is_none() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(config.map_name_to_upn_impl("", &passwd), None);
+        assert_eq!(config.map_name_to_upn_impl("   ", &passwd), None);
+    }
+
+    #[test]
+    fn test_map_name_to_upn_ignored_names_are_none() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        for name in [
+            "gdm",
+            "sssd",
+            "systemd-coredump",
+            "gnome-initial-setup",
+            "gdm-greeter",
+            "gdm-greeter-2",
+            "gdm-greeter-9",
+            "pam_unix_non_existent",
+            "pam_unix_non_existent:",
+        ] {
+            assert_eq!(
+                config.map_name_to_upn_impl(name, &passwd),
+                None,
+                "{name} should be None"
+            );
+        }
+    }
+
+    #[test]
+    fn test_map_name_to_upn_prefix_does_not_overmatch() {
+        // A real user whose name merely starts with "gdm" must NOT be ignored.
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(
+            config.map_name_to_upn_impl("gdmitrij.popov", &passwd),
+            Some("gdmitrij.popov@example.com".to_string())
         );
     }
 
     #[test]
     fn test_map_name_to_upn_no_mapping() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-
-        assert_eq!(config.map_name_to_upn(account_id), account_id.to_string());
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user".to_string())
+        );
     }
 
     #[test]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -64,6 +64,10 @@ pub const DEFAULT_ID_ATTR_MAP: IdAttr = IdAttr::Name;
 pub const BROKER_APP_ID: &str = "29d9ed98-a469-4536-ade2-f981bc1d605e";
 pub const BROKER_CLIENT_IDENT: &str = "38aa3b87-a06d-4817-b275-7a316988d93b";
 pub const CN_NAME_MAPPING: bool = true;
+// Local-only names that must never be mapped to a UPN / looked up in Entra.
+// See himmelblau-idm/himmelblau#1392.
+pub const NSS_IGNORE_EXACT: &[&str] = &["gdm", "sssd", "systemd-coredump", "gnome-initial-setup"];
+pub const NSS_IGNORE_PREFIX: &[&str] = &["gdm-greeter", "pam_unix_non_existent"]; // variable suffix
 pub const DEFAULT_HELLO_PIN_MIN_LEN: usize = 6;
 pub const DEFAULT_HELLO_PIN_RETRY_COUNT: u32 = 3;
 pub const DEFAULT_KERBEROS_CONF_DIR: &str = "/etc/krb5.conf.d/";

--- a/src/nss/src/implementation.rs
+++ b/src/nss/src/implementation.rs
@@ -223,7 +223,10 @@ impl PasswdHooks for HimmelblauPasswd {
             (name.to_lowercase(), Some(local))
         } else {
             // No mapping - use standard cn_name_mapping
-            (cfg.map_name_to_upn(&name), None)
+            match cfg.map_name_to_upn(&name) {
+                Some(upn) => (upn, None),
+                None => return Response::NotFound,
+            }
         };
 
         let req = ClientRequest::NssAccountByName(upn.clone());
@@ -375,7 +378,10 @@ impl GroupHooks for HimmelblauGroup {
         if is_local_group(&cfg.map_upn_to_name(&name)) {
             return Response::NotFound;
         }
-        let upn = cfg.map_name_to_upn(&name);
+        let upn = match cfg.map_name_to_upn(&name) {
+            Some(upn) => upn,
+            None => return Response::NotFound,
+        };
         let mut daemon_client = match DaemonClientBlocking::new(cfg.get_socket_path().as_str()) {
             Ok(dc) => dc,
             Err(_) => {
@@ -528,7 +534,10 @@ pub unsafe extern "C" fn _nss_himmelblau_initgroups_dyn(
     let user_map = UserMap::new(&cfg.get_user_map_file());
     let account_id = match user_map.get_upn_from_local(c_user) {
         Some(upn) => upn,
-        None => cfg.map_name_to_upn(c_user),
+        None => match cfg.map_name_to_upn(c_user) {
+            Some(upn) => upn,
+            None => return NSS_STATUS_NOTFOUND,
+        },
     };
     let req = ClientRequest::NssInitgroups(account_id);
 

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -265,7 +265,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
         let req = ClientRequest::PamAccountAllowed(account_id);
         // PamResultCode::PAM_IGNORE
@@ -377,7 +380,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         let authtok = match pamh.get_authtok() {
@@ -490,7 +496,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         // Local user (no UPN): not a Himmelblau/Entra account. Return PAM_IGNORE
@@ -1002,7 +1011,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         let req = ClientRequest::PamAccountBeginSession(account_id);


### PR DESCRIPTION
## Summary

`map_name_to_upn` returns `Option<String>`, yielding `None` for names that cannot represent a directory user so callers skip the lookup instead of round-tripping to Entra's pre-auth `GetCredentialType` endpoint (per-IP rate-limited; treats unknown-UPN probes as username enumeration). Addresses #1392.

## What Changed

- `map_name_to_upn` now returns `None` for: empty/whitespace input; a built-in local-only name list — exact `gdm`/`sssd`/`systemd-coredump`/`gnome-initial-setup`, prefix `gdm-greeter` (covers `gdm-greeter-<N>`) and `pam_unix_non_existent`; and a `name_mapping_script` that emits empty output (lets operators express an allowlist in userspace).
- Local-user (`/etc/passwd`) resolution keeps priority over the ignore list.
- Callers treat `None` as user-unknown: NSS → `NotFound`, PAM → `PAM_IGNORE`, CLI → error.
- Split into `map_name_to_upn_impl(account_id, passwd_path)` so the local-user precedence is unit-tested hermetically.
- Replaces the previous log-only `other_module_warn_users` list (4 hardcoded names, no short-circuit, no `-N` coverage).

## Testing

- **Distro(s) tested:** Ubuntu 25.10 thinclient image (himmelblaud 4.0.0).
- **Steps performed:** booted a netboot testbox with the change; transparently captured `login.microsoftonline.com` via mitmproxy across a full boot + interactive login; probed the ignored names and a dotted control name through NSS.
- **Results observed:** zero `GetCredentialType` requests for `systemd-coredump`/`gdm-greeter`/`gdm-greeter-2`/`gnome-initial-setup`/`vishal`/`pam_unix_non_existent` (daemon never contacted); a dotted name (`zzztest.zzzuser`) correctly reached the daemon; real `firstname.lastname` login succeeded; GDM greeter session registered normally. 8 new/updated unit tests pass.

## Automated Checks

- [x] I ran `cargo test -p himmelblau_unix_common` (map_name_to_upn suite, 8 passing) and `cargo check` on the nss/pam/cli/daemon crates. Did not run the full `make test`.
- [ ] I ran the distro package build target — built via the downstream thinclient image (cargo-deb) rather than the in-repo target.
- [ ] `make test-selinux` — N/A (no SELinux policy change).

## System Integration Impact

Affects NSS and PAM behaviour: names that can't be directory users now resolve as `NotFound` (NSS) / `PAM_IGNORE` (PAM) without contacting the daemon, instead of being synthesised into a UPN and queried against Entra. Real local accounts (`/etc/passwd`) are unaffected — they keep priority. No systemd/SELinux/AppArmor/path/credential changes.

## Checklist

- [x] I manually tested this change on a test VM
- [x] PR scope is focused and linked to an issue/enhancement/discussion

## AI-assistance disclosure
I used claude code to write this PR.