### PR TITLE
Debian orchestrator fixes

### DIFF
--- a/platform/debian/apparmor.himmelblau-orchestrator-container
+++ b/platform/debian/apparmor.himmelblau-orchestrator-container
@@ -1,6 +1,6 @@
 # AppArmor profile for the browser container launched by himmelblaud-orchestrator.
 
-abi <abi/4.0>,
+abi <abi/3.0>,
 include <tunables/global>
 
 profile himmelblau-orchestrator-container flags=(attach_disconnected,mediate_deleted) {

--- a/scripts/gen_servicefiles.py
+++ b/scripts/gen_servicefiles.py
@@ -344,7 +344,7 @@ WantedBy=himmelblaud.service
     ]
     orchestrator_private_devices = "PrivateDevices=false" if supported("PrivateDevices") else ""
     orchestrator_rw_line = (
-        "ReadWritePaths=/run/himmelblaud /run/lock /run/netns -/run/containers -/var/lib/containers -/run/libpod -/run/crun -/run/runc -/var/cache/himmelblaud/orchestrator -/var/cache/private/himmelblaud/orchestrator"
+        "ReadWritePaths=/run/himmelblaud /run/lock /run/netns -/run/containers -/var/lib/containers -/run/libpod -/run/crun -/run/runc -/etc/containers/networks -/var/cache/himmelblaud/orchestrator -/var/cache/private/himmelblaud/orchestrator"
         if rw_paths_available
         else ""
     )

--- a/src/apparmor/scripts/postinst
+++ b/src/apparmor/scripts/postinst
@@ -13,7 +13,9 @@ reload_apparmor_profile() {
         return 0
     fi
 
-    apparmor_parser -r "$profile" >/dev/null 2>&1 || echo "apparmor reload failed for $name" >&2
+    if ! apparmor_parser -r "$profile" >/dev/null; then
+        echo "apparmor reload failed for $name ($profile)" >&2
+    fi
 }
 
 reload_apparmor_profile /etc/apparmor.d/himmelblau-orchestrator-container himmelblau-orchestrator-container

--- a/src/nss/Cargo.toml
+++ b/src/nss/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { workspace = true }
 [package.metadata.deb]
 name = "nss-himmelblau"
 maintainer = "David Mulder <dmulder@suse.com>"
+depends = ["$auto", "libnss-systemd"]
 assets = [
   ["target/release/libnss_himmelblau.so", "usr/lib/libnss_himmelblau.so.2", "755"],
   ["src/nss-himmelblau.tmpfiles.conf", "usr/lib/tmpfiles.d/nss-himmelblau.conf", "644"],

--- a/src/orchestrator/src/main.rs
+++ b/src/orchestrator/src/main.rs
@@ -171,7 +171,7 @@ async fn main() -> Result<()> {
         ensure_container_image(&podman_client, Path::new(&args.container_build_dir)).await
     {
         error!(
-            %error,
+            error = %format_args!("{:#}", error),
             exit_code = CONTAINER_IMAGE_BUILD_FAILURE_EXIT_CODE,
             "orchestrator container image is unavailable; exiting without restart"
         );


### PR DESCRIPTION
## Summary

Fixes issues discovered when attempting to utilize the orchestrator for Keycloak native-MFA authentication on Debian 12.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:** Debian 12
- **Steps performed:** Authenticated against Keycloak.
- **Results observed:** Native-MFA successful.

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [x] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [x] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
