### PR TITLE
tpm: fix validate_hsm_pin_path to accept real state and credential dirs

### DIFF
--- a/src/common/src/tpm.rs
+++ b/src/common/src/tpm.rs
@@ -49,11 +49,20 @@ fn validate_hsm_pin_path(hsm_pin_path: &str) -> Result<PathBuf, Box<dyn Error>> 
         }
     })?;
 
-    if !canonical.starts_with("/var/lib/himmelblau") {
+    // Accept the himmelblaud state directory (with and without the systemd
+    // DynamicUser `/var/lib/private/` prefix) and the runtime credentials
+    // directory that `LoadCredentialEncrypted=` materialises for the unit.
+    const ALLOWED_PREFIXES: &[&str] = &[
+        "/var/lib/himmelblaud",
+        "/var/lib/private/himmelblaud",
+        "/run/credentials/himmelblaud.service",
+    ];
+    if !ALLOWED_PREFIXES.iter().any(|p| canonical.starts_with(p)) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             format!(
-                "HSM PIN path must be within /var/lib/himmelblau/, got: {}",
+                "HSM PIN path must be within one of {:?}, got: {}",
+                ALLOWED_PREFIXES,
                 canonical.display()
             ),
         )


### PR DESCRIPTION
## Problem

`himmelblaud.service` cannot start on any system: it exits with code 1 in a restart loop and the journal shows:

```
ERROR Failed to create HSM PIN into /run/credentials/himmelblaud.service/hsm-pin
err: PermissionDenied, "HSM PIN path must be within /var/lib/himmelblau/,
     got: /run/credentials/himmelblaud.service/hsm-pin"
```

## Root cause

`validate_hsm_pin_path()` in `src/common/src/tpm.rs` enforces:

```rust
```

`Path::starts_with` matches **whole path components**, so the string `/var/lib/himmelblau` (no trailing `d`) is **never** a component prefix of the real state directory `/var/lib/himmelblaud`. This contradicts:

- `DEFAULT_HSM_PIN_PATH` = `/var/lib/himmelblaud/hsm-pin`
- `DEFAULT_HSM_PIN_PATH_ENC` = `/var/lib/himmelblaud/hsm-pin-nopcr.enc`
- `StateDirectory=himmelblaud` in `himmelblaud.service`
- `LoadCredentialEncrypted=hsm-pin:/var/lib/himmelblaud/hsm-pin-nopcr.enc` in `himmelblaud.service`

So `decrypt_hsm_pin(DEFAULT_HSM_PIN_PATH_ENC)` is rejected before it ever calls `systemd-creds`, and the fallback `write_hsm_pin($cfg.get_hsm_pin_path())` is also rejected because the env-supplied path `/run/credentials/himmelblaud.service/hsm-pin` (from `Environment=HIMMELBLAU_HSM_PIN_PATH=%d/hsm-pin`) is likewise not under the typo'd prefix.

## Fix

Replace the single `starts_with` check with an explicit allowlist of the three legitimate locations that the systemd unit and constants actually use:

- `/var/lib/himmelblaud` — state dir, plain
- `/var/lib/private/himmelblaud` — state dir as resolved under `DynamicUser=yes`
- `/run/credentials/himmelblaud.service` — `LoadCredentialEncrypted=` materialised path

This restores the safety intent of the original check (PIN must live in one of a small set of trusted directories) while letting the daemon's normal paths through.

## Verification

Reproduced the restart loop on Fedora 44 with the released `himmelblau-4.0.0-1` RPM. After rebuilding the `himmelblau`, `himmelblau-broker`, and `pam-himmelblau` packages with this patch and reinstalling:

```
$ systemctl status himmelblaud
● himmelblaud.service - Himmelblau Authentication Daemon
     Active: active (running) ...
     ...himmelblaud[...]: INFO [info]: Server started ...
```

Daemon now opens the TPM, restores broker PRTs from the FD store, and serves requests normally.

## Packaging impact

None beyond the source change. No systemd unit, PAM/NSS, authselect, SELinux, or filesystem-path changes.