### PR TITLE
ci(release): simplify generated release notes

### DIFF
--- a/.github/release-notes-prompt.md
+++ b/.github/release-notes-prompt.md
@@ -31,9 +31,9 @@ Do NOT wrap the entire output in triple backticks.
 
 The changelog MUST follow this structure:
 
-# What's Changed
+## What's Changed
 
-## Category Name
+### Category Name
 
 - Concise explanation of the change.
 - Describe the impact to users or administrators when applicable.
@@ -43,25 +43,25 @@ The changelog MUST follow this structure:
 - Mention security, authentication, networking, packaging, compatibility, or performance implications explicitly.
 - Mention issue numbers when discoverable.
 
-## Another Category
+### Another Category
 
 - Additional grouped changes.
 
-## Packaging / Build / CI
+### Packaging / Build / CI
 
 - Packaging improvements
 - Dependency changes
 - Build fixes
 - CI improvements
 
-## Documentation
+### Documentation
 
 - Documentation updates
 - Examples
 - Man page changes
 - Wiki improvements
 
-## Known Issues
+### Known Issues
 (Only include if applicable)
 
 - Describe remaining limitations or caveats.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         TAG="${{ steps.release-tag.outputs.tag }}"
         if gh release view "$TAG" >/dev/null 2>&1; then
-          gh release edit "$TAG" --title "Himmelblau $TAG" --notes-file release-notes.md
+          gh release edit "$TAG" --title "$TAG" --notes-file release-notes.md
         else
-          gh release create "$TAG" --title "Himmelblau $TAG" --notes-file release-notes.md --verify-tag
+          gh release create "$TAG" --title "$TAG" --notes-file release-notes.md --verify-tag
         fi


### PR DESCRIPTION
## Summary

Use the tag itself as the GitHub release title when creating or updating releases. Adjust the generated release notes heading levels so the content nests cleanly under the release title.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
