### PR TITLE
Add an Okta Orchestrator Provider

### DIFF
--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -56,7 +56,8 @@ libkrimes = { workspace = true }
 name = "himmelblau"
 maintainer = "David Mulder <dmulder@suse.com>"
 depends = ["$auto"]
-recommends = ["nss-himmelblau", "pam-himmelblau", "krb5-user", "cron", "tpm2-tools", "himmelblau-orchestrator", "himmelblau-apparmor"]
+recommends = ["nss-himmelblau", "pam-himmelblau", "krb5-user", "cron", "tpm2-tools", "himmelblau-apparmor"]
+suggests = ["himmelblau-orchestrator"]
 assets = [
   ["../../target/debian/himmelblau.conf.example", "etc/himmelblau/himmelblau.conf", "644"],
   ["../../src/config/gdm3_service_override.conf", "usr/lib/systemd/system/gdm3.service.d/himmelblau-override.conf", "644"],
@@ -115,7 +116,6 @@ nss-himmelblau = "*"
 pam-himmelblau = "*"
 himmelblau-selinux = "*"
 himmelblau-apparmor = "*"
-himmelblau-orchestrator = "*"
 krb5 = "*"
 cron = "*" # For Intune policy scripts
 system-user-tss = "*"
@@ -131,6 +131,7 @@ authd-msentraid = ""
 
 [package.metadata.generate-rpm.suggests]
 himmelblau-sso = ""
+himmelblau-orchestrator = "*"
 
 [package.metadata.generate-rpm.requires]
 man = ""

--- a/src/orchestrator/src/provider_definitions.rs
+++ b/src/orchestrator/src/provider_definitions.rs
@@ -9,8 +9,9 @@ use tokio::fs;
 use url::Url;
 
 //const BUILTIN_PROVIDER_KEYS: [&str; 4] = ["entra", "okta", "google", "keycloak"];
-const BUILTIN_PROVIDER_KEYS: [&str; 1] = ["keycloak"];
+const BUILTIN_PROVIDER_KEYS: [&str; 2] = ["keycloak", "okta"];
 const BUILTIN_KEYCLOAK_PROVIDER: &str = include_str!("providers/keycloak.json");
+const BUILTIN_OKTA_PROVIDER: &str = include_str!("providers/okta.json");
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderMatchers {
@@ -166,6 +167,14 @@ impl ProviderRegistry {
 
         // Keycloak
         for definition in parse_provider_override(BUILTIN_KEYCLOAK_PROVIDER)? {
+            validate_provider_definition(&definition)?;
+            if !by_name.contains_key(&definition.provider) {
+                by_name.insert(definition.provider.clone(), Arc::new(definition));
+            }
+        }
+
+        // Okta
+        for definition in parse_provider_override(BUILTIN_OKTA_PROVIDER)? {
             validate_provider_definition(&definition)?;
             if !by_name.contains_key(&definition.provider) {
                 by_name.insert(definition.provider.clone(), Arc::new(definition));
@@ -630,6 +639,19 @@ mod tests {
     #[test]
     fn validates_builtin_keycloak_provider() {
         let definitions = parse_provider_override(BUILTIN_KEYCLOAK_PROVIDER);
+        assert!(definitions.is_ok());
+
+        let mut definitions = definitions.unwrap_or_default();
+        assert!(!definitions.is_empty());
+
+        for definition in definitions.drain(..) {
+            assert!(validate_provider_definition(&definition).is_ok());
+        }
+    }
+
+    #[test]
+    fn validates_builtin_okta_provider() {
+        let definitions = parse_provider_override(BUILTIN_OKTA_PROVIDER);
         assert!(definitions.is_ok());
 
         let mut definitions = definitions.unwrap_or_default();

--- a/src/orchestrator/src/providers/okta.json
+++ b/src/orchestrator/src/providers/okta.json
@@ -3,11 +3,17 @@
   "display_name": "Okta",
   "matchers": {
     "issuer_contains": [
-      "okta.com"
+      "okta.com",
+      "oktapreview.com",
+      "okta-emea.com",
+      "okta-gov.com"
     ],
     "domains": [],
     "url_contains": [
-      "okta.com"
+      "okta.com",
+      "oktapreview.com",
+      "okta-emea.com",
+      "okta-gov.com"
     ]
   },
   "start_url": "$dag_auth_url",

--- a/src/orchestrator/src/providers/okta.json
+++ b/src/orchestrator/src/providers/okta.json
@@ -1,0 +1,274 @@
+{
+  "provider": "okta",
+  "display_name": "Okta",
+  "matchers": {
+    "issuer_contains": [
+      "okta.com"
+    ],
+    "domains": [],
+    "url_contains": [
+      "okta.com"
+    ]
+  },
+  "start_url": "$dag_auth_url",
+  "steps": [
+    {
+      "name": "okta_device_activation_code",
+      "wait_for": {
+        "selector": "[data-se='o-form-fieldset-userCode'] input[name='userCode']"
+      },
+      "required_inputs": [
+        {
+          "name": "dag_user_code",
+          "type": "text",
+          "prompt": null,
+          "optional": false
+        }
+      ],
+      "actions": [
+        {
+          "type": "fill",
+          "selector": "[data-se='o-form-fieldset-userCode'] input[name='userCode']",
+          "input": "dag_user_code"
+        },
+        {
+          "type": "click",
+          "selector": ".o-form-button-bar input[type='submit'][value='Next'][data-type='save']"
+        },
+        {
+          "type": "wait",
+          "millis": 3000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-identifier'] input[name='identifier'][autocomplete='username']"
+          },
+          "goto_step": "okta_identifier"
+        }
+      ]
+    },
+    {
+      "name": "okta_identifier",
+      "wait_for": {
+        "selector": "[data-se='o-form-fieldset-identifier'] input[name='identifier'][autocomplete='username']"
+      },
+      "required_inputs": [
+        {
+          "name": "username",
+          "type": "text",
+          "prompt": null,
+          "optional": false
+        }
+      ],
+      "actions": [
+        {
+          "type": "fill",
+          "selector": "[data-se='o-form-fieldset-identifier'] input[name='identifier'][autocomplete='username']",
+          "input": "username"
+        },
+        {
+          "type": "click",
+          "selector": "input[type='submit'][value='Next'], button[type='submit']"
+        },
+        {
+          "type": "wait",
+          "millis": 3000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": ".authenticator-verify-list [data-se='okta_password'] a[data-se='button'], .authenticator-verify-list [data-se='okta_verify-totp'] a[data-se='button']"
+          },
+          "goto_step": "okta_select_password_method"
+        },
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.passcode'] input[name='credentials.passcode'][type='password']"
+          },
+          "goto_step": "okta_password"
+        },
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.totp'] input[name='credentials.totp']"
+          },
+          "goto_step": "okta_verify_totp"
+        }
+      ]
+    },
+    {
+      "name": "okta_select_password_method",
+      "optional": true,
+      "wait_for": {
+        "selector": ".authenticator-verify-list [data-se='okta_password'] a[data-se='button']"
+      },
+      "required_inputs": [],
+      "actions": [
+        {
+          "type": "click",
+          "selector": ".authenticator-verify-list [data-se='okta_password'] a[data-se='button']"
+        },
+        {
+          "type": "wait",
+          "millis": 3000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.passcode'] input[name='credentials.passcode'][type='password']"
+          },
+          "goto_step": "okta_password"
+        },
+        {
+          "condition": {
+            "type": "always"
+          },
+          "goto_step": "okta_select_okta_verify_method"
+        }
+      ]
+    },
+    {
+      "name": "okta_select_okta_verify_method",
+      "optional": true,
+      "wait_for": {
+        "selector": ".authenticator-verify-list [data-se='okta_verify-totp'] a[data-se='button']"
+      },
+      "required_inputs": [],
+      "actions": [
+        {
+          "type": "click",
+          "selector": ".authenticator-verify-list [data-se='okta_verify-totp'] a[data-se='button']"
+        },
+        {
+          "type": "wait",
+          "millis": 3000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.totp'] input[name='credentials.totp']"
+          },
+          "goto_step": "okta_verify_totp"
+        }
+      ]
+    },
+    {
+      "name": "okta_verify_totp",
+      "wait_for": {
+        "selector": "[data-se='o-form-fieldset-credentials.totp'] input[name='credentials.totp']"
+      },
+      "required_inputs": [
+        {
+          "name": "otp",
+          "type": "otp",
+          "prompt": "Okta Verify code",
+          "optional": false
+        }
+      ],
+      "actions": [
+        {
+          "type": "fill",
+          "selector": "[data-se='o-form-fieldset-credentials.totp'] input[name='credentials.totp']",
+          "input": "otp"
+        },
+        {
+          "type": "click",
+          "selector": ".o-form-button-bar input[type='submit'][value='Verify'][data-type='save']"
+        },
+        {
+          "type": "wait",
+          "millis": 5000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "form[data-se='o-form'][action='/activate'].terminal-state"
+          },
+          "goto_step": "okta_confirm_device_login_success"
+        },
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.passcode'] input[name='credentials.passcode'][type='password']"
+          },
+          "goto_step": "okta_password"
+        }
+      ]
+    },
+    {
+      "name": "okta_password",
+      "wait_for": {
+        "selector": "[data-se='o-form-fieldset-credentials.passcode'] input[name='credentials.passcode'][type='password']"
+      },
+      "required_inputs": [
+        {
+          "name": "password",
+          "type": "password",
+          "prompt": "Password",
+          "long_prompt": "Verify with your password",
+          "optional": false
+        }
+      ],
+      "actions": [
+        {
+          "type": "fill",
+          "selector": "[data-se='o-form-fieldset-credentials.passcode'] input[name='credentials.passcode'][type='password']",
+          "input": "password"
+        },
+        {
+          "type": "click",
+          "selector": ".o-form-button-bar input[type='submit'][value='Verify'][data-type='save']"
+        },
+        {
+          "type": "wait",
+          "millis": 5000
+        }
+      ],
+      "branches": [
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "form[data-se='o-form'][action='/activate'].terminal-state"
+          },
+          "goto_step": "okta_confirm_device_login_success"
+        },
+        {
+          "condition": {
+            "type": "dom_selector",
+            "selector": "[data-se='o-form-fieldset-credentials.totp'] input[name='credentials.totp']"
+          },
+          "goto_step": "okta_verify_totp"
+        }
+      ]
+    },
+    {
+      "name": "okta_confirm_device_login_success",
+      "optional": true,
+      "wait_for": {
+        "selector": "form[data-se='o-form'][action='/activate'].terminal-state"
+      },
+      "required_inputs": [],
+      "actions": [
+        {
+          "type": "log",
+          "message": "Checking for Okta device-login success page."
+        }
+      ],
+      "success": {
+        "dom_selector": "form[data-se='o-form'][action='/activate'].terminal-state"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Okta as a built-in orchestrated authentication provider. We now have both Keycloak and Okta.

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:** openSUSE Tumbleweed.
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
