### PR TITLE
Fix release publishing for old tags

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,7 +52,10 @@ jobs:
         fi
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           git fetch --tags --force
-          git checkout --detach "$TAG"
+          if ! git rev-parse -q --verify "refs/tags/$TAG^{commit}" >/dev/null; then
+            echo "Stable tag does not exist: $TAG" >&2
+            exit 1
+          fi
         fi
         echo "stable=true" >> "$GITHUB_OUTPUT"
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Release runs checked out the requested tag before invoking the release automation, which removed the current workflow scripts for tags that predate them. Validate the requested tag instead so release notes are generated with the current automation while still targeting the selected release tag.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
