### PR TITLE
Auto update linux entra sso extensions

### DIFF
--- a/.github/scripts/test_update_linux_entra_sso.py
+++ b/.github/scripts/test_update_linux_entra_sso.py
@@ -119,23 +119,23 @@ class LinuxEntraSsoUpdaterTests(unittest.TestCase):
 
     def test_normalizes_drift_without_newer_version(self) -> None:
         self.repo.write_tracked(
-            "old.txt",
+            "src/sso-policies/scripts/postinst",
             '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
         )
         self.repo.write_tracked(
-            "new.txt",
+            "src/sso-policies/src/firefox/policies.json",
             '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
         )
         release = updater.release_from_payload(release_payload("1.10.0"))
 
         changed = updater.update_tracked_urls(self.repo.root, release)
 
-        self.assertEqual(changed, [Path("old.txt")])
+        self.assertEqual(changed, [Path("src/sso-policies/scripts/postinst")])
         updater.validate_tracked_urls(self.repo.root, release)
 
     def test_refuses_to_downgrade(self) -> None:
         self.repo.write_tracked(
-            "current.txt",
+            "src/sso-policies/src/firefox/policies.json",
             '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
         )
         release = updater.release_from_payload(release_payload("1.9.9"))
@@ -145,7 +145,7 @@ class LinuxEntraSsoUpdaterTests(unittest.TestCase):
 
     def test_ignores_untracked_files(self) -> None:
         self.repo.write_tracked(
-            "current.txt",
+            "src/sso-policies/src/firefox/policies.json",
             '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
         )
         untracked = self.repo.root / "generated.spec"
@@ -158,6 +158,23 @@ class LinuxEntraSsoUpdaterTests(unittest.TestCase):
         updater.update_tracked_urls(self.repo.root, release)
 
         self.assertIn("v1.8.0", untracked.read_text(encoding="utf-8"))
