### PR TITLE
chore(deps): update libwebauthn to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluer"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af68112f5c60196495c8b0eea68349817855f565df5b04b2477916d09fb1a901"
+dependencies = [
+ "futures",
+ "hex",
+ "libc",
+ "log",
+ "macaddr",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "bluez-async"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +837,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -3124,14 +3151,16 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.3.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f74ddf06fefa81809987cb138dc265bcd50131bdce8f9d4ddc7e409a5c7167"
+checksum = "9e105a094cd8a9714866e5683c5be55ebdf6b4e734c09f5deeb3be6cadb23204"
 dependencies = [
  "aes",
+ "aes-gcm",
  "async-trait",
  "base64-url",
  "bitflags 2.9.1",
+ "bluer",
  "btleplug",
  "byteorder",
  "cbc",
@@ -3139,12 +3168,16 @@ dependencies = [
  "ctap-types",
  "curve25519-dalek",
  "dbus",
+ "der 0.7.10",
+ "flate2",
  "futures",
  "heapless",
  "hex",
  "hidapi",
  "hkdf",
  "hmac 0.12.1",
+ "http",
+ "icu_normalizer",
  "idna",
  "maplit",
  "mockall",
@@ -3152,6 +3185,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "p256",
+ "publicsuffix",
  "rand 0.8.6",
  "rustls",
  "serde",
@@ -3163,6 +3197,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.9",
  "snow",
+ "spki",
  "text_io",
  "thiserror 2.0.16",
  "time",
@@ -3171,8 +3206,10 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tungstenite",
+ "url",
  "uuid",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]
@@ -3243,6 +3280,12 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "malloced"
@@ -3372,6 +3415,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -5274,6 +5329,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -2212,6 +2212,113 @@ rec {
           "tracing" = [ "dep:tracing" ];
         };
       };
+      "bluer" = rec {
+        crateName = "bluer";
+        version = "0.17.4";
+        edition = "2021";
+        sha256 = "00d9n6gx05kr8yr08nyzcpsmay41961sdvmhr2an86b0bhpi2s5g";
+        authors = [
+          "Sebastian Urban <surban@surban.net>"
+          "BlueR contributors"
+          "Attila Dusnoki <adusnoki@inf.u-szeged.hu>"
+          "Ben Stern <bstern@fortian.com>"
+          "Dejan Bosanac <dbosanac@redhat.com>"
+        ];
+        dependencies = [
+          {
+            name = "futures";
+            packageId = "futures";
+          }
+          {
+            name = "hex";
+            packageId = "hex";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+          }
+          {
+            name = "log";
+            packageId = "log";
+          }
+          {
+            name = "macaddr";
+            packageId = "macaddr";
+          }
+          {
+            name = "nix";
+            packageId = "nix";
+            usesDefaultFeatures = false;
+            features = [ "ioctl" ];
+          }
+          {
+            name = "num-derive";
+            packageId = "num-derive";
+          }
+          {
+            name = "num-traits";
+            packageId = "num-traits";
+          }
+          {
+            name = "serde";
+            packageId = "serde";
+            optional = true;
+            features = [ "derive" ];
+          }
+          {
+            name = "strum";
+            packageId = "strum";
+            features = [ "derive" ];
+          }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "net" "io-util" ];
+          }
+          {
+            name = "uuid";
+            packageId = "uuid";
+            features = [ "v4" ];
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "serde";
+            packageId = "serde";
+            features = [ "derive" ];
+          }
+          {
+            name = "serde_json";
+            packageId = "serde_json";
+          }
+          {
+            name = "uuid";
+            packageId = "uuid";
+          }
+        ];
+        devDependencies = [
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "io-std" "io-util" "rt-multi-thread" "signal" ];
+          }
+        ];
+        features = {
+          "bluetoothd" = [ "dbus" "dbus-tokio" "dbus-crossroads" "pin-project" "tokio/rt" "tokio/sync" "tokio/macros" "tokio-stream" "lazy_static" "custom_debug" "displaydoc" ];
+          "custom_debug" = [ "dep:custom_debug" ];
+          "dbus" = [ "dep:dbus" ];
+          "dbus-crossroads" = [ "dep:dbus-crossroads" ];
+          "dbus-tokio" = [ "dep:dbus-tokio" ];
+          "displaydoc" = [ "dep:displaydoc" ];
+          "full" = [ "bluetoothd" "id" "l2cap" "rfcomm" "mesh" "serde" ];
+          "lazy_static" = [ "dep:lazy_static" ];
+          "mesh" = [ "bluetoothd" ];
+          "pin-project" = [ "dep:pin-project" ];
+          "serde" = [ "uuid/serde" "dep:serde" ];
+          "tokio-stream" = [ "dep:tokio-stream" ];
+        };
+        resolvedDefaultFeatures = [ "l2cap" ];
+      };
       "bluez-async" = rec {
         crateName = "bluez-async";
         version = "0.8.2";
@@ -2770,6 +2877,16 @@ rec {
           "core" = [ "dep:core" ];
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
+      };
+      "cfg_aliases" = rec {
+        crateName = "cfg_aliases";
+        version = "0.2.1";
+        edition = "2018";
+        sha256 = "092pxdc1dbgjb6qvh83gk56rkic2n2ybm4yvy76cgynmzi3zwfk1";
+        authors = [
+          "Zicklag <zicklag@katharostech.com>"
+        ];
+
       };
       "chacha20" = rec {
         crateName = "chacha20";
@@ -10167,16 +10284,22 @@ rec {
       };
       "libwebauthn" = rec {
         crateName = "libwebauthn";
-        version = "0.3.0";
+        version = "0.9.0";
         edition = "2021";
-        sha256 = "0rvibjd40znw9nfqzkmx640xbg35qa6i7jw7k6083ypy0vglvxy2";
+        sha256 = "011jnannrgmkxrfrzh1lwysgdgaywmdkqs75cr473afq9h4ml44y";
         authors = [
-          "Alfie Fresta <alfie.fresta@gmail.com>"
+          "Alfie Fresta <afresta@noentropy.org>"
+          "Martin Sirringhaus <martin.sirringhaus@suse.com>"
+          "Isaiah Inuwa <isaiah.inuwa@gmail.com>"
         ];
         dependencies = [
           {
             name = "aes";
             packageId = "aes";
+          }
+          {
+            name = "aes-gcm";
+            packageId = "aes-gcm";
           }
           {
             name = "async-trait";
@@ -10189,6 +10312,12 @@ rec {
           {
             name = "bitflags";
             packageId = "bitflags 2.9.1";
+          }
+          {
+            name = "bluer";
+            packageId = "bluer";
+            usesDefaultFeatures = false;
+            features = [ "l2cap" ];
           }
           {
             name = "btleplug";
@@ -10220,6 +10349,16 @@ rec {
             packageId = "dbus";
           }
           {
+            name = "der";
+            packageId = "der 0.7.10";
+            usesDefaultFeatures = false;
+            features = [ "alloc" "derive" "oid" ];
+          }
+          {
+            name = "flate2";
+            packageId = "flate2";
+          }
+          {
             name = "futures";
             packageId = "futures";
           }
@@ -10244,6 +10383,16 @@ rec {
           {
             name = "hmac";
             packageId = "hmac 0.12.1";
+          }
+          {
+            name = "http";
+            packageId = "http";
+          }
+          {
+            name = "icu_normalizer";
+            packageId = "icu_normalizer";
+            usesDefaultFeatures = false;
+            features = [ "compiled_data" ];
           }
           {
             name = "idna";
@@ -10273,6 +10422,10 @@ rec {
             name = "p256";
             packageId = "p256";
             features = [ "ecdh" "arithmetic" "serde" ];
+          }
+          {
+            name = "publicsuffix";
+            packageId = "publicsuffix";
           }
           {
             name = "rand";
@@ -10322,6 +10475,12 @@ rec {
             features = [ "use-p256" ];
           }
           {
+            name = "spki";
+            packageId = "spki";
+            usesDefaultFeatures = false;
+            features = [ "alloc" ];
+          }
+          {
             name = "text_io";
             packageId = "text_io";
           }
@@ -10356,6 +10515,10 @@ rec {
             packageId = "tungstenite";
           }
           {
+            name = "url";
+            packageId = "url";
+          }
+          {
             name = "uuid";
             packageId = "uuid";
             features = [ "serde" "v4" ];
@@ -10364,15 +10527,21 @@ rec {
             name = "x509-parser";
             packageId = "x509-parser";
           }
+          {
+            name = "zeroize";
+            packageId = "zeroize";
+            features = [ "derive" ];
+          }
         ];
         features = {
           "apdu" = [ "dep:apdu" ];
           "apdu-core" = [ "dep:apdu-core" ];
-          "libnfc" = [ "nfc" "nfc1-sys" "nfc1" ];
           "nfc" = [ "apdu-core" "apdu" ];
+          "nfc-backend-libnfc" = [ "nfc" "nfc1-sys" "nfc1" ];
+          "nfc-backend-pcsc" = [ "nfc" "dep:pcsc" ];
           "nfc1" = [ "dep:nfc1" ];
           "nfc1-sys" = [ "dep:nfc1-sys" ];
-          "pcsc" = [ "nfc" "dep:pcsc" ];
+          "reqwest-related-origins-source" = [ "dep:reqwest" ];
         };
         resolvedDefaultFeatures = [ "default" ];
       };
@@ -10584,6 +10753,21 @@ rec {
           "Jonathan Reem <jonathan.reem@gmail.com>"
         ];
 
+      };
+      "macaddr" = rec {
+        crateName = "macaddr";
+        version = "1.0.1";
+        edition = "2018";
+        sha256 = "1n5jxn79krlql810c4w3hdkvyqc01141dc5y6fr9sxff2yy0pvms";
+        authors = [
+          "svartalf <self@svartalf.info>"
+        ];
+        features = {
+          "default" = [ "std" ];
+          "serde" = [ "dep:serde" ];
+          "serde_std" = [ "std" "serde/std" ];
+        };
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
       "malloced" = rec {
         crateName = "malloced";
@@ -10939,6 +11123,53 @@ rec {
           "Jonathan Reem <jonathan.reem@gmail.com>"
         ];
 
+      };
+      "nix" = rec {
+        crateName = "nix";
+        version = "0.29.0";
+        edition = "2021";
+        sha256 = "0ikvn7s9r2lrfdm3mx1h7nbfjvcc6s9vxdzw7j5xfkd2qdnp9qki";
+        authors = [
+          "The nix-rust Project Developers"
+        ];
+        dependencies = [
+          {
+            name = "bitflags";
+            packageId = "bitflags 2.9.1";
+          }
+          {
+            name = "cfg-if";
+            packageId = "cfg-if";
+          }
+          {
+            name = "libc";
+            packageId = "libc";
+            features = [ "extra_traits" ];
+          }
+        ];
+        buildDependencies = [
+          {
+            name = "cfg_aliases";
+            packageId = "cfg_aliases";
+          }
+        ];
+        features = {
+          "aio" = [ "pin-utils" ];
+          "dir" = [ "fs" ];
+          "memoffset" = [ "dep:memoffset" ];
+          "mount" = [ "uio" ];
+          "mqueue" = [ "fs" ];
+          "net" = [ "socket" ];
+          "pin-utils" = [ "dep:pin-utils" ];
+          "ptrace" = [ "process" ];
+          "sched" = [ "process" ];
+          "signal" = [ "process" ];
+          "socket" = [ "memoffset" ];
+          "ucontext" = [ "signal" ];
+          "user" = [ "feature" ];
+          "zerocopy" = [ "fs" "uio" ];
+        };
+        resolvedDefaultFeatures = [ "ioctl" ];
       };
       "nom 7.1.3" = rec {
         crateName = "nom";
@@ -17338,6 +17569,69 @@ rec {
         authors = [
           "Danny Guo <danny@dannyguo.com>"
           "maxbachmann <oss@maxbachmann.de>"
+        ];
+
+      };
+      "strum" = rec {
+        crateName = "strum";
+        version = "0.26.3";
+        edition = "2018";
+        sha256 = "01lgl6jvrf4j28v5kmx9bp480ygf1nhvac8b4p7rcj9hxw50zv4g";
+        authors = [
+          "Peter Glotfelty <peter.glotfelty@microsoft.com>"
+        ];
+        dependencies = [
+          {
+            name = "strum_macros";
+            packageId = "strum_macros";
+            optional = true;
+          }
+        ];
+        devDependencies = [
+          {
+            name = "strum_macros";
+            packageId = "strum_macros";
+          }
+        ];
+        features = {
+          "default" = [ "std" ];
+          "derive" = [ "strum_macros" ];
+          "phf" = [ "dep:phf" ];
+          "strum_macros" = [ "dep:strum_macros" ];
+        };
+        resolvedDefaultFeatures = [ "default" "derive" "std" "strum_macros" ];
+      };
+      "strum_macros" = rec {
+        crateName = "strum_macros";
+        version = "0.26.4";
+        edition = "2018";
+        sha256 = "1gl1wmq24b8md527cpyd5bw9rkbqldd7k1h38kf5ajd2ln2ywssc";
+        procMacro = true;
+        authors = [
+          "Peter Glotfelty <peter.glotfelty@microsoft.com>"
+        ];
+        dependencies = [
+          {
+            name = "heck";
+            packageId = "heck";
+          }
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "rustversion";
+            packageId = "rustversion";
+          }
+          {
+            name = "syn";
+            packageId = "syn 2.0.117";
+            features = [ "parsing" "extra-traits" ];
+          }
         ];
 
       };

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -1,4 +1,4 @@
-.TH HIMMELBLAU.CONF "5" "July 2026" "Himmelblau Configuration" "File Formats"
+.TH HIMMELBLAU.CONF "5" "August 2026" "Himmelblau Configuration" "File Formats"
 .SH NAME
 himmelblau.conf \- Configuration file for Himmelblau, enabling Azure Entra ID authentication on Linux.
 

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -76,6 +76,51 @@ in
       example = "https://login.microsoftonline.com/0656e57d-a8fc-4aa4-8366-8045787115ca/v2.0";
     };
 
+    oidc_account_id_claims = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = ''
+        A comma-separated, ordered list of OIDC userinfo claim names to use as the
+        Linux account name for generic OIDC providers.
+        
+        When this option is set, Himmelblau tries each named claim in order and uses
+        the first claim that is present as a non-empty string. The claim names are not
+        limited to standard OpenID Connect claims; provider-specific userinfo claims
+        may also be listed.
+        
+        If none of the configured claims match a non-empty string claim in userinfo,
+        Himmelblau logs a warning and falls back to the default account-name selection:
+        **preferred_username**
+        first, then
+        **email.**
+      '';
+      example = [ "uid" "username" "preferred_username" "email" ];
+    };
+
+    oidc_account_id_strip_at_suffix = mkOption {
+      type = types.nullOr (types.bool);
+      default = false;
+      description = ''
+        A boolean option that removes any suffix beginning with
+        **@**
+        from the OIDC account name selected by
+        **oidc_account_id_claims**
+        or by the default
+        **preferred_username**
+        then
+        **email**
+        fallback.
+        
+        This is useful when the selected OIDC claim is scoped, such as
+        **user@example.com,**
+        but the desired Linux account name is only the local portion.
+        Only enable this when the remaining local portion is unique across all accepted
+        OIDC issuers/domains; otherwise distinct identities that differ only by suffix
+        can collide on the same Linux account name.
+      '';
+      example = true;
+    };
+
     debug = mkOption {
       type = types.nullOr (types.bool);
       default = false;
@@ -91,9 +136,11 @@ in
       type = types.nullOr (types.listOf types.str);
       default = null;
       description = ''
-        A comma-separated list of Entra Id Users and Groups permitted to access the system. Users should be specified by UPN. Groups MUST be specified using their Object ID GUID. Group names may not be used because these names are not guaranteed to be unique in Entra Id.
+        A comma-separated list of users and groups permitted to access the system.
+        For Entra ID, users should be specified by UPN. Entra ID groups MUST be specified using their Object ID GUID. Group names may not be used because these names are not guaranteed to be unique in Entra ID.
+        For generic OIDC providers, group and role entries may be specified by the exact value emitted in the userinfo groups, realm_access.roles, or resource_access roles claim.
         
-        If not set, all Entra ID users are permitted to authenticate.
+        If not set, all users are permitted to authenticate.
         
         This restriction is enforced during PAM account management: a user who is not
         permitted causes pam_himmelblau to return PAM_AUTH_ERR from its account phase.

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1.12.3"
 sha2 = "0.11.0"
 base64.workspace = true
 authenticator = { version = "0.5.0", default-features = false, features = ["crypto_openssl"] }
-libwebauthn = "0.3.0"
+libwebauthn = "0.9.0"
 rpassword = "7.5.2"
 der = "0.8.0"
 openidconnect = "4.0.1"

--- a/src/common/src/auth.rs
+++ b/src/common/src/auth.rs
@@ -43,8 +43,10 @@ use authenticator::{
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 use base64::Engine;
 use libwebauthn::ops::webauthn::{GetAssertionRequest, UserVerificationRequirement as CableUvReq};
-use libwebauthn::transport::cable::qr_code_device::{CableQrCodeDevice, QrCodeOperationHint};
-use libwebauthn::transport::Device;
+use libwebauthn::transport::cable::qr_code_device::{
+    CableQrCodeDevice, CableTransports, QrCodeOperationHint,
+};
+use libwebauthn::transport::{ChannelSettings, Device};
 use libwebauthn::webauthn::WebAuthn;
 use rpassword::prompt_password;
 use serde_json::{json, to_string as json_to_string};
@@ -415,11 +417,14 @@ async fn qr_bluetooth_fido_auth(
     let mut device = match device {
         Some(d) => d,
         None => {
-            let d = CableQrCodeDevice::new_transient(QrCodeOperationHint::GetAssertionRequest)
-                .map_err(|e| {
-                    error!("Failed to create QR/Bluetooth device: {:?}", e);
-                    PamResultCode::PAM_CRED_INSUFFICIENT
-                })?;
+            let d = CableQrCodeDevice::new_transient(
+                QrCodeOperationHint::GetAssertionRequest,
+                CableTransports::CloudAssistedOnly,
+            )
+            .map_err(|e| {
+                error!("Failed to create QR/Bluetooth device: {:?}", e);
+                PamResultCode::PAM_CRED_INSUFFICIENT
+            })?;
             let qr_url = d.qr_code.to_string();
             // Combine into single print_text to avoid GDM per-message delay.
             msg_printer.print_text(&format!("[QR_BT_LABEL] {}\n[QR_BT] {}", qr_prompt, qr_url));
@@ -428,10 +433,13 @@ async fn qr_bluetooth_fido_auth(
     };
 
     // Wait for the phone to scan the QR and establish a BLE tunnel.
-    let mut channel = device.channel().await.map_err(|e| {
-        error!("QR/Bluetooth channel establishment failed: {:?}", e);
-        PamResultCode::PAM_CRED_INSUFFICIENT
-    })?;
+    let mut channel = device
+        .channel(ChannelSettings::default())
+        .await
+        .map_err(|e| {
+            error!("QR/Bluetooth channel establishment failed: {:?}", e);
+            PamResultCode::PAM_CRED_INSUFFICIENT
+        })?;
 
     // Empty allowList forces the phone to use a discoverable credential,
     // which includes userHandle (required by Entra to identify the user).
@@ -439,7 +447,7 @@ async fn qr_bluetooth_fido_auth(
         relying_party_id: "login.microsoft.com".to_string(),
         challenge: fido_challenge.as_bytes().to_vec(),
         origin: "https://login.microsoft.com".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: vec![],
         extensions: None,
         user_verification: CableUvReq::Preferred,
@@ -518,8 +526,11 @@ pub fn fido_auth_with_qr_bluetooth(
     // (FIDO_INSERT + QR_BT_LABEL + QR_BT) in a single print_text call
     // from within fido_auth. This avoids concurrent PAM conversation
     // calls that block each other for ~2.5s each in GDM.
-    let cable_device = CableQrCodeDevice::new_transient(QrCodeOperationHint::GetAssertionRequest)
-        .map_err(|e| {
+    let cable_device = CableQrCodeDevice::new_transient(
+        QrCodeOperationHint::GetAssertionRequest,
+        CableTransports::CloudAssistedOnly,
+    )
+    .map_err(|e| {
         error!("Failed to create QR/Bluetooth device: {:?}", e);
         PamResultCode::PAM_CRED_INSUFFICIENT
     })?;

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -607,6 +607,11 @@ version = "0.8.2"
 [[audits.libwebauthn]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+version = "0.9.0"
+
+[[audits.libwebauthn]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.2.2 -> 0.3.0"
 
 [[audits.locale_config]]
@@ -653,6 +658,11 @@ version = "0.36.1"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.7.3 -> 0.8.4"
+
+[[audits.nix]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+version = "0.15.0"
 
 [[audits.nom]]
 who = "David Mulder <dmulder@samba.org>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -691,14 +691,6 @@ criteria = "safe-to-deploy"
 version = "0.1.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.libwebauthn]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.libwebauthn]]
-version = "0.9.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.mac]]
 version = "0.1.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -695,6 +695,10 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.libwebauthn]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.mac]]
 version = "0.1.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1655,6 +1655,12 @@ criteria = "safe-to-deploy"
 version = "2.1.0"
 notes = "Some unsafe usage but with safety comments and tests, and appear sound but didn't do detailed evaluation. No ambient capabilities"
 
+[[audits.embark-studios.audits.cfg_aliases]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "No unsafe usage or ambient capabilities"
+
 [[audits.embark-studios.audits.ident_case]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -2350,6 +2356,28 @@ Previously reviewed during security review and the audit is grandparented in.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.strum]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strum_macros]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.tinyvec]]
 who = "Adrian Taylor <adetaylor@chromium.org>"
 criteria = "safe-to-deploy"
@@ -2931,6 +2959,13 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.2.1"
+notes = "Very minor changes."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.core-foundation]]
@@ -3522,6 +3557,47 @@ criteria = "safe-to-deploy"
 delta = "0.6.5 -> 0.7.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.nix]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.15.0 -> 0.25.0"
+notes = "Plenty of new bindings but also several important bug fixes (including buffer overflows). New unsafe sections are restricted to wrappers and are no more dangerous than calling the C functions."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.25.0 -> 0.25.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.25.1 -> 0.26.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.26.2 -> 0.27.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.27.1 -> 0.28.0"
+notes = """
+Many new features and bugfixes. Obviously there's a lot of unsafe code calling
+libc, but the usage looks correct.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.28.0 -> 0.29.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.num-conv]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3807,6 +3883,18 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-c
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.10.0 -> 0.11.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strum]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.25.0 -> 0.26.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.strum_macros]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.25.3 -> 0.26.4"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.subtle]]


### PR DESCRIPTION
Thanks for using [libwebauthn](https://github.com/linux-credentials/libwebauthn)! I maintain it, so I figured I'd save you the bump. 0.3.0 is six releases behind. It's picked up a lot of security fixes since then, the API surface has changed non-trivially, and a pile of bugs got cleared out along the way, including caBLE fixes around Android compatibility.

The only file that touches libwebauthn is `src/common/src/auth.rs` (the caBLE QR login), so the migration is small. Three breaking-API adjustments:

- `GetAssertionRequest`: `cross_origin` is replaced by `top_origin`. himmelblau sets neither, so it stays `None`.
- `CableQrCodeDevice::new_transient` now takes a `CableTransports`. I pass `CloudAssistedOnly`, which preserves 0.3.0's exact behavior (the alternative also advertises a direct BLE L2CAP channel, which isn't stable yet).
- `Device::channel` now takes a `ChannelSettings`. I pass `ChannelSettings::default()`, which is empty today. Its only field is an optional store for reusing PIN/UV tokens across sessions, which himmelblau doesn't use.

I compiled the migration against 0.9.0 locally, but will let CI cover the full build. The one thing CI can't exercise is the live phone leg, so could one of you smoke-test a caBLE phone login before merging? Happy to jump in if anything looks off. Thanks!
