### PR TITLE
Make MFA poll prompt services configurable

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -1,4 +1,4 @@
-.TH HIMMELBLAU.CONF "5" "May 2026" "Himmelblau Configuration" "File Formats"
+.TH HIMMELBLAU.CONF "5" "June 2026" "Himmelblau Configuration" "File Formats"
 .SH NAME
 himmelblau.conf \- Configuration file for Himmelblau, enabling Azure Entra ID authentication on Linux.
 
@@ -321,6 +321,27 @@ Default: ssh,telnet,ftp,rsh,rlogin,rexec,vnc,xrdp,cockpit,mosh
 
 .P
 Example: password_only_remote_services_deny_list = ssh,telnet,vnc,xrdp
+
+.TP
+.B mfa_poll_prompt_services
+.RE
+A comma-separated list of PAM service names that should receive an input prompt
+after Himmelblau prints MFA polling text. This is required for PAM consumers
+that do not display
+.B PAM_TEXT_INFO
+messages until an input prompt is shown.
+
+This setting only applies when the
+.B mfa_poll_prompt
+PAM module option is enabled.
+
+Entries are matched as substrings, so "ssh" will match "ssh", "sshd", "openssh", etc.
+
+.P
+Default: ssh,cockpit
+
+.P
+Example: mfa_poll_prompt_services = ssh,cockpit
 
 .TP
 .B mfa_method

--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -37,10 +37,12 @@ fallback to local authentication via subsequent PAM modules.
 .PD 0
 .P
 .PD
-Workaround for OpenSSH Bug 2876, which prevents PAM messages from being
-flushed to stdout until after sending a prompt for input.
-This workaround causes pam to prompt the user to `press enter to
-continue' when polling on another device for MFA.
+Workaround for PAM consumers such as OpenSSH and Cockpit that do not
+display MFA polling messages until after an input prompt is sent.
+This causes PAM to prompt the user to `press enter to continue' when
+polling on another device for MFA.
+Matching services are configured with
+\f[CR]mfa_poll_prompt_services\f[R] in \f[CR]himmelblau.conf\f[R].
 .IP \(bu 2
 \f[B]no_hello_pin\f[R]
 .PD 0

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -24,7 +24,7 @@
   Returns `PAM_IGNORE` for users not in Entra ID, allowing fallback to local authentication via subsequent PAM modules.
 
 - **mfa_poll_prompt**  
-  Workaround for OpenSSH Bug 2876, which prevents PAM messages from being flushed to stdout until after sending a prompt for input. This workaround causes pam to prompt the user to 'press enter to continue' when polling on another device for MFA.
+  Workaround for PAM consumers such as OpenSSH and Cockpit that do not display MFA polling messages until after an input prompt is sent. This causes PAM to prompt the user to 'press enter to continue' when polling on another device for MFA. Matching services are configured with `mfa_poll_prompt_services` in `himmelblau.conf`.
 
 - **no_hello_pin**  
   Disables Linux Hello PIN login for this service (e.g., for `sudo` or `ssh`), even if Hello is configured globally.

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -235,7 +235,7 @@ in
 
     password_only_remote_services_deny_list = mkOption {
       type = types.nullOr (types.listOf types.str);
-      default = [ ];
+      default = [ "ssh" "telnet" "ftp" "rsh" "rlogin" "rexec" "vnc" "xrdp" "cockpit" "mosh" ];
       description = ''
         A comma-separated list of PAM service names that should always require MFA,
         regardless of the
@@ -254,7 +254,7 @@ in
 
     mfa_poll_prompt_services = mkOption {
       type = types.nullOr (types.listOf types.str);
-      default = [ ];
+      default = [ "ssh" "cockpit" ];
       description = ''
         A comma-separated list of PAM service names that should receive an input prompt
         after Himmelblau prints MFA polling text. This is required for PAM consumers

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -252,6 +252,25 @@ in
       example = [ "ssh" "telnet" "vnc" "xrdp" ];
     };
 
+    mfa_poll_prompt_services = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = [ ];
+      description = ''
+        A comma-separated list of PAM service names that should receive an input prompt
+        after Himmelblau prints MFA polling text. This is required for PAM consumers
+        that do not display
+        **PAM_TEXT_INFO**
+        messages until an input prompt is shown.
+        
+        This setting only applies when the
+        **mfa_poll_prompt**
+        PAM module option is enabled.
+        
+        Entries are matched as substrings, so "ssh" will match "ssh", "sshd", "openssh", etc.
+      '';
+      example = [ "ssh" "cockpit" ];
+    };
+
     mfa_method = mkOption {
       type = types.nullOr (types.str);
       default = null;

--- a/src/common/docs-xml/himmelblauconf/base/mfa_poll_prompt_services.xml
+++ b/src/common/docs-xml/himmelblauconf/base/mfa_poll_prompt_services.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="mfa_poll_prompt_services"
+                      section="global"
+                      type="string_list"
+                      rust_type="Vec&lt;String&gt;"
+                      documented="true"
+                      domain_specific="false"
+                      order="1510"
+                     >
+<description>
+A comma-separated list of PAM service names that should receive an input prompt
+after Himmelblau prints MFA polling text. This is required for PAM consumers
+that do not display
+.B PAM_TEXT_INFO
+messages until an input prompt is shown.
+
+This setting only applies when the
+.B mfa_poll_prompt
+PAM module option is enabled.
+
+Entries are matched as substrings, so "ssh" will match "ssh", "sshd", "openssh", etc.
+</description>
+<conf_description>PAM services that need MFA poll prompt flushing.</conf_description>
+<default>ssh,cockpit</default>
+<default_const>DEFAULT_MFA_POLL_PROMPT_SERVICES</default_const>
+<example>mfa_poll_prompt_services = ssh,cockpit</example>
+</parameter>

--- a/src/common/scripts/gen_param_code.py
+++ b/src/common/scripts/gen_param_code.py
@@ -980,7 +980,9 @@ def format_nix_default(param: Parameter) -> Optional[str]:
             return f'"{default}"'
 
     elif param_type == 'string_list':
-        return '[ ]'
+        items = [item.strip() for item in default.split(',') if item.strip()]
+        items_str = ' '.join(f'"{item}"' for item in items)
+        return f'[ {items_str} ]'
 
     elif param_type == 'enum':
         return f'"{default}"'

--- a/src/common/scripts/gen_param_code.py
+++ b/src/common/scripts/gen_param_code.py
@@ -291,9 +291,9 @@ def generate_rust_code(params: List[Parameter], sections: Dict[str, Section]) ->
         elif param.param_type == 'string_list':
             default_expr = param.default_const if param.default_const else f'DEFAULT_{param.name.upper()}'
             lines.append(f'        match self.config.get("{section}", "{param.name}") {{')
-            lines.append(f'            Some(val) => val.split(\',\').map(|s| s.trim().to_string()).collect(),')
+            lines.append(f'            Some(val) => val.split(\',\').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect(),')
             if param.default:
-                lines.append(f'            None => {default_expr}.split(\',\').map(|s| s.trim().to_string()).collect(),')
+                lines.append(f'            None => {default_expr}.split(\',\').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect(),')
             else:
                 lines.append('            None => vec![],')
             lines.append('        }')

--- a/src/common/src/auth.rs
+++ b/src/common/src/auth.rs
@@ -679,9 +679,9 @@ fn handle_pam_auth_response_mfapoll(
     // Necessary because of OpenSSH bug
     // https://bugzilla.mindrot.org/show_bug.cgi?id=2876 -
     // PAM_TEXT_INFO and PAM_ERROR_MSG conversation not
-    // honoured during PAM authentication. Only prompt if
-    // this is the ssh service and a message was sent.
-    if state.opts.mfa_poll_prompt && state.service.contains("ssh") && !msg.trim().is_empty() {
+    // honoured during PAM authentication. Some other PAM consumers, such as
+    // Cockpit, also need an input prompt before they display the message.
+    if should_prompt_mfa_poll(&state.service, &state.opts, &state.cfg, &msg) {
         state.msg_printer.prompt_echo_off("Press enter to continue");
     }
 
@@ -726,6 +726,20 @@ fn handle_pam_auth_response_mfapollwait(state: &mut AuthenticateState) -> PamWha
         poll_attempt: state.poll_attempt as u32,
     });
     PamWhatNext::Next(req)
+}
+
+fn should_prompt_mfa_poll(
+    service: &str,
+    opts: &Options,
+    cfg: &HimmelblauConfig,
+    msg: &str,
+) -> bool {
+    opts.mfa_poll_prompt
+        && !msg.trim().is_empty()
+        && cfg
+            .get_mfa_poll_prompt_services()
+            .iter()
+            .any(|s| service.contains(s))
 }
 
 enum PamWhatNext {
@@ -1306,5 +1320,129 @@ pub async fn authenticate_async(
             PamResultCode::PAM_SERVICE_ERR
         }
         Ok(r) => r,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn create_temp_config(contents: &str) -> String {
+        let file_path = format!(
+            "/tmp/himmelblau_auth_test_config_{}.ini",
+            uuid::Uuid::new_v4()
+        );
+        fs::write(&file_path, contents).expect("Failed to write temporary config file");
+        file_path
+    }
+
+    fn test_config(contents: &str) -> HimmelblauConfig {
+        let temp_file = create_temp_config(contents);
+        HimmelblauConfig::new(Some(&temp_file)).unwrap()
+    }
+
+    fn test_options(mfa_poll_prompt: bool) -> Options {
+        Options {
+            mfa_poll_prompt,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_should_prompt_mfa_poll_for_ssh_default() {
+        let cfg = test_config("");
+        let opts = test_options(true);
+
+        assert!(should_prompt_mfa_poll(
+            "sshd",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+    }
+
+    #[test]
+    fn test_should_prompt_mfa_poll_for_cockpit_default() {
+        let cfg = test_config("");
+        let opts = test_options(true);
+
+        assert!(should_prompt_mfa_poll(
+            "cockpit",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+    }
+
+    #[test]
+    fn test_should_prompt_mfa_poll_for_remote_cockpit_default() {
+        let cfg = test_config("");
+        let opts = test_options(true);
+
+        assert!(should_prompt_mfa_poll(
+            "remote:cockpit",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+    }
+
+    #[test]
+    fn test_should_not_prompt_mfa_poll_for_unmatched_service() {
+        let cfg = test_config("");
+        let opts = test_options(true);
+
+        assert!(!should_prompt_mfa_poll(
+            "login",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+    }
+
+    #[test]
+    fn test_should_not_prompt_mfa_poll_when_option_disabled() {
+        let cfg = test_config("");
+        let opts = test_options(false);
+
+        assert!(!should_prompt_mfa_poll(
+            "cockpit",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+    }
+
+    #[test]
+    fn test_should_not_prompt_mfa_poll_for_empty_message() {
+        let cfg = test_config("");
+        let opts = test_options(true);
+
+        assert!(!should_prompt_mfa_poll("cockpit", &opts, &cfg, "   "));
+    }
+
+    #[test]
+    fn test_should_prompt_mfa_poll_for_configured_service() {
+        let cfg = test_config(
+            r#"
+            [global]
+            mfa_poll_prompt_services = login
+            "#,
+        );
+        let opts = test_options(true);
+
+        assert!(should_prompt_mfa_poll(
+            "login",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
+        assert!(!should_prompt_mfa_poll(
+            "cockpit",
+            &opts,
+            &cfg,
+            "Approve sign-in"
+        ));
     }
 }

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -33,12 +33,13 @@ use crate::constants::{
     DEFAULT_CONSOLE_PASSWORD_ONLY, DEFAULT_DB_PATH, DEFAULT_FIDO_TIMEOUT, DEFAULT_HELLO_ENABLED,
     DEFAULT_HELLO_PIN_MIN_LEN, DEFAULT_HELLO_PIN_RETRY_COUNT, DEFAULT_HOME_ALIAS,
     DEFAULT_HOME_ATTR, DEFAULT_HOME_PREFIX, DEFAULT_HSM_PIN_PATH, DEFAULT_ID_ATTR_MAP,
-    DEFAULT_JOIN_TYPE, DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL,
-    DEFAULT_ORCHESTRATOR_SOCK_PATH, DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST,
-    DEFAULT_POLICIES_DB_DIR, DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX,
-    DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
-    DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE, DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE,
-    NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX, SERVER_CONFIG_PATH,
+    DEFAULT_JOIN_TYPE, DEFAULT_MFA_POLL_PROMPT_SERVICES, DEFAULT_ODC_PROVIDER,
+    DEFAULT_OFFLINE_BREAKGLASS_TTL, DEFAULT_ORCHESTRATOR_SOCK_PATH,
+    DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST, DEFAULT_POLICIES_DB_DIR,
+    DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX, DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL,
+    DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH, DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE,
+    DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE, NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX,
+    SERVER_CONFIG_PATH,
 };
 use crate::mapping::{MappedNameCache, Mode};
 use crate::unix_config::{HomeAttr, HsmType};
@@ -2167,6 +2168,63 @@ mod tests {
 
         let result = config.get_password_only_remote_services_deny_list();
         assert_eq!(result, vec!["ssh"]);
+    }
+
+    #[test]
+    fn test_get_mfa_poll_prompt_services_default_value() {
+        let config = create_empty_config();
+
+        let result = config.get_mfa_poll_prompt_services();
+        let expected: Vec<String> = DEFAULT_MFA_POLL_PROMPT_SERVICES
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(result, expected);
+        assert!(result.contains(&"ssh".to_string()));
+        assert!(result.contains(&"cockpit".to_string()));
+    }
+
+    #[test]
+    fn test_get_mfa_poll_prompt_services_comma_separated() {
+        let config_data = r#"
+        [global]
+        mfa_poll_prompt_services = ssh,cockpit,custom
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        let result = config.get_mfa_poll_prompt_services();
+        assert_eq!(result, vec!["ssh", "cockpit", "custom"]);
+    }
+
+    #[test]
+    fn test_get_mfa_poll_prompt_services_whitespace_trimming() {
+        let config_data = r#"
+        [global]
+        mfa_poll_prompt_services = ssh , cockpit,  custom
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        let result = config.get_mfa_poll_prompt_services();
+        assert_eq!(result, vec!["ssh", "cockpit", "custom"]);
+    }
+
+    #[test]
+    fn test_get_mfa_poll_prompt_services_empty_string() {
+        let config_data = r#"
+        [global]
+        mfa_poll_prompt_services =
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        let result = config.get_mfa_poll_prompt_services();
+        assert_eq!(result, Vec::<String>::new());
     }
 
     // Tests for parse_ttl_to_seconds()

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -60,6 +60,8 @@ pub const DEFAULT_CONSOLE_PASSWORD_ONLY: bool = true;
 // These are substring patterns matched via contains(), so "ssh" matches "sshd", "openssh", etc.
 pub const DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST: &str =
     "ssh,telnet,ftp,rsh,rlogin,rexec,vnc,xrdp,cockpit,mosh";
+// PAM services that need an input prompt to flush/display MFA poll messages.
+pub const DEFAULT_MFA_POLL_PROMPT_SERVICES: &str = "ssh,cockpit";
 pub const DEFAULT_ID_ATTR_MAP: IdAttr = IdAttr::Name;
 pub const BROKER_APP_ID: &str = "29d9ed98-a469-4536-ade2-f981bc1d605e";
 pub const BROKER_CLIENT_IDENT: &str = "38aa3b87-a06d-4817-b275-7a316988d93b";


### PR DESCRIPTION
## Summary

Add a generated mfa_poll_prompt_services option so Cockpit can use the same PAM prompt-flush workaround as SSH. The auth path now checks the configured service list, filters empty string-list values, and documents the new option.

Fixes #1453

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
