### PR TITLE
fix(broker): try silent token acquire before interactive pinentry

### DIFF
--- a/src/broker/src/main.rs
+++ b/src/broker/src/main.rs
@@ -169,9 +169,10 @@ impl MessagePrinter for PinentryMessagePrinter {
 }
 
 /// Session broker that forwards all D-Bus calls to the himmelblaud
-/// broker socket, but overrides `acquireTokenInteractively` to
-/// drive a full interactive auth (via `authenticate()` on the main
-/// daemon socket with pinentry) when silent acquisition fails.
+/// broker socket, but overrides `acquireTokenInteractively` to try
+/// silent acquisition first and only fall back to interactive auth
+/// (via `authenticate()` on the main daemon socket with pinentry)
+/// when silent fails and a graphical session is available.
 struct InteractiveSessionBroker {
     /// Path to the himmelblaud broker socket.
     broker_sock_path: String,
@@ -311,7 +312,31 @@ impl SessionBroker for InteractiveSessionBroker {
         correlation_id: String,
         request_json: String,
     ) -> Result<String, dbus::MethodErr> {
-        // Extract the username from the request for authenticate()
+        // Prefer silent first. Edge/OneAuth often calls AcquireTokenInteractively
+        // even when a warm PRT can satisfy the request. Interactive auth needs
+        // DISPLAY/WAYLAND_DISPLAY + pinentry, which himmelblau-broker often
+        // lacks under background.slice — failing interactive first returned
+        // org.freedesktop.DBus.Error.Failed (Edge tag 4ulu3) despite a usable PRT.
+        match self.acquire_token_silently(
+            protocol_version.clone(),
+            correlation_id.clone(),
+            request_json.clone(),
+        ) {
+            Ok(resp) => return Ok(resp),
+            Err(e) => {
+                info!(
+                    "Silent token acquisition failed ({}); considering interactive re-auth",
+                    e
+                );
+            }
+        }
+
+        if !interactive_session_available() {
+            return Err(dbus::MethodErr::failed(
+                &"Silent token acquisition failed and no interactive session is available to re-authenticate",
+            ));
+        }
+
         let account_id = Self::extract_account_id(&request_json)
             .ok_or_else(|| dbus::MethodErr::failed(&"Missing account username in request"))?;
 


### PR DESCRIPTION
## Summary

- Edge/OneAuth on Linux calls D-Bus `AcquireTokenInteractively` (`com.microsoft.identity.broker1`) even when a warm PRT can already satisfy the request.
- `InteractiveSessionBroker::acquire_token_interactively` previously **always** ran pinentry interactive auth first, then silent. Interactive auth requires `DISPLAY`/`WAYLAND_DISPLAY` + pinentry in the **broker process**; `himmelblau-broker` often runs under `background.slice` without those vars.
- Result: immediate `org.freedesktop.DBus.Error.Failed` → Edge “Something went wrong” / tag **4ulu3**, despite `getAccounts` working and a usable PRT.

This PR prefers **silent-first**, matching the existing silent-then-interactive pattern used for PRT SSO cookies:

1. Try `acquire_token_silently`
2. Only if that fails **and** `interactive_session_available()`: pinentry re-auth, then silent again
3. Otherwise return a clear D-Bus error (instead of failing interactive when silent would have worked)

## Why this is Edge-visible

Chrome on Himmelblau typically uses `himmelblau-sso` / native messaging for web SSO. Edge profile “Sign in to sync” uses OneAuth → broker Interactive API, so it hits this path.

## Test plan

- [ ] Build/install patched `himmelblau-broker` on an Entra-joined host with warm PRT
- [ ] Confirm broker env often lacks `DISPLAY`/`WAYLAND` (`tr '\\0' '\\n' < /proc/$(systemctl --user show -p MainPID --value himmelblau-broker.service)/environ | grep -E DISPLAY|WAYLAND`)
- [ ] Edge → Sign in to sync / work account: should succeed (or at least not fail immediately with 4ulu3 when silent token works)
- [ ] Cold PRT / expired session: silent fails → interactive prompt only when a graphical session is available
- [ ] Regression: `getAccounts`, `acquireTokenSilently`, PRT SSO cookie path still behave as before