### PR TITLE
Add Thunderbird policy asset and install/remove support for sso-policies

### DIFF
--- a/src/sso-policies/Cargo.toml
+++ b/src/sso-policies/Cargo.toml
@@ -21,6 +21,7 @@ assets = [
   ["src/chrome/policies.json", "etc/opt/chrome/policies/managed/himmelblau.json", "644"],
   ["src/chrome/policies.json", "etc/chromium/policies/managed/himmelblau.json", "644"],
   ["src/firefox/policies.json", "usr/share/doc/himmelblau-sso-policies/firefox-policies.json.example", "644"],
+  ["src/thunderbird/policies.json", "usr/share/doc/himmelblau-sso-policies/thunderbird-policies.json.example", "644"],
 ]
 maintainer-scripts = "scripts"
 
@@ -30,6 +31,7 @@ assets = [
   { source = "src/chrome/policies.json", dest = "/etc/opt/chrome/policies/managed/himmelblau.json", mode = "644" },
   { source = "src/chrome/policies.json", dest = "/etc/chromium/policies/managed/himmelblau.json", mode = "644" },
   { source = "src/firefox/policies.json", dest = "/usr/share/doc/himmelblau-sso-policies/firefox-policies.json.example", mode = "644", doc = true },
+  { source = "src/thunderbird/policies.json", dest = "/usr/share/doc/himmelblau-sso-policies/thunderbird-policies.json.example", mode = "644", doc = true },
 ]
 post_install_script = "scripts/postinst"
 post_uninstall_script = "scripts/postrm"

--- a/src/sso-policies/scripts/postinst
+++ b/src/sso-policies/scripts/postinst
@@ -2,14 +2,16 @@
 set -e
 
 # Himmelblau SSO policies postinst script
-# Merges Firefox extension configuration into existing policies without overwriting
+# Merges Firefox/Thunderbird extension configuration into existing policies without overwriting
 # (Chrome/Chromium use separate policy files per application, so no merging needed)
 
 FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
+THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
 
 # Function to merge Firefox extension into policies.json
