### PR TITLE
Fix Chrome ExtensionInstallForcelist missing update URL

### DIFF
--- a/src/sso-policies/src/chrome/policies.json
+++ b/src/sso-policies/src/chrome/policies.json
@@ -1,5 +1,5 @@
 {
   "ExtensionInstallForcelist": [
-    "jlnfnnolkbjieggibinobhkjdfbpcohn"
+    "jlnfnnolkbjieggibinobhkjdfbpcohn;https://clients2.google.com/service/update2/crx"
   ]
 }

--- a/src/sso/src/chrome/policies.json
+++ b/src/sso/src/chrome/policies.json
@@ -1,5 +1,5 @@
 {
   "ExtensionInstallForcelist": [
-    "jlnfnnolkbjieggibinobhkjdfbpcohn"
+    "jlnfnnolkbjieggibinobhkjdfbpcohn;https://clients2.google.com/service/update2/crx"
   ]
 }


### PR DESCRIPTION
## Summary

The Siemens linux-entra-sso extension was not being installed in Chrome/Chromium after installing `himmelblau-sso-policies`. The `ExtensionInstallForcelist` policy entry was missing the required update URL, causing Chrome to silently ignore it.

## What Changed

- `src/sso/src/chrome/policies.json` — appended `;https://clients2.google.com/service/update2/crx` to the extension ID in `ExtensionInstallForcelist`
- `src/sso-policies/src/chrome/policies.json` — same fix

Chrome's `ExtensionInstallForcelist` policy requires entries in the format `extensionID;updateURL`. A bare extension ID is not valid and is silently ignored.

**Root cause context:** The extension previously installed via Chrome's External Extensions directory (`/usr/share/google-chrome/extensions/`), which `himmelblau-sso` still ships. Newer Chrome versions deprecated the `external_update_url` mechanism in that directory for Chrome Web Store extensions, leaving `ExtensionInstallForcelist` as the only working path — which was broken due to the missing URL.

## Testing

On a test VM with `himmelblau-sso-policies` installed:
1. Rebuild the package (`make ubuntu24.04` or equivalent distro target)
2. Install the updated package on the test VM
3. Open Chrome/Chromium and navigate to `chrome://extensions`
4. Verify the Siemens linux-entra-sso extension (`jlnfnnolkbjieggibinobhkjdfbpcohn`) appears as force-installed

## Automated Checks

No new code introduced — policy JSON files only. Existing CI/packaging tests apply.

## System Integration Impact

- Affects `/etc/opt/chrome/policies/managed/himmelblau.json` and `/etc/chromium/policies/managed/himmelblau.json` (both installed by the package)
- No changes to PAM/NSS/authselect, systemd units, SELinux policy, or credential handling

## Checklist

- [x] Change is limited in scope and reviewable
- [x] Both `src/sso/` and `src/sso-policies/` copies updated consistently
- [x] No generated files modified directly
- [x] Packaging impact noted above