### PR TITLE
Revert "Fix broker expiresOn unit conversion"

### DIFF
--- a/src/daemon/src/broker.rs
+++ b/src/daemon/src/broker.rs
@@ -180,7 +180,7 @@ impl HimmelblauBroker for Broker {
                     .ok_or("Failed to fetch access token")?,
                 "accessTokenType": 0,
                 "clientInfo": URL_SAFE_NO_PAD.encode(json!(&token.client_info).to_string()),
-                "expiresOn": now.as_millis() + u128::from(token.expires_in) * 1000,
+                "expiresOn": (token.expires_in as u128) + now.as_millis(),
                 "extendedExpiresOn": (token.ext_expires_in as u64) + now.as_secs(),
                 "grantedScopes": token.scope.clone()
                     .ok_or("Failed to fetch scopes")?,


### PR DESCRIPTION
This reverts commit df79f6cf3f26325b74e0a61e9f8631415fab2607.

## Summary

The original fix from https://github.com/himmelblau-idm/himmelblau/pull/1370 appears to have broken Himmelblau. Tokens now expire rapidly, which forces frequent re-authentication.

## What Changed

Commit was reverted.

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