-merge_firefox_policy() {
+merge_mozilla_policy() {
     POLICY_FILE="$1"
+    EXTENSION_URL="$2"
     POLICY_DIR=$(dirname "$POLICY_FILE")
 
     # Ensure directory exists
@@ -19,26 +21,26 @@ merge_firefox_policy() {
         # Check if jq is available for proper JSON merging
         if command -v jq >/dev/null 2>&1; then
             # Check if the extension URL is already present
-            if jq -e ".policies.Extensions.Install[]? | select(. == \"$FIREFOX_EXTENSION_URL\")" "$POLICY_FILE" >/dev/null 2>&1; then
+            if jq -e ".policies.Extensions.Install[]? | select(. == \"$EXTENSION_URL\")" "$POLICY_FILE" >/dev/null 2>&1; then
                 echo "Firefox SSO extension already configured in $POLICY_FILE"
                 return 0
             fi
 
             # Merge the extension into existing policy
             TEMP_FILE=$(mktemp)
-            jq --arg url "$FIREFOX_EXTENSION_URL" '
+            jq --arg url "$EXTENSION_URL" '
                 .policies.Extensions.Install = ((.policies.Extensions.Install // []) + [$url] | unique)
             ' "$POLICY_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$POLICY_FILE"
             echo "Merged Firefox SSO extension into $POLICY_FILE"
         else
             # Without jq, check if our extension is already there
-            if grep -q "$FIREFOX_EXTENSION_URL" "$POLICY_FILE" 2>/dev/null; then
+            if grep -q "$EXTENSION_URL" "$POLICY_FILE" 2>/dev/null; then
                 echo "Firefox SSO extension already configured in $POLICY_FILE"
                 return 0
             fi
             echo "Warning: jq not found. Cannot safely merge into existing $POLICY_FILE"
             echo "Please manually add the extension URL to policies.Extensions.Install:"
-            echo "  $FIREFOX_EXTENSION_URL"
+            echo "  $EXTENSION_URL"
         fi
     else
         # Create new policy file
@@ -47,7 +49,7 @@ merge_firefox_policy() {
   "policies": {
     "Extensions": {
       "Install": [
-        "$FIREFOX_EXTENSION_URL"
+        "$EXTENSION_URL"
       ]
     }
   }
@@ -58,6 +60,7 @@ EOF
 }
 
 # Merge Firefox policy
-merge_firefox_policy "/etc/firefox/policies/policies.json"
+merge_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL"
+merge_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"
 
-echo "Himmelblau SSO Firefox policy configuration complete"
+echo "Himmelblau SSO Mozilla policy configuration complete"

--- a/src/sso-policies/scripts/postinst
+++ b/src/sso-policies/scripts/postinst
@@ -5,8 +5,8 @@ set -e
 # Merges Firefox/Thunderbird extension configuration into existing policies without overwriting
 # (Chrome/Chromium use separate policy files per application, so no merging needed)
 
-FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
-THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
+FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.xpi"
+THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.thunderbird.xpi"
 
 # Function to merge a Mozilla extension into policies.json
 merge_mozilla_policy() {

--- a/src/sso-policies/scripts/postinst
+++ b/src/sso-policies/scripts/postinst
@@ -8,10 +8,11 @@ set -e
 FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
 THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
 
-# Function to merge Firefox extension into policies.json
+# Function to merge a Mozilla extension into policies.json
 merge_mozilla_policy() {
     POLICY_FILE="$1"
     EXTENSION_URL="$2"
+    APP_NAME="$3"
     POLICY_DIR=$(dirname "$POLICY_FILE")
 
     # Ensure directory exists
@@ -21,8 +22,8 @@ merge_mozilla_policy() {
         # Check if jq is available for proper JSON merging
         if command -v jq >/dev/null 2>&1; then
             # Check if the extension URL is already present
-            if jq -e ".policies.Extensions.Install[]? | select(. == \"$EXTENSION_URL\")" "$POLICY_FILE" >/dev/null 2>&1; then
-                echo "Firefox SSO extension already configured in $POLICY_FILE"
+            if jq -e --arg url "$EXTENSION_URL" '.policies.Extensions.Install[]? | select(. == $url)' "$POLICY_FILE" >/dev/null 2>&1; then
+                echo "$APP_NAME SSO extension already configured in $POLICY_FILE"
                 return 0
             fi
 
@@ -31,11 +32,11 @@ merge_mozilla_policy() {
             jq --arg url "$EXTENSION_URL" '
                 .policies.Extensions.Install = ((.policies.Extensions.Install // []) + [$url] | unique)
             ' "$POLICY_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$POLICY_FILE"
-            echo "Merged Firefox SSO extension into $POLICY_FILE"
+            echo "Merged $APP_NAME SSO extension into $POLICY_FILE"
         else
             # Without jq, check if our extension is already there
             if grep -q "$EXTENSION_URL" "$POLICY_FILE" 2>/dev/null; then
-                echo "Firefox SSO extension already configured in $POLICY_FILE"
+                echo "$APP_NAME SSO extension already configured in $POLICY_FILE"
                 return 0
             fi
             echo "Warning: jq not found. Cannot safely merge into existing $POLICY_FILE"
@@ -55,12 +56,12 @@ merge_mozilla_policy() {
   }
 }
 EOF
-        echo "Created Firefox SSO policy at $POLICY_FILE"
+        echo "Created $APP_NAME SSO policy at $POLICY_FILE"
     fi
 }
 
-# Merge Firefox policy
-merge_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL"
-merge_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"
+# Merge Firefox and Thunderbird policies
+merge_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL" "Firefox"
+merge_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL" "Thunderbird"
 
 echo "Himmelblau SSO Mozilla policy configuration complete"

--- a/src/sso-policies/scripts/postrm
+++ b/src/sso-policies/scripts/postrm
@@ -43,9 +43,9 @@ remove_mozilla_policy() {
     fi
 }
 
-# Only run on purge or remove
+# Only run on Debian purge/remove or RPM erase ($1=0)
 case "$1" in
-    remove|purge)
+    remove|purge|0)
         # Remove Firefox and Thunderbird policies
         remove_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL"
         remove_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"

--- a/src/sso-policies/scripts/postrm
+++ b/src/sso-policies/scripts/postrm
@@ -39,6 +39,10 @@ remove_mozilla_policy() {
                 rm -f "$POLICY_FILE"
                 echo "Removed empty policy file $POLICY_FILE"
             fi
+        else
+            echo "Warning: jq not found. Cannot safely remove SSO extension from $POLICY_FILE"
+            echo "Please manually remove the extension URL from policies.Extensions.Install:"
+            echo "  $EXTENSION_URL"
         fi
     fi
 }

--- a/src/sso-policies/scripts/postrm
+++ b/src/sso-policies/scripts/postrm
@@ -2,27 +2,29 @@
 set -e
 
 # Himmelblau SSO policies postrm script
-# Removes Firefox extension configuration that was merged during install
+# Removes Firefox/Thunderbird extension configuration that was merged during install
 # (Chrome/Chromium policy files are handled by package manager directly)
 
 FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
+THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
 
-# Function to remove Firefox extension from policies.json
-remove_firefox_policy() {
+# Function to remove a Mozilla extension from policies.json
+remove_mozilla_policy() {
     POLICY_FILE="$1"
+    EXTENSION_URL="$2"
 
     if [ -f "$POLICY_FILE" ]; then
         if command -v jq >/dev/null 2>&1; then
             # Remove the extension URL from the Install array
             TEMP_FILE=$(mktemp)
-            jq --arg url "$FIREFOX_EXTENSION_URL" '
+            jq --arg url "$EXTENSION_URL" '
                 if .policies.Extensions.Install then
                     .policies.Extensions.Install = [.policies.Extensions.Install[] | select(. != $url)]
                 else
                     .
                 end
             ' "$POLICY_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$POLICY_FILE"
-            echo "Removed Firefox SSO extension from $POLICY_FILE"
+            echo "Removed Mozilla SSO extension from $POLICY_FILE"
 
             # If the Install array is now empty, clean up the structure
             if jq -e '.policies.Extensions.Install == []' "$POLICY_FILE" >/dev/null 2>&1; then
@@ -44,9 +46,10 @@ remove_firefox_policy() {
 # Only run on purge or remove
 case "$1" in
     remove|purge)
-        # Remove Firefox policy
-        remove_firefox_policy "/etc/firefox/policies/policies.json"
+        # Remove Firefox and Thunderbird policies
+        remove_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL"
+        remove_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"
 
-        echo "Himmelblau SSO Firefox policy configuration removed"
+        echo "Himmelblau SSO Mozilla policy configuration removed"
         ;;
 esac

--- a/src/sso-policies/scripts/postrm
+++ b/src/sso-policies/scripts/postrm
@@ -5,8 +5,8 @@ set -e
 # Removes Firefox/Thunderbird extension configuration that was merged during install
 # (Chrome/Chromium policy files are handled by package manager directly)
 
-FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
-THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
+FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.xpi"
+THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.thunderbird.xpi"
 
 # Function to remove a Mozilla extension from policies.json
 remove_mozilla_policy() {

--- a/src/sso-policies/src/firefox/policies.json
+++ b/src/sso-policies/src/firefox/policies.json
@@ -2,7 +2,7 @@
   "policies": {
     "Extensions": {
       "Install": [
-        "https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"
+        "https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.xpi"
       ]
     }
   }

--- a/src/sso-policies/src/thunderbird/policies.json
+++ b/src/sso-policies/src/thunderbird/policies.json
@@ -2,7 +2,7 @@
   "policies": {
     "Extensions": {
       "Install": [
-        "https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
+        "https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.thunderbird.xpi"
       ]
     }
   }

--- a/src/sso-policies/src/thunderbird/policies.json
+++ b/src/sso-policies/src/thunderbird/policies.json
@@ -1,0 +1,9 @@
+{
+  "policies": {
+    "Extensions": {
+      "Install": [
+        "https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.thunderbird.xpi"
+      ]
+    }
+  }
+}

--- a/src/sso/src/firefox/linux_entra_sso.json
+++ b/src/sso/src/firefox/linux_entra_sso.json
@@ -4,6 +4,7 @@
     "path": "/usr/bin/linux-entra-sso",
     "type": "stdio",
     "allowed_extensions": [
-        "linux-entra-sso@example.com"
+        "linux-entra-sso@example.com",
+        "@linux-entra-sso.tb"
     ]
 }


### PR DESCRIPTION
    Register src/thunderbird/policies.json as package documentation/example asset
    Extend src/sso-policies/scripts/postinst to configure /etc/thunderbird/policies/policies.json
    Extend src/sso-policies/scripts/postrm to remove Thunderbird policy on uninstall/purge
    Also include unrelated user updates in the same branch as requested.

## Summary
PINEAPPLE

Add Thunderbird policy to install Linux Entra SSO extension.

Fixes #1451

## Testing

- **Distro(s) tested:** Ubuntu 24.04
- **Steps performed:** Manually installed *himmelblau-sso* and *himmelblau-sso-policies* generated by `make`
- **Results observed:** Policy was applied and SSO worked in Thunderbird.

## Automated Checks

- [x] I ran `make test` (or explained why not)
- [x] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [x] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion

## Disclaimer
LLM was used to identify all files that needed update and with some changes.