### PR TITLE
Improve #1206 resume/network recovery workaround

### DIFF
--- a/platform/common/NetworkManager/dispatcher.d/99-himmelblau-restart-on-down
+++ b/platform/common/NetworkManager/dispatcher.d/99-himmelblau-restart-on-down
@@ -4,22 +4,43 @@
 IFACE="${1:-}"
 ACTION="${2:-}"
 TAG="himmelblau-nm-dispatcher"
+SYSTEMD_RUN_DIR="${HIMMELBLAU_SYSTEMD_RUN_DIR:-/run/systemd/system}"
+LOCKFILE="${HIMMELBLAU_NM_LOCKDIR:-/run/himmelblau-nm-dispatcher.lock}"
+STAMP="${HIMMELBLAU_NM_STAMP:-/run/himmelblau-nm-dispatcher.last}"
+COOLDOWN_SECONDS=15
+STATUS_TIMEOUT_SECONDS=2
 
-case "$IFACE" in
-    ""|lo|docker*|virbr*|br-*|veth*|vnet*|tun*|tap*|wg*|ppp*)
-        exit 0
-        ;;
-esac
+log_skip() {
+    logger -t "$TAG" "Skipping $ACTION on ${IFACE:-none}: $1"
+}
+
+log_info() {
+    logger -t "$TAG" "$1"
+}
 
 case "$ACTION" in
     pre-down|down)
+        case "$IFACE" in
+            ""|lo|docker*|virbr*|br-*|veth*|vnet*|tun*|tap*|wg*|ppp*)
+                exit 0
+                ;;
+        esac
+        ;;
+    vpn-down)
+        ;;
+    connectivity-change)
+        case "${CONNECTIVITY_STATE:-unknown}" in
+            FULL|full)
+                exit 0
+                ;;
+        esac
         ;;
     *)
         exit 0
         ;;
 esac
 
-if [ ! -d /run/systemd/system ] || ! command -v systemctl >/dev/null 2>&1; then
+if [ ! -d "$SYSTEMD_RUN_DIR" ] || ! command -v systemctl >/dev/null 2>&1; then
     exit 0
 fi
 
@@ -27,12 +48,80 @@ state="$(systemctl is-active himmelblaud.service 2>/dev/null || true)"
 case "$state" in
     active|failed)
         ;;
+    activating|deactivating)
+        log_skip "himmelblaud.service is $state"
+        exit 0
+        ;;
     *)
+        log_skip "himmelblaud.service is $state"
         exit 0
         ;;
 esac
 
-logger -t "$TAG" "Network $IFACE going $ACTION - restarting himmelblaud.service"
-systemctl restart --no-block himmelblaud.service 2>&1 | logger -t "$TAG"
+restart_if_needed() {
+    now="$(date +%s 2>/dev/null || echo 0)"
+    last=0
+    if [ -r "$STAMP" ]; then
+        last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+    fi
+    case "$last" in
+        *[!0-9]*|"")
+            last=0
+            ;;
+    esac
+
+    if [ "$now" -gt 0 ] && [ "$last" -gt 0 ]; then
+        elapsed=$((now - last))
+        if [ "$elapsed" -ge 0 ] && [ "$elapsed" -lt "$COOLDOWN_SECONDS" ]; then
+            log_skip "restart cooldown active (${elapsed}s)"
+            exit 0
+        fi
+    fi
+
+    if [ "$state" = "active" ] && [ "$ACTION" != "pre-down" ]; then
+        if command -v aad-tool >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+            if timeout "$STATUS_TIMEOUT_SECONDS" aad-tool status 2>/dev/null | grep -qx "working!"; then
+                log_skip "himmelblaud.service is responsive"
+                exit 0
+            fi
+        fi
+    fi
+
+    if [ "$now" -gt 0 ]; then
+        printf '%s\n' "$now" >"$STAMP" 2>/dev/null || true
+    fi
+
+    logger -t "$TAG" "Network ${IFACE:-none} event $ACTION - restarting himmelblaud.service and himmelblaud-tasks.service"
+    systemctl restart --no-block himmelblaud.service himmelblaud-tasks.service 2>&1 | logger -t "$TAG"
+
+    exit 0
+}
+
+if [ -d "$LOCKFILE" ]; then
+    if rmdir "$LOCKFILE" 2>/dev/null; then
+        log_info "Removed stale dispatcher lock directory: $LOCKFILE"
+    else
+        log_skip "stale dispatcher lock directory is present"
+        exit 0
+    fi
+fi
+
+if command -v flock >/dev/null 2>&1; then
+    (
+        if ! exec 9>"$LOCKFILE"; then
+            log_skip "dispatcher lock file is unavailable"
+            exit 0
+        fi
+        if ! flock -n 9; then
+            log_skip "another dispatcher run is active"
+            exit 0
+        fi
+        restart_if_needed
+    )
+    exit $?
+fi
+
+log_info "flock unavailable; proceeding without dispatcher lock"
+restart_if_needed
 
 exit 0

--- a/src/common/src/auth.rs
+++ b/src/common/src/auth.rs
@@ -20,13 +20,14 @@ use crate::config::HimmelblauConfig;
 use crate::hello_pin_complexity::{is_simple_pin, meets_intune_pin_policy};
 use crate::unix_proto::{ClientRequest, ClientResponse, PamAuthRequest, PamAuthResponse};
 use regex::{Match, Regex};
+use std::io::{self, ErrorKind};
 use std::sync::Arc;
 
 use lazy_static::lazy_static;
 use tracing::{debug, error};
 
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::pam::{Options, PamResultCode};
 use authenticator::{
@@ -69,6 +70,10 @@ pub trait MessagePrinter: Send + Sync {
     fn print_error(&self, msg: &str);
     fn prompt_echo_off(&self, prompt: &str) -> Option<String>;
 }
+
+pub const DAEMON_START_WAIT_MESSAGE: &str = "Himmelblau authentication is starting, please wait...";
+pub const DAEMON_START_WAIT_TIMEOUT: Duration = Duration::from_secs(20);
+pub const DAEMON_START_WAIT_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Default)]
 pub struct SimpleMessagePrinter {}
@@ -1257,7 +1262,86 @@ struct AuthenticateState {
     polling_interval: u32,
 }
 
