### PR TITLE
fix(nss): avoid locked shadow entries

### DIFF
--- a/src/nss/src/implementation.rs
+++ b/src/nss/src/implementation.rs
@@ -481,7 +481,7 @@ fn group_from_nssgroup(ng: NssGroup) -> Group {
 fn shadow_from_nssuser(nu: &NssUser) -> Shadow {
     Shadow {
         name: nu.name.clone(),
-        passwd: "!".to_string(), // Locked - passwords handled by Azure AD/pam_himmelblau
+        passwd: "x".to_string(), // Hash invalid - passwords handled by pam_himmelblau
         last_change: -1,         // Disable Unix password aging; auth is handled by pam_himmelblau.
         change_min_days: 0,
         change_max_days: 99999,
@@ -889,7 +889,7 @@ mod tests {
         let shadow = mapped_shadow_from_nssuser(&nu, &cfg, Some("alice-local".to_string()));
 
         assert_eq!(shadow.name, "alice-local");
-        assert_eq!(shadow.passwd, "!");
+        assert_eq!(shadow.passwd, "x");
         assert_eq!(shadow.last_change, -1);
         Ok(())
     }
@@ -902,7 +902,7 @@ mod tests {
         let shadow = mapped_shadow_from_nssuser(&nu, &cfg, None);
 
         assert_eq!(shadow.name, "alice");
-        assert_eq!(shadow.passwd, "!");
+        assert_eq!(shadow.passwd, "x");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Return an invalid shadow hash instead of a lock marker. This keeps GDM from hiding Himmelblau users.

Fixes #1508 and #1519

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
