### PR TITLE
ci: add Socket firewall checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: dependency-firewall
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -151,6 +152,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: dependency-firewall
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -302,3 +304,31 @@ jobs:
       - name: Check for unused dependencies with udeps
         run: cargo +nightly udeps --all-targets
         continue-on-error: true
+
+  dependency-firewall:
+    name: Socket Dependency Firewall
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall
+
+      - name: Clear Cargo package cache
+        run: rm -rf ~/.cargo/registry ~/.cargo/git
+
+      - name: Fetch dependencies through Socket Firewall
+        run: |
+          unset RUSTC_WRAPPER
+          unset SCCACHE_GHA_ENABLED
+          sfw cargo fetch --locked

--- a/.github/workflows/fuzz_pr.yml
+++ b/.github/workflows/fuzz_pr.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@55d80eb3c5a4228eec5390a083c092095115c6f1 # nightly
         with: { components: llvm-tools-preview }
@@ -83,7 +87,7 @@ jobs:
             fuzz-weekly-corpus-${{ runner.os }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --version 0.13.1
+        run: sfw cargo install cargo-fuzz --version 0.13.1
 
       - name: Run ${{ matrix.target }} (ASan quick)
         run: |

--- a/.github/workflows/fuzz_weekly.yml
+++ b/.github/workflows/fuzz_weekly.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@55d80eb3c5a4228eec5390a083c092095115c6f1 # nightly
         with: { components: llvm-tools-preview }
@@ -83,7 +87,7 @@ jobs:
             fuzz-pr-corpus-${{ runner.os }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --version 0.13.1
+        run: sfw cargo install cargo-fuzz --version 0.13.1
 
       - name: Run ${{ matrix.target }} (ASan deep)
         run: |


### PR DESCRIPTION
## Summary

Route dependency-fetching cargo commands through Socket Firewall. Add a dedicated CI job to verify locked dependency fetches.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