-pub fn authenticate(
+fn daemon_connect_error_is_retryable(err: &io::Error) -> bool {
+    if matches!(
+        err.kind(),
+        ErrorKind::NotFound
+            | ErrorKind::ConnectionRefused
+            | ErrorKind::TimedOut
+            | ErrorKind::WouldBlock
+            | ErrorKind::Interrupted
+    ) {
+        return true;
+    }
+
+    matches!(
+        err.raw_os_error(),
+        Some(libc::ENOENT | libc::ECONNREFUSED | libc::ETIMEDOUT | libc::EAGAIN | libc::EINTR)
+    )
+}
+
+fn wait_for_daemon_client_with<T, F, S>(
+    path: &str,
+    msg_printer: &dyn MessagePrinter,
+    timeout: Duration,
+    interval: Duration,
+    mut connect: F,
+    mut sleep: S,
+) -> Result<T, PamResultCode>
+where
+    F: FnMut(&str) -> io::Result<T>,
+    S: FnMut(Duration),
+{
+    let started = Instant::now();
+    let mut announced = false;
+
+    loop {
+        match connect(path) {
+            Ok(client) => return Ok(client),
+            Err(err) => {
+                if !daemon_connect_error_is_retryable(&err) {
+                    error!(?err, "himmelblaud socket connection failed");
+                    msg_printer.print_error("Himmelblau authentication service is unavailable.");
+                    return Err(PamResultCode::PAM_IGNORE);
+                }
+
+                if !announced {
+                    msg_printer.print_text(DAEMON_START_WAIT_MESSAGE);
+                    announced = true;
+                }
+
+                let elapsed = started.elapsed();
+                if elapsed >= timeout {
+                    error!(?err, "timed out waiting for himmelblaud socket");
+                    msg_printer.print_error(
+                        "Himmelblau authentication service did not become available in time.",
+                    );
+                    return Err(PamResultCode::PAM_IGNORE);
+                }
+
+                let remaining = timeout.saturating_sub(elapsed);
+                sleep(std::cmp::min(interval, remaining));
+            }
+        }
+    }
+}
+
+pub fn wait_for_daemon_client(
+    path: &str,
+    msg_printer: Arc<dyn MessagePrinter>,
+) -> Result<DaemonClientBlocking, PamResultCode> {
+    wait_for_daemon_client_with(
+        path,
+        msg_printer.as_ref(),
+        DAEMON_START_WAIT_TIMEOUT,
+        DAEMON_START_WAIT_INTERVAL,
+        DaemonClientBlocking::new,
+        thread::sleep,
+    )
+}
+
+pub fn authenticate_with_client(
+    daemon_client: DaemonClientBlocking,
     authtok: Option<String>,
     cfg: HimmelblauConfig,
     account_id: &str,
@@ -1265,14 +1349,6 @@ pub fn authenticate(
     opts: Options,
     msg_printer: Arc<dyn MessagePrinter>,
 ) -> PamResultCode {
-    let daemon_client = match DaemonClientBlocking::new(cfg.get_socket_path().as_str()) {
-        Ok(dc) => dc,
-        Err(e) => {
-            debug!(err = ?e, "himmelblaud not available, ignoring");
-            return PamResultCode::PAM_IGNORE;
-        }
-    };
-
     let mut state = AuthenticateState {
         daemon_client,
         authtok,
@@ -1302,6 +1378,31 @@ pub fn authenticate(
     }
 }
 
+pub fn authenticate(
+    authtok: Option<String>,
+    cfg: HimmelblauConfig,
+    account_id: &str,
+    service: &str,
+    opts: Options,
+    msg_printer: Arc<dyn MessagePrinter>,
+) -> PamResultCode {
+    let daemon_client =
+        match wait_for_daemon_client(cfg.get_socket_path().as_str(), msg_printer.clone()) {
+            Ok(dc) => dc,
+            Err(code) => return code,
+        };
+
+    authenticate_with_client(
+        daemon_client,
+        authtok,
+        cfg,
+        account_id,
+        service,
+        opts,
+        msg_printer,
+    )
+}
+
 pub async fn authenticate_async(
     authtok: Option<String>,
     cfg: HimmelblauConfig,
@@ -1327,6 +1428,8 @@ pub async fn authenticate_async(
 mod tests {
     use super::*;
     use std::fs;
+    use std::io::Error as IoError;
+    use std::sync::Mutex;
 
     fn create_temp_config(contents: &str) -> String {
         let file_path = format!(
@@ -1347,6 +1450,168 @@ mod tests {
             mfa_poll_prompt,
             ..Default::default()
         }
+    }
+
+    #[derive(Default)]
+    struct RecordingPrinter {
+        text: Mutex<Vec<String>>,
+        error: Mutex<Vec<String>>,
+    }
+
+    impl MessagePrinter for RecordingPrinter {
+        fn print_text(&self, msg: &str) {
+            self.text.lock().unwrap().push(msg.to_string());
+        }
+
+        fn print_error(&self, msg: &str) {
+            self.error.lock().unwrap().push(msg.to_string());
+        }
+
+        fn prompt_echo_off(&self, _prompt: &str) -> Option<String> {
+            None
+        }
+    }
+
+    fn retryable_connect_error() -> io::Error {
+        IoError::new(ErrorKind::NotFound, "missing socket")
+    }
+
+    #[test]
+    fn test_wait_for_daemon_client_immediate_success_has_no_message() {
+        let printer = RecordingPrinter::default();
+        let mut attempts = 0;
+
+        let result = wait_for_daemon_client_with(
+            "/run/himmelblaud/socket",
+            &printer,
+            Duration::from_secs(20),
+            Duration::from_millis(250),
+            |_| {
+                attempts += 1;
+                Ok("connected")
+            },
+            |_| panic!("sleep should not be called"),
+        );
+
+        assert_eq!(result.unwrap(), "connected");
+        assert_eq!(attempts, 1);
+        assert!(printer.text.lock().unwrap().is_empty());
+        assert!(printer.error.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_wait_for_daemon_client_retries_transient_errors() {
+        let printer = RecordingPrinter::default();
+        let mut attempts = 0;
+        let mut sleeps = Vec::new();
+
+        let result = wait_for_daemon_client_with(
+            "/run/himmelblaud/socket",
+            &printer,
+            Duration::from_secs(20),
+            Duration::from_millis(250),
+            |_| {
+                attempts += 1;
+                if attempts < 3 {
+                    Err(retryable_connect_error())
+                } else {
+                    Ok("connected")
+                }
+            },
+            |duration| sleeps.push(duration),
+        );
+
+        assert_eq!(result.unwrap(), "connected");
+        assert_eq!(attempts, 3);
+        assert_eq!(sleeps, vec![Duration::from_millis(250); 2]);
+        assert_eq!(
+            printer.text.lock().unwrap().as_slice(),
+            &[DAEMON_START_WAIT_MESSAGE.to_string()]
+        );
+        assert!(printer.error.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_wait_for_daemon_client_times_out() {
+        let printer = RecordingPrinter::default();
+
+        let result: Result<(), PamResultCode> = wait_for_daemon_client_with(
+            "/run/himmelblaud/socket",
+            &printer,
+            Duration::ZERO,
+            Duration::from_millis(250),
+            |_| Err(retryable_connect_error()),
+            |_| panic!("sleep should not be called after timeout"),
+        );
+
+        assert_eq!(result.err(), Some(PamResultCode::PAM_IGNORE));
+        assert_eq!(
+            printer.text.lock().unwrap().as_slice(),
+            &[DAEMON_START_WAIT_MESSAGE.to_string()]
+        );
+        assert_eq!(
+            printer.error.lock().unwrap().as_slice(),
+            &["Himmelblau authentication service did not become available in time.".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_wait_for_daemon_client_retries_missing_socket_os_error() {
+        let printer = RecordingPrinter::default();
+        let connect_error = IoError::from_raw_os_error(libc::ENOENT);
+        assert!(
+            daemon_connect_error_is_retryable(&connect_error),
+            "missing socket error should be retryable: kind={:?} raw_os_error={:?} err={:?}",
+            connect_error.kind(),
+            connect_error.raw_os_error(),
+            connect_error
+        );
+        let mut connect_error = Some(connect_error);
+
+        let result: Result<(), PamResultCode> = wait_for_daemon_client_with(
+            "/run/himmelblaud/socket",
+            &printer,
+            Duration::ZERO,
+            Duration::from_millis(250),
+            |_| Err(connect_error.take().unwrap()),
+            |_| panic!("sleep should not be called after timeout"),
+        );
+
+        assert_eq!(result.err(), Some(PamResultCode::PAM_IGNORE));
+        assert_eq!(
+            printer.text.lock().unwrap().as_slice(),
+            &[DAEMON_START_WAIT_MESSAGE.to_string()]
+        );
+        assert_eq!(
+            printer.error.lock().unwrap().as_slice(),
+            &["Himmelblau authentication service did not become available in time.".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_wait_for_daemon_client_stops_on_non_retryable_error() {
+        let printer = RecordingPrinter::default();
+
+        let result: Result<(), PamResultCode> = wait_for_daemon_client_with(
+            "/run/himmelblaud/socket",
+            &printer,
+            Duration::from_secs(20),
+            Duration::from_millis(250),
+            |_| {
+                Err(IoError::new(
+                    ErrorKind::PermissionDenied,
+                    "permission denied",
+                ))
+            },
+            |_| panic!("sleep should not be called for non-retryable errors"),
+        );
+
+        assert_eq!(result.unwrap_err(), PamResultCode::PAM_IGNORE);
+        assert!(printer.text.lock().unwrap().is_empty());
+        assert_eq!(
+            printer.error.lock().unwrap().as_slice(),
+            &["Himmelblau authentication service is unavailable.".to_string()]
+        );
     }
 
     #[test]

--- a/src/common/src/client_sync.rs
+++ b/src/common/src/client_sync.rs
@@ -42,28 +42,26 @@ pub struct DaemonClientBlocking {
 }
 
 impl DaemonClientBlocking {
-    pub fn new(path: &str) -> Result<DaemonClientBlocking, Box<dyn Error>> {
+    pub fn new(path: &str) -> std::io::Result<DaemonClientBlocking> {
         debug!(%path);
 
-        let stream = UnixStream::connect(path)
-            .map_err(|e| {
-                // ENOENT means the daemon isn't running — expected during boot,
-                // daemon-reload, or when himmelblau is not configured. Log at
-                // debug to avoid distracting users with spurious error output.
-                if e.kind() == ErrorKind::NotFound {
-                    debug!(
-                        "himmelblaud socket not found at {} (daemon not running?)",
-                        path
-                    );
-                } else {
-                    error!(
-                        "Unix socket stream setup error while connecting to {} -> {:?}",
-                        path, e
-                    );
-                }
-                e
-            })
-            .map_err(Box::new)?;
+        let stream = UnixStream::connect(path).map_err(|e| {
+            // ENOENT means the daemon isn't running - expected during boot,
+            // daemon-reload, or when himmelblau is not configured. Log at
+            // debug to avoid distracting users with spurious error output.
+            if e.kind() == ErrorKind::NotFound {
+                debug!(
+                    "himmelblaud socket not found at {} (daemon not running?)",
+                    path
+                );
+            } else {
+                error!(
+                    "Unix socket stream setup error while connecting to {} -> {:?}",
+                    path, e
+                );
+            }
+            e
+        })?;
 
         Ok(DaemonClientBlocking { stream })
     }

--- a/src/daemon/scripts/postinst
+++ b/src/daemon/scripts/postinst
@@ -89,6 +89,44 @@ for OLD_FILE in \
     fi
 done
 
+disable_old_nm_dispatcher_workarounds() {
+    dispatcher_dir="${DPKG_ROOT:-}/etc/NetworkManager/dispatcher.d"
+    [ -d "$dispatcher_dir" ] || return 0
+
+    for file in \
+        "$dispatcher_dir/99-zzz-himmelblau" \
+        "$dispatcher_dir/99-restart-himmelblau" \
+        "$dispatcher_dir/99-himmelblau"; do
+        [ -f "$file" ] || continue
+        if grep -Eq 'himmelblau-idm/himmelblau#1206|NM-dispatcher\.99-restart-himmelblau|99-zzz-himmelblau' "$file" \
+            && grep -Eq 'systemctl[[:space:]]+restart.*himmelblaud(\.service)?' "$file"; then
+            disabled="${file}.himmelblau-disabled"
+            if [ -e "$disabled" ]; then
+                disabled="${disabled}.$$"
+            fi
+            if mv "$file" "$disabled"; then
+                echo "Disabled old manual Himmelblau NetworkManager workaround: $file -> $disabled"
+            else
+                echo "Warning: failed to disable old manual Himmelblau NetworkManager workaround: $file" >&2
+            fi
+        fi
+    done
+
+    for file in "$dispatcher_dir"/*himmelblau* "$dispatcher_dir"/*himmelblaud*; do
+        [ -f "$file" ] || continue
+        case "$file" in
+            *.himmelblau-disabled|*.himmelblau-disabled.*)
+                continue
+                ;;
+        esac
+        if grep -Eq 'systemctl[[:space:]]+restart.*himmelblaud(\.service)?' "$file"; then
+            echo "Warning: found unmanaged Himmelblau NetworkManager dispatcher script: $file" >&2
+        fi
+    done
+}
+
+disable_old_nm_dispatcher_workarounds
+
 if command -v deb-systemd-helper >/dev/null 2>&1; then
     if [ "$1" != "configure" ]; then
         exit 0

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -90,7 +90,9 @@ use tracing_subscriber::prelude::*;
 use std::thread;
 use std::time::Duration;
 
-use himmelblau_unix_common::auth::{authenticate, fido_auth, MessagePrinter};
+use himmelblau_unix_common::auth::{
+    authenticate_with_client, fido_auth, wait_for_daemon_client, MessagePrinter,
+};
 use himmelblau_unix_common::pam::Options;
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
@@ -441,6 +443,11 @@ impl PamHooks for PamKanidm {
         let set_authtok = opts.set_authtok;
         let keyring_secret = Arc::new(Mutex::new(authtok.clone()));
         let base_printer: Arc<dyn MessagePrinter> = Arc::new(PamConvMessagePrinter::new(conv));
+        let daemon_client =
+            match wait_for_daemon_client(cfg.get_socket_path().as_str(), base_printer.clone()) {
+                Ok(client) => client,
+                Err(code) => return code,
+            };
         let msg_printer: Arc<dyn MessagePrinter> = if set_authtok {
             Arc::new(KeyringCaptureMessagePrinter::new(
                 base_printer.clone(),
@@ -450,7 +457,15 @@ impl PamHooks for PamKanidm {
             base_printer
         };
 
-        let result = authenticate(authtok, cfg, &account_id, &service, opts, msg_printer);
+        let result = authenticate_with_client(
+            daemon_client,
+            authtok,
+            cfg,
+            &account_id,
+            &service,
+            opts,
+            msg_printer,
+        );
 
         if set_authtok && result == PamResultCode::PAM_SUCCESS {
             if let Ok(Some(secret)) = keyring_secret.lock().map(|s| s.clone()) {


### PR DESCRIPTION
## Summary

  - Refines the #1206 NetworkManager dispatcher workaround to cover VPN/connectivity-loss events, avoid duplicate restarts, probe daemon responsiveness, and restart both Himmelblau services together.
  - Adds package upgrade cleanup for known manually installed dispatcher workaround scripts to prevent double restarts.
  - Makes PAM wait briefly for himmelblaud after confirming a Himmelblau user, showing a loading message instead of immediately falling through while the daemon restarts.

More work toward fixing #1206.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