+
+    def test_ignores_tracked_test_fixture_urls(self) -> None:
+        self.repo.write_tracked(
+            "src/sso-policies/src/firefox/policies.json",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        test_fixture = self.repo.write_tracked(
+            ".github/scripts/test_update_linux_entra_sso.py",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
+        )
+        release = updater.release_from_payload(release_payload("1.9.9"))
+
+        changed = updater.update_tracked_urls(self.repo.root, release)
+        updater.validate_tracked_urls(self.repo.root, release)
+
+        self.assertEqual(changed, [])
+        self.assertIn("v1.10.0", test_fixture.read_text(encoding="utf-8"))
 
     def test_skips_tracked_directory_paths(self) -> None:
         self.repo.write_tracked(
@@ -173,8 +190,9 @@ class LinuxEntraSsoUpdaterTests(unittest.TestCase):
             "git_ls_files",
             return_value=[self.repo.root / "current.txt", tracked_dir],
         ):
-            changed = updater.update_tracked_urls(self.repo.root, release)
-            updater.validate_tracked_urls(self.repo.root, release)
+            candidate_paths = ("current.txt", "docs-xml")
+            changed = updater.update_tracked_urls(self.repo.root, release, candidate_paths)
+            updater.validate_tracked_urls(self.repo.root, release, candidate_paths)
 
         self.assertEqual(changed, [Path("current.txt")])
 

--- a/.github/scripts/test_update_linux_entra_sso.py
+++ b/.github/scripts/test_update_linux_entra_sso.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+import update_linux_entra_sso as updater
+
+
+def release_payload(version: str, *, include_firefox: bool = True, include_thunderbird: bool = True) -> dict:
+    assets = []
+    if include_firefox:
+        assets.append(
+            {
+                "name": f"linux_entra_sso-{version}.xpi",
+                "browser_download_url": (
+                    f"https://github.com/siemens/linux-entra-sso/releases/download/v{version}/"
+                    f"linux_entra_sso-{version}.xpi"
+                ),
+            }
+        )
+    if include_thunderbird:
+        assets.append(
+            {
+                "name": f"linux_entra_sso-{version}.thunderbird.xpi",
+                "browser_download_url": (
+                    f"https://github.com/siemens/linux-entra-sso/releases/download/v{version}/"
+                    f"linux_entra_sso-{version}.thunderbird.xpi"
+                ),
+            }
+        )
+    return {"tag_name": f"v{version}", "assets": assets}
+
+
+class GitRepoFixture:
+    def __init__(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        subprocess.run(["git", "init"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=self.root, check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=self.root, check=True)
+
+    def close(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_tracked(self, relative_path: str, text: str) -> Path:
+        path = self.root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        subprocess.run(["git", "add", relative_path], cwd=self.root, check=True)
+        return path
+
+
+class LinuxEntraSsoUpdaterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = GitRepoFixture()
+
+    def tearDown(self) -> None:
+        self.repo.close()
+
+    def test_numeric_version_comparison(self) -> None:
+        self.assertGreater(updater.Version.parse("1.10.0"), updater.Version.parse("1.9.9"))
+
+    def test_release_payload_requires_expected_assets(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "thunderbird"):
+            updater.release_from_payload(release_payload("1.10.0", include_thunderbird=False))
+
+    def test_noop_when_urls_already_match_latest(self) -> None:
+        self.repo.write_tracked(
+            "src/sso-policies/src/firefox/policies.json",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
+        )
+        release = updater.release_from_payload(release_payload("1.10.0"))
+
+        changed = updater.update_tracked_urls(self.repo.root, release)
+
+        self.assertEqual(changed, [])
+
+    def test_rewrites_all_tracked_extension_urls(self) -> None:
+        self.repo.write_tracked(
+            "src/sso-policies/scripts/postinst",
+            "\n".join(
+                [
+                    'FIREFOX_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+                    'THUNDERBIRD_EXTENSION_URL="https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.thunderbird.xpi"',
+                ]
+            ),
+        )
+        self.repo.write_tracked(
+            "src/sso-policies/src/firefox/policies.json",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        self.repo.write_tracked(
+            "src/sso-policies/src/thunderbird/policies.json",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.thunderbird.xpi"',
+        )
+        self.repo.write_tracked(
+            "nix/modules/himmelblau.nix",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        release = updater.release_from_payload(release_payload("1.10.0"))
+
+        changed = updater.update_tracked_urls(self.repo.root, release)
+
+        self.assertEqual(
+            changed,
+            [
+                Path("nix/modules/himmelblau.nix"),
+                Path("src/sso-policies/scripts/postinst"),
+                Path("src/sso-policies/src/firefox/policies.json"),
+                Path("src/sso-policies/src/thunderbird/policies.json"),
+            ],
+        )
+        updater.validate_tracked_urls(self.repo.root, release)
+
+    def test_normalizes_drift_without_newer_version(self) -> None:
+        self.repo.write_tracked(
+            "old.txt",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        self.repo.write_tracked(
+            "new.txt",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
+        )
+        release = updater.release_from_payload(release_payload("1.10.0"))
+
+        changed = updater.update_tracked_urls(self.repo.root, release)
+
+        self.assertEqual(changed, [Path("old.txt")])
+        updater.validate_tracked_urls(self.repo.root, release)
+
+    def test_refuses_to_downgrade(self) -> None:
+        self.repo.write_tracked(
+            "current.txt",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.10.0/linux_entra_sso-1.10.0.xpi"',
+        )
+        release = updater.release_from_payload(release_payload("1.9.9"))
+
+        with self.assertRaisesRegex(RuntimeError, "Refusing to downgrade"):
+            updater.update_tracked_urls(self.repo.root, release)
+
+    def test_ignores_untracked_files(self) -> None:
+        self.repo.write_tracked(
+            "current.txt",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        untracked = self.repo.root / "generated.spec"
+        untracked.write_text(
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.8.0/linux_entra_sso-1.8.0.xpi"',
+            encoding="utf-8",
+        )
+        release = updater.release_from_payload(release_payload("1.10.0"))
+
+        updater.update_tracked_urls(self.repo.root, release)
+
+        self.assertIn("v1.8.0", untracked.read_text(encoding="utf-8"))
+
+    def test_skips_tracked_directory_paths(self) -> None:
+        self.repo.write_tracked(
+            "current.txt",
+            '"https://github.com/siemens/linux-entra-sso/releases/download/v1.9.9/linux_entra_sso-1.9.9.xpi"',
+        )
+        tracked_dir = self.repo.root / "docs-xml"
+        tracked_dir.mkdir()
+        release = updater.release_from_payload(release_payload("1.10.0"))
+
+        with unittest.mock.patch.object(
+            updater,
+            "git_ls_files",
+            return_value=[self.repo.root / "current.txt", tracked_dir],
+        ):
+            changed = updater.update_tracked_urls(self.repo.root, release)
+            updater.validate_tracked_urls(self.repo.root, release)
+
+        self.assertEqual(changed, [Path("current.txt")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_linux_entra_sso.py
+++ b/.github/scripts/update_linux_entra_sso.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Update pinned linux-entra-sso browser extension URLs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LATEST_RELEASE_API = "https://api.github.com/repos/siemens/linux-entra-sso/releases/latest"
+USER_AGENT = "Himmelblau-linux-entra-sso-updater/1.0"
+VERSION_RE = re.compile(r"^v?(?P<version>[0-9]+(?:\.[0-9]+){2})$")
+EXTENSION_URL_RE = re.compile(
+    r"https://github\.com/siemens/linux-entra-sso/releases/download/"
+    r"v?(?P<release>[0-9]+(?:\.[0-9]+){2})/"
+    r"linux_entra_sso-(?P<asset>[0-9]+(?:\.[0-9]+){2})(?P<thunderbird>\.thunderbird)?\.xpi"
+)
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> "Version":
+        match = VERSION_RE.fullmatch(value.strip())
+        if not match:
+            raise ValueError(f"Unsupported linux-entra-sso version: {value!r}")
+        return cls(*(int(part) for part in match.group("version").split(".")))
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    version: Version
+    firefox_url: str
+    thunderbird_url: str
+
+
+def eprint(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def http_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("User-Agent", USER_AGENT)
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read()[:500].decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} fetching {url}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to fetch {url}: {exc}") from exc
+
+
+def release_from_payload(payload: dict[str, Any]) -> ReleaseInfo:
+    tag_name = str(payload.get("tag_name", "")).strip()
+    version = Version.parse(tag_name)
+
+    firefox_asset = f"linux_entra_sso-{version}.xpi"
+    thunderbird_asset = f"linux_entra_sso-{version}.thunderbird.xpi"
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        raise RuntimeError("Latest release payload does not contain an assets list")
+
+    asset_urls: dict[str, str] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        name = asset.get("name")
+        browser_download_url = asset.get("browser_download_url")
+        if isinstance(name, str) and isinstance(browser_download_url, str):
+            asset_urls[name] = browser_download_url
+
+    missing = [name for name in (firefox_asset, thunderbird_asset) if name not in asset_urls]
+    if missing:
+        raise RuntimeError(
+            "Latest linux-entra-sso release "
+            f"{tag_name} is missing required asset(s): {', '.join(missing)}"
+        )
+
+    return ReleaseInfo(
+        version=version,
+        firefox_url=asset_urls[firefox_asset],
+        thunderbird_url=asset_urls[thunderbird_asset],
+    )
+
+
+def fetch_latest_release() -> ReleaseInfo:
+    return release_from_payload(http_json(LATEST_RELEASE_API))
+
+
+def git_ls_files(repo_root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def find_extension_urls(text: str) -> list[re.Match[str]]:
+    return list(EXTENSION_URL_RE.finditer(text))
+
+
+def highest_tracked_version(files: list[Path]) -> Version | None:
+    highest: Version | None = None
+    for path in files:
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for match in find_extension_urls(text):
+            release_version = Version.parse(match.group("release"))
+            asset_version = Version.parse(match.group("asset"))
+            if release_version != asset_version:
+                raise RuntimeError(f"Mismatched release and asset version in {path}: {match.group(0)}")
+            if highest is None or release_version > highest:
+                highest = release_version
+    return highest
+
+
+def update_tracked_urls(repo_root: Path, release: ReleaseInfo) -> list[Path]:
+    tracked_files = git_ls_files(repo_root)
+    current_version = highest_tracked_version(tracked_files)
+    if current_version is None:
+        raise RuntimeError("No tracked linux-entra-sso extension URLs found")
+    if release.version < current_version:
+        raise RuntimeError(
+            f"Refusing to downgrade linux-entra-sso from {current_version} to latest release {release.version}"
+        )
+
+    changed: list[Path] = []
+    for path in tracked_files:
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        def replacement(match: re.Match[str]) -> str:
+            return release.thunderbird_url if match.group("thunderbird") else release.firefox_url
+
+        updated = EXTENSION_URL_RE.sub(replacement, text)
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(path.relative_to(repo_root))
+
+    return changed
+
+
+def validate_tracked_urls(repo_root: Path, release: ReleaseInfo) -> None:
+    expected = {release.firefox_url, release.thunderbird_url}
+    unexpected: list[str] = []
+    for path in git_ls_files(repo_root):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for match in find_extension_urls(text):
+            url = match.group(0)
+            if url not in expected:
+                unexpected.append(f"{path.relative_to(repo_root)}: {url}")
+
+    if unexpected:
+        details = "\n".join(unexpected)
+        raise RuntimeError(f"Tracked linux-entra-sso URLs are not aligned with {release.version}:\n{details}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="validate tracked URLs after updating")
+    args = parser.parse_args()
+
+    try:
+        release = fetch_latest_release()
+        changed = update_tracked_urls(REPO_ROOT, release)
+        if args.check:
+            validate_tracked_urls(REPO_ROOT, release)
+    except Exception as exc:
+        eprint(f"error: {exc}")
+        return 1
+
+    if changed:
+        print(f"Updated linux-entra-sso extension URLs to {release.version}:")
+        for path in changed:
+            print(f"  {path}")
+    else:
+        print(f"linux-entra-sso extension URLs already match {release.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_linux_entra_sso.py
+++ b/.github/scripts/update_linux_entra_sso.py
@@ -25,6 +25,13 @@ EXTENSION_URL_RE = re.compile(
     r"v?(?P<release>[0-9]+(?:\.[0-9]+){2})/"
     r"linux_entra_sso-(?P<asset>[0-9]+(?:\.[0-9]+){2})(?P<thunderbird>\.thunderbird)?\.xpi"
 )
+DEFAULT_EXTENSION_URL_PATHS = (
+    "nix/modules/himmelblau.nix",
+    "src/sso-policies/scripts/postinst",
+    "src/sso-policies/scripts/postrm",
+    "src/sso-policies/src/firefox/policies.json",
+    "src/sso-policies/src/thunderbird/policies.json",
+)
 
 
 @dataclass(frozen=True, order=True)
@@ -125,6 +132,18 @@ def find_extension_urls(text: str) -> list[re.Match[str]]:
     return list(EXTENSION_URL_RE.finditer(text))
 
 
+def tracked_extension_url_files(
+    repo_root: Path,
+    candidate_paths: tuple[str, ...] = DEFAULT_EXTENSION_URL_PATHS,
+) -> list[Path]:
+    tracked = {
+        path.relative_to(repo_root).as_posix()
+        for path in git_ls_files(repo_root)
+        if path.is_relative_to(repo_root)
+    }
+    return [repo_root / path for path in candidate_paths if path in tracked]
+
+
 def highest_tracked_version(files: list[Path]) -> Version | None:
     highest: Version | None = None
     for path in files:
@@ -144,8 +163,12 @@ def highest_tracked_version(files: list[Path]) -> Version | None:
     return highest
 
 
-def update_tracked_urls(repo_root: Path, release: ReleaseInfo) -> list[Path]:
-    tracked_files = git_ls_files(repo_root)
+def update_tracked_urls(
+    repo_root: Path,
+    release: ReleaseInfo,
+    candidate_paths: tuple[str, ...] = DEFAULT_EXTENSION_URL_PATHS,
+) -> list[Path]:
+    tracked_files = tracked_extension_url_files(repo_root, candidate_paths)
     current_version = highest_tracked_version(tracked_files)
     if current_version is None:
         raise RuntimeError("No tracked linux-entra-sso extension URLs found")
@@ -174,10 +197,14 @@ def update_tracked_urls(repo_root: Path, release: ReleaseInfo) -> list[Path]:
     return changed
 
 
-def validate_tracked_urls(repo_root: Path, release: ReleaseInfo) -> None:
+def validate_tracked_urls(
+    repo_root: Path,
+    release: ReleaseInfo,
+    candidate_paths: tuple[str, ...] = DEFAULT_EXTENSION_URL_PATHS,
+) -> None:
     expected = {release.firefox_url, release.thunderbird_url}
     unexpected: list[str] = []
-    for path in git_ls_files(repo_root):
+    for path in tracked_extension_url_files(repo_root, candidate_paths):
         if not path.is_file():
             continue
         try:

--- a/.github/workflows/linux-entra-sso-update.yml
+++ b/.github/workflows/linux-entra-sso-update.yml
@@ -1,0 +1,88 @@
+---
+name: Update Linux Entra SSO Extension
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-entra-sso-update-main
+  cancel-in-progress: false
+
+jobs:
+  update-linux-entra-sso:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.LINUX_ENTRA_SSO_UPDATE_APP_ID }}
+          private-key: ${{ secrets.LINUX_ENTRA_SSO_UPDATE_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Run updater tests
+        run: python3 .github/scripts/test_update_linux_entra_sso.py
+
+      - name: Update extension URLs
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: python3 .github/scripts/update_linux_entra_sso.py --check
+
+      - name: Validate policy JSON
+        run: |
+          set -euo pipefail
+          python3 -m json.tool src/sso-policies/src/firefox/policies.json >/dev/null
+          python3 -m json.tool src/sso-policies/src/thunderbird/policies.json >/dev/null
+
+      - name: Check diff
+        run: git diff --check
+
+      - name: Commit updated extension URLs
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet; then
+            echo "No linux-entra-sso update needed."
+            exit 0
+          fi
+
+          VERSION=$(python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path("src/sso-policies/src/firefox/policies.json").read_text()
+          match = re.search(r"linux_entra_sso-([0-9]+(?:\.[0-9]+){2})\.xpi", text)
+          if not match:
+              raise SystemExit("Unable to detect linux-entra-sso version")
+          print(match.group(1))
+          PY
+          )
+
+          git config user.name "Himmelblau SSO Updater"
+          git config user.email "action@github.com"
+          git add -u
+          git commit -m "fix(sso): update Entra SSO extension to ${VERSION}" \
+            -m "Update Firefox and Thunderbird policy URLs to linux-entra-sso ${VERSION}." \
+            --signoff
+          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,6 @@ platform/opensuse/himmelblau-hsm-pin-init.service
 
 platform/el/authselect
 scripts/__pycache__
+.github/scripts/__pycache__
 
 .claude/

--- a/nix/modules/himmelblau.nix
+++ b/nix/modules/himmelblau.nix
@@ -131,7 +131,7 @@ in
     programs.firefox = {
       policies = {
         Extensions.Install = [
-          "https://github.com/siemens/linux-entra-sso/releases/download/v1.7.1/linux_entra_sso-1.7.1.xpi"
+          "https://github.com/siemens/linux-entra-sso/releases/download/v1.9.1/linux_entra_sso-1.9.1.xpi"
         ];
       };
       nativeMessagingHosts.packages = [ cfg.ssoPackage ];

--- a/scripts/backport.py
+++ b/scripts/backport.py
@@ -13,14 +13,17 @@ Usage:
 """
 
 import argparse
+import importlib.util
 import json
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import ModuleType
 from typing import Optional, Set
 
 # Configuration constants
@@ -30,6 +33,8 @@ TIMEOUT_CARGO_UPDATE_SECONDS = 120  # 2 minutes for cargo update
 TIMEOUT_BUILD_SECONDS = 600  # 10 minutes for cargo build
 TIMEOUT_MAKE_VET_SECONDS = 600  # 10 minutes for make vet
 MAX_BUILD_FIX_ATTEMPTS = 3
+LINUX_ENTRA_SSO_UPDATER_PATH = ".github/scripts/update_linux_entra_sso.py"
+LINUX_ENTRA_SSO_UPDATER_REF = "origin/main"
 
 # Git status codes that indicate unresolved conflicts
 CONFLICT_STATUS_CODES = {"UU", "AA", "DD"}
@@ -974,6 +979,69 @@ class BackportManager:
         self.versions = versions
         self.repository = repository
         self.dry_run = dry_run
+        self._linux_entra_sso_updater: Optional[ModuleType] = None
+        self._linux_entra_sso_updater_tempdir: Optional[tempfile.TemporaryDirectory] = None
+
+    def _load_linux_entra_sso_updater_from_main(self) -> ModuleType:
+        """Load the linux-entra-sso updater from origin/main without checking it out."""
+        if self._linux_entra_sso_updater is not None:
+            return self._linux_entra_sso_updater
+
+        script_ref = f"{LINUX_ENTRA_SSO_UPDATER_REF}:{LINUX_ENTRA_SSO_UPDATER_PATH}"
+        result = self.git.run("show", script_ref)
+        tempdir = tempfile.TemporaryDirectory(prefix="himmelblau-linux-entra-sso-")
+        script_path = Path(tempdir.name) / "update_linux_entra_sso.py"
+        script_path.write_text(result.stdout, encoding="utf-8")
+
+        module_name = f"_himmelblau_update_linux_entra_sso_{id(self)}"
+        spec = importlib.util.spec_from_file_location(module_name, script_path)
+        if spec is None or spec.loader is None:
+            tempdir.cleanup()
+            raise RuntimeError(f"Could not load {script_ref}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            tempdir.cleanup()
+            raise
+
+        self._linux_entra_sso_updater = module
+        self._linux_entra_sso_updater_tempdir = tempdir
+        return module
+
+    def update_linux_entra_sso_extensions(self) -> Optional[str]:
+        """Update pinned linux-entra-sso extension URLs using the updater from main."""
+        print_color("\nUpdating linux-entra-sso extension URLs...", "blue")
+
+        try:
+            updater = self._load_linux_entra_sso_updater_from_main()
+            release = updater.fetch_latest_release()
+            changed = updater.update_tracked_urls(self.repo_root, release)
+            updater.validate_tracked_urls(self.repo_root, release)
+
+            if not changed:
+                print_color(f"  linux-entra-sso extension URLs already match {release.version}", "green")
+                return None
+
+            files_to_stage = [str(path) for path in changed]
+            self.git.add(*files_to_stage)
+            if self.git.has_staged_changes(*files_to_stage):
+                self.git.commit(
+                    f"fix(sso): update Entra SSO extension to {release.version}\n\n"
+                    f"Update Firefox and Thunderbird policy URLs to linux-entra-sso {release.version}.",
+                    signoff=True,
+                )
+                print_color(f"  Updated linux-entra-sso extension URLs to {release.version}", "green")
+                return str(release.version)
+
+            print_color("  No staged linux-entra-sso URL changes needed", "green")
+            return None
+        except Exception as e:
+            print_color(f"  Warning: Could not update linux-entra-sso extension URLs: {e}", "yellow")
+            return None
 
     def update_make_vet_from_main(self, target_branch: str) -> bool:
         """Update make vet target and cargo_vet_review.py from main branch."""
@@ -1302,6 +1370,7 @@ class BackportManager:
         target_version: SupportedVersion,
         commits: list[Commit],
         dependabot_prs: Optional[list[DependabotPR]] = None,
+        linux_entra_sso_version: Optional[str] = None,
     ) -> bool:
         """Create a PR for the backport."""
         print_color(f"\nCreating PR for {branch_name}...", "blue")
@@ -1330,11 +1399,20 @@ class BackportManager:
 
 """
 
+        extension_section = ""
+        if linux_entra_sso_version:
+            extension_section = f"""
+### Linux Entra SSO Extension Update Included
+- Updated pinned browser extension URLs to linux-entra-sso {linux_entra_sso_version}
+
+"""
+
         body = f"""## Summary
 Backport commits to {target_version.branch}:
 
 {commit_list}
 {dependabot_section}
+{extension_section}
 ## Test plan
 - [ ] Build succeeds
 - [ ] `make vet` passes
@@ -1353,6 +1431,8 @@ Generated with [Claude Code](https://claude.com/claude-code)
                 title_parts.append(f"{len(commits)} commits")
         if dependabot_prs:
             title_parts.append(f"{len(dependabot_prs)} dependency update(s)")
+        if linux_entra_sso_version:
+            title_parts.append(f"linux-entra-sso {linux_entra_sso_version}")
 
         title = f"Backport to {target_version.version}: " + " + ".join(title_parts)
 
@@ -1497,6 +1577,11 @@ Examples:
         "--skip-dependabot",
         action="store_true",
         help="Skip cherry-picking open dependabot PRs",
+    )
+    parser.add_argument(
+        "--skip-linux-entra-sso",
+        action="store_true",
+        help="Skip updating pinned linux-entra-sso browser extension URLs",
     )
     parser.add_argument(
         "--branch",
@@ -1890,6 +1975,12 @@ Examples:
         if not all_success:
             print_color(f"\nSome cherry-picks failed for {version_str}", "yellow")
 
+        linux_entra_sso_version = None
+        if not args.skip_linux_entra_sso:
+            linux_entra_sso_version = manager.update_linux_entra_sso_extensions()
+        else:
+            print_color("\nSkipping linux-entra-sso extension URL update (--skip-linux-entra-sso)", "yellow")
+
         # Try to build
         build_success, build_error = manager.try_build()
         max_fix_attempts = MAX_BUILD_FIX_ATTEMPTS
@@ -1950,7 +2041,9 @@ Examples:
                 # May fail if nothing to commit
                 pass
 
-        successful_branches.append((branch_name, target, commits_for_version, cherry_picked_dependabot_prs))
+        successful_branches.append(
+            (branch_name, target, commits_for_version, cherry_picked_dependabot_prs, linux_entra_sso_version)
+        )
         print_color(f"\nBackport branch {branch_name} ready", "green")
 
     # Return to original branch
@@ -1970,8 +2063,14 @@ Examples:
         print_color("Creating Pull Requests", "bold")
         print_color(f"{'=' * 70}", "cyan")
 
-        for branch_name, target, commits_list, dependabot_prs_list in successful_branches:
-            manager.create_pr(branch_name, target, [c for c, _info in commits_list], dependabot_prs_list)
+        for branch_name, target, commits_list, dependabot_prs_list, linux_entra_sso_version in successful_branches:
+            manager.create_pr(
+                branch_name,
+                target,
+                [c for c, _info in commits_list],
+                dependabot_prs_list,
+                linux_entra_sso_version,
+            )
 
     # Summary
     print()
@@ -1984,9 +2083,10 @@ Examples:
 
     if successful_branches:
         print("\n  Created branches:")
-        for branch_name, target, commits_list, dependabot_list in successful_branches:
+        for branch_name, target, commits_list, dependabot_list, linux_entra_sso_version in successful_branches:
             deps_info = f" (+{len(dependabot_list)} dependabot)" if dependabot_list else ""
-            print(f"    - {branch_name} -> {target.branch}{deps_info}")
+            sso_info = f" (+linux-entra-sso {linux_entra_sso_version})" if linux_entra_sso_version else ""
+            print(f"    - {branch_name} -> {target.branch}{deps_info}{sso_info}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add a daily workflow that checks upstream releases and updates tracked browser extension URLs. Include updater tests or version comparison, asset validation, drift repair, and downgrade refusal.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
