### PR TITLE
Continue the never-ending chase for SELinux support

### DIFF
--- a/src/selinux/src/himmelblaud.te
+++ b/src/selinux/src/himmelblaud.te
@@ -596,8 +596,7 @@ optional {
 	allow himmelblaud_tasks_t systemd_unit_file_t:dir getattr;
 	allow himmelblaud_tasks_t init_var_run_t:sock_file write;
 	allow himmelblaud_tasks_t init_t:process { rlimitinh siginh noatsecure };
-	allow himmelblaud_tasks_t root_t:dir search;
-	allow himmelblaud_tasks_t root_t:dir getattr;
+	allow himmelblaud_tasks_t root_t:dir { search getattr open read };
 	allow himmelblaud_tasks_t bin_t:dir search;
 	allow himmelblaud_tasks_t himmelblaud_tasks_exec_t:file { getattr open read execute map };
 	allow himmelblaud_tasks_t himmelblaud_t:unix_stream_socket connectto;
@@ -1161,6 +1160,8 @@ optional {
 		type postfix_pickup_t;
 	}
 	allow postfix_pickup_t himmelblau_etc_t:dir search;
+	allow postfix_pickup_t himmelblau_etc_t:file { getattr };
+	allow postfix_pickup_t himmelblau_var_cache_t:dir search;
 	allow postfix_pickup_t himmelblau_var_cache_t:lnk_file read;
 }
 
@@ -1171,6 +1172,8 @@ optional {
 		type postfix_qmgr_t;
 	}
 	allow postfix_qmgr_t himmelblau_etc_t:dir search;
+	allow postfix_qmgr_t himmelblau_etc_t:file { getattr };
+	allow postfix_qmgr_t himmelblau_var_cache_t:dir search;
 	allow postfix_qmgr_t himmelblau_var_cache_t:lnk_file read;
 }
 


### PR DESCRIPTION
## Summary

Every few weeks SELinux breaks _again_. Fixing denials from openSUSE Tumbleweed.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
