### PR TITLE
ci: add OBS auto-update workflow for stable-3.x

### DIFF
--- a/.github/workflows/obs-update.yml
+++ b/.github/workflows/obs-update.yml
@@ -1,0 +1,198 @@
+---
+name: Update OBS Package
+
+permissions:
+  contents: read
+
+# Trigger on pushes to stable-3.x branch, with a manual fallback for
+# exceptional maintenance updates such as direct CVE fixes.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - stable-3.x
+
+jobs:
+  update-obs:
+    name: Update Tumbleweed Package on OBS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for version detection
+
+      - name: Install osc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y osc
+
+      - name: Setup unique branch project
+        id: branch
+        run: |
+          # Create unique branch project name using run ID and attempt
+          BRANCH_PROJECT="home:${{ secrets.OBS_USER }}:branches:network:idm:gh${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "branch_project=$BRANCH_PROJECT" >> "$GITHUB_OUTPUT"
+          echo "Using branch project: $BRANCH_PROJECT"
+
+      - name: Branch package from network:idm
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_TOKEN: ${{ secrets.OBS_TOKEN }}
+        run: |
+          # Create config only when needed, in-memory where possible
+          OSC_CONFIG="$HOME/.config/osc/oscrc"
+          trap 'rm -f "$OSC_CONFIG"' EXIT
+          mkdir -p ~/.config/osc
+          cat > "$OSC_CONFIG" << EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = $OBS_USER
+          pass = $OBS_TOKEN
+          EOF
+          chmod 600 "$OSC_CONFIG"
+
+          WORKDIR="/tmp/obs-work"
+          mkdir -p "$WORKDIR"
+          cd "$WORKDIR"
+
+          # Branch to unique project name to avoid conflicts
+          osc branch network:idm himmelblau ${{ steps.branch.outputs.branch_project }}
+
+          echo "Branched to: ${{ steps.branch.outputs.branch_project }}"
+
+      - name: Checkout branched package
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_TOKEN: ${{ secrets.OBS_TOKEN }}
+        run: |
+          # Recreate config for this operation
+          OSC_CONFIG="$HOME/.config/osc/oscrc"
+          trap 'rm -f "$OSC_CONFIG"' EXIT
+          mkdir -p ~/.config/osc
+          cat > "$OSC_CONFIG" << EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = $OBS_USER
+          pass = $OBS_TOKEN
+          EOF
+          chmod 600 "$OSC_CONFIG"
+
+          WORKDIR="/tmp/obs-work"
+          cd "$WORKDIR"
+          osc co "${{ steps.branch.outputs.branch_project }}/himmelblau"
+          cd "${{ steps.branch.outputs.branch_project }}/himmelblau"
+          ls -la
+
+      - name: Update package sources
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_TOKEN: ${{ secrets.OBS_TOKEN }}
+        run: |
+          # Recreate config
+          OSC_CONFIG="$HOME/.config/osc/oscrc"
+          trap 'rm -f "$OSC_CONFIG"' EXIT
+          mkdir -p ~/.config/osc
+          cat > "$OSC_CONFIG" << EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = $OBS_USER
+          pass = $OBS_TOKEN
+          EOF
+          chmod 600 "$OSC_CONFIG"
+
+          WORKDIR="/tmp/obs-work"
+          cd "$WORKDIR/${{ steps.branch.outputs.branch_project }}/himmelblau"
+
+          # Find and remove old tarball
+          OLD_TARBALL=$(find . -maxdepth 1 -type f -name 'himmelblau-*.tar.gz' -exec basename {} \; | head -n 1)
+          if [ -n "$OLD_TARBALL" ]; then
+            echo "Removing old tarball: $OLD_TARBALL"
+            osc rm "$OLD_TARBALL"
+          fi
+
+          # Run service to update spec, changes, AND create new tarball
+          osc service mr
+
+          # Find and add the new tarball created by the service
+          NEW_TARBALL=$(find . -maxdepth 1 -type f -name 'himmelblau-*.tar.gz' -exec basename {} \; | head -n 1)
+          if [ -n "$NEW_TARBALL" ]; then
+            echo "Adding new tarball: $NEW_TARBALL"
+            osc add "$NEW_TARBALL"
+          else
+            echo "Error: No tarball found after service run"
+            exit 1
+          fi
+
+          # Show what changed
+          osc status
+          osc diff || true
+
+      - name: Commit and submit changes
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_TOKEN: ${{ secrets.OBS_TOKEN }}
+        run: |
+          # Recreate config
+          OSC_CONFIG="$HOME/.config/osc/oscrc"
+          trap 'rm -f "$OSC_CONFIG"' EXIT
+          mkdir -p ~/.config/osc
+          cat > "$OSC_CONFIG" << EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = $OBS_USER
+          pass = $OBS_TOKEN
+          EOF
+          chmod 600 "$OSC_CONFIG"
+
+          WORKDIR="/tmp/obs-work"
+          cd "$WORKDIR/${{ steps.branch.outputs.branch_project }}/himmelblau"
+
+          # Commit changes to the branch
+          osc commit -m "Update from GitHub stable-3.x"
+
+          # Submit back to network:idm/himmelblau
+          osc sr network:idm himmelblau -m "Automated update from GitHub Actions stable-3.x branch
+
+          Changes:
+          - Source tarball, spec, and changes files updated via osc service
+
+          Source: https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+
+          echo "Submit request created successfully"
+
+      - name: Cleanup branch project
+        if: always()
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_TOKEN: ${{ secrets.OBS_TOKEN }}
+        run: |
+          # Recreate config one last time
+          OSC_CONFIG="$HOME/.config/osc/oscrc"
+          trap 'rm -f "$OSC_CONFIG"' EXIT
+          mkdir -p ~/.config/osc
+          cat > "$OSC_CONFIG" << EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = $OBS_USER
+          pass = $OBS_TOKEN
+          EOF
+          chmod 600 "$OSC_CONFIG"
+
+          # Delete the temporary branch project after submission
+          osc rdelete -m "Cleanup after automated submission" ${{ steps.branch.outputs.branch_project }} || true


### PR DESCRIPTION
## Summary

This workflow automatically submits Himmelblau updates to build.opensuse.org (Tumbleweed) when changes are pushed to the stable-3.x branch. It branches network:idm/himmelblau to a unique project name using the GitHub run ID to avoid conflicts between concurrent runs, uses osc service to update the spec/changes files and generate the source tarball, then submits back to network:idm. Credentials are created and immediately destroyed after each step to minimize the attack surface.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
