### PR TITLE
pam: fold info text into the password prompt (single PAM_PROMPT_ECHO_…

### DIFF
--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -6,7 +6,7 @@
 Himmelblau
 .SH SYNOPSIS
 \f[B]pam_himmelblau.so\f[R] [debug] [use_first_pass]
-[ignore_unknown_user] [mfa_poll_prompt] [no_hello_pin] [try_unseal]
+[ignore_unknown_user] [mfa_poll_prompt] [no_hello_pin] [no_info_prompt] [try_unseal]
 .SH DESCRIPTION
 \f[B]pam_himmelblau\f[R] is a PAM module that authenticates users
 against Microsoft Azure Entra ID using the Himmelblau daemon
@@ -51,6 +51,17 @@ Matching services are configured with
 Disables Linux Hello PIN login for this service (e.g., for
 \f[CR]sudo\f[R] or \f[CR]ssh\f[R]), even if Hello is configured
 globally.
+.IP \(bu 2
+\f[B]no_info_prompt\f[R]
+.PD 0
+.P
+.PD
+Folds any informational text (the configured Entra password prompt and any
+MFA message) into the password prompt itself, so the PAM conversation carries
+a single \f[CR]PAM_PROMPT_ECHO_OFF\f[R] instead of sending a separate
+\f[CR]PAM_TEXT_INFO\f[R] message first.
+Required for PAM consumers that cannot carry a standalone info message during
+authentication, such as the MariaDB \f[CR]auth_pam\f[R] dialog relay.
 .IP \(bu 2
 \f[B]try_unseal\f[R]
 .PD 0

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -6,7 +6,7 @@
 
 # SYNOPSIS
 
-**pam_himmelblau.so** [debug] [use_first_pass] [ignore_unknown_user] [mfa_poll_prompt] [no_hello_pin] [try_unseal]
+**pam_himmelblau.so** [debug] [use_first_pass] [ignore_unknown_user] [mfa_poll_prompt] [no_hello_pin] [no_info_prompt] [try_unseal]
 
 # DESCRIPTION
 
@@ -28,6 +28,9 @@
 
 - **no_hello_pin**  
   Disables Linux Hello PIN login for this service (e.g., for `sudo` or `ssh`), even if Hello is configured globally.
+
+- **no_info_prompt**  
+  Folds any informational text (the configured Entra password prompt and any MFA message) into the password prompt itself, so the PAM conversation carries a single `PAM_PROMPT_ECHO_OFF` instead of sending a separate `PAM_TEXT_INFO` message first. Required for PAM consumers that cannot carry a standalone info message during authentication, such as MariaDB's `auth_pam` dialog relay.
 
 - **try_unseal**  
   Silently attempt to unseal the Hello secret using the password from a previous PAM module (similar to how `pam_gnome_keyring.so` unlocks the GNOME keyring at login). Implies `use_first_pass` and `ignore_unknown_user`. Will never fail and never wait for an answer, as it simply sends a request via IPC to himmelblaud. Intended for use with `user_map_file` setups where a local user logs in via `pam_unix` or another local auth flow, so that the Hello secret will be unsealed automatically, without requiring a manual `aad-tool` invocation. Requires the local user password to be identical to the himmelblau PIN.

--- a/src/broker/src/main.rs
+++ b/src/broker/src/main.rs
@@ -377,6 +377,7 @@ impl InteractiveSessionBroker {
             ignore_unknown_user: false,
             mfa_poll_prompt: false,
             no_hello_pin: false,
+            no_info_prompt: false,
             set_authtok: false,
             try_unseal: false,
             force_reauth: false,

--- a/src/common/src/auth.rs
+++ b/src/common/src/auth.rs
@@ -822,21 +822,36 @@ fn handle_pam_auth_response_password(
     let cred = if let Some(cred) = consume_authtok {
         cred
     } else {
-        if let Some(long_prompt) = long_prompt.filter(|prompt| !prompt.trim().is_empty()) {
-            state.msg_printer.print_text(long_prompt);
+        let fold = state.opts.no_info_prompt;
+        let long_prompt = long_prompt.filter(|prompt| !prompt.trim().is_empty());
+
+        // The info text is normally sent as a standalone PAM_TEXT_INFO before the
+        // prompt. With no_info_prompt it is folded into the single password prompt
+        // instead, for PAM clients that cannot carry a separate info message during
+        // authentication (e.g. MariaDB's auth_pam dialog).
+        if !fold {
+            if let Some(long_prompt) = long_prompt {
+                state.msg_printer.print_text(long_prompt);
+            }
         }
 
         let prompt = match prompt.filter(|prompt| !prompt.trim().is_empty()) {
             Some(prompt) => i18n::translate_external_message(prompt),
             None if state.cfg.get_oidc_issuer_url().is_some() => tr("Cloud Password:"),
             None => {
-                state
-                    .msg_printer
-                    .print_text(&i18n::translate_external_message(
-                        &state.cfg.get_entra_id_password_prompt(),
-                    ));
-                tr("Entra Id Password:")
+                let info =
+                    i18n::translate_external_message(&state.cfg.get_entra_id_password_prompt());
+                if fold {
+                    format!("{}\n{}", info, tr("Entra Id Password:"))
+                } else {
+                    state.msg_printer.print_text(&info);
+                    tr("Entra Id Password:")
+                }
             }
+        };
+        let prompt = match (fold, long_prompt) {
+            (true, Some(long_prompt)) => format!("{}\n{}", long_prompt, prompt),
+            _ => prompt,
         };
         match state.msg_printer.prompt_echo_off(&prompt) {
             Some(cred) => cred,
@@ -1563,6 +1578,7 @@ mod tests {
     struct RecordingPrinter {
         text: Mutex<Vec<String>>,
         error: Mutex<Vec<String>>,
+        prompts: Mutex<Vec<String>>,
     }
 
     impl MessagePrinter for RecordingPrinter {
@@ -1578,8 +1594,9 @@ mod tests {
             None
         }
 
-        fn prompt_echo_off(&self, _prompt: &str) -> Option<String> {
-            None
+        fn prompt_echo_off(&self, prompt: &str) -> Option<String> {
+            self.prompts.lock().unwrap().push(prompt.to_string());
+            Some("hunter2".to_string())
         }
     }
 
@@ -1871,6 +1888,78 @@ mod tests {
         assert!(
             msg.len() > input.len(),
             "DAG message should still include generated QR content"
+        );
+    }
+
+    fn test_password_state(
+        printer: Arc<RecordingPrinter>,
+    ) -> (AuthenticateState, std::os::unix::net::UnixListener) {
+        let socket_path = format!("/tmp/himmelblau_auth_test_sock_{}", uuid::Uuid::new_v4());
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path)
+            .expect("Failed to bind test socket");
+        let daemon_client =
+            DaemonClientBlocking::new(&socket_path).expect("Failed to connect test socket");
+        (
+            AuthenticateState {
+                daemon_client,
+                authtok: None,
+                cfg: test_config(""),
+                account_id: "user@example.com".to_string(),
+                service: "mariadb".to_string(),
+                opts: Options::default(),
+                msg_printer: printer,
+                poll_attempt: 0,
+                polling_interval: 0,
+            },
+            listener,
+        )
+    }
+
+    // no_info_prompt folds the info text into a single PAM_PROMPT_ECHO_OFF.
+    #[test]
+    fn test_no_info_prompt_folds_info_into_single_prompt() {
+        let printer = Arc::new(RecordingPrinter::default());
+        let (mut state, _listener) = test_password_state(printer.clone());
+        state.opts.no_info_prompt = true;
+
+        let next = handle_pam_auth_response_password(&mut state, None, Some("MFA required"));
+
+        assert!(
+            printer.text.lock().unwrap().is_empty(),
+            "no standalone info text should be emitted when folding"
+        );
+        let prompts = printer.prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1, "folding must produce a single prompt");
+        assert!(prompts[0].starts_with("MFA required"));
+        assert!(prompts[0].contains(&state.cfg.get_entra_id_password_prompt()));
+        assert!(prompts[0].contains("Entra Id Password:"));
+        match next {
+            PamWhatNext::Next(ClientRequest::PamAuthenticateStep(PamAuthRequest::Password {
+                cred,
+            })) => assert_eq!(cred, "hunter2"),
+            _ => panic!("expected a password step request"),
+        }
+    }
+
+    // Default (no_info_prompt unset) keeps the upstream behavior: info as separate text.
+    #[test]
+    fn test_default_sends_info_as_separate_text() {
+        let printer = Arc::new(RecordingPrinter::default());
+        let (mut state, _listener) = test_password_state(printer.clone());
+
+        let _ = handle_pam_auth_response_password(&mut state, None, Some("MFA required"));
+
+        let text = printer.text.lock().unwrap();
+        assert!(text.iter().any(|t| t.contains("MFA required")));
+        assert!(text
+            .iter()
+            .any(|t| t.contains(&state.cfg.get_entra_id_password_prompt())));
+        let prompts = printer.prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].contains("Entra Id Password:"));
+        assert!(
+            !prompts[0].contains("MFA required"),
+            "info must not be folded into the prompt by default"
         );
     }
 }

--- a/src/common/src/pam.rs
+++ b/src/common/src/pam.rs
@@ -73,6 +73,7 @@ pub struct Options {
     pub ignore_unknown_user: bool,
     pub mfa_poll_prompt: bool,
     pub no_hello_pin: bool,
+    pub no_info_prompt: bool,
     pub set_authtok: bool,
     pub try_unseal: bool,
     /// Only set by CLI (aad-tool auth-test --force-reauth), not parsed from PAM module arguments.
@@ -99,6 +100,7 @@ impl TryFrom<&Vec<&CStr>> for Options {
             ignore_unknown_user: gopts.contains("ignore_unknown_user") || try_unseal,
             mfa_poll_prompt: gopts.contains("mfa_poll_prompt"),
             no_hello_pin: gopts.contains("no_hello_pin"),
+            no_info_prompt: gopts.contains("no_info_prompt"),
             set_authtok: gopts.contains("set_authtok") || gopts.contains("keyring_authtok"),
             try_unseal,
             force_reauth: false,


### PR DESCRIPTION
## Summary

pam_himmelblau sends a standalone PAM_TEXT_INFO before the password prompt.
Some PAM clients don't honour info messages during authentication (OpenSSH
bug 2876), and for others it breaks the conversation outright: MariaDB's
auth_pam dialog relay aborts with "unexpected response from failed
conversation function", making Entra-backed PAM authentication to MariaDB
impossible. This folds the info text into the prompt message itself, so the
conversation carries a single PAM_PROMPT_ECHO_OFF and the user still sees all
the text.

Fixes #1539

## What changed

- `handle_pam_auth_response_password` no longer emits standalone PAM_TEXT_INFO:
  `long_prompt` and the configured `entra_id_password_prompt` are folded into
  the single PAM_PROMPT_ECHO_OFF prompt message.
- Test support: `RecordingPrinter` now records prompts and returns a
  credential; two new unit tests assert the behavior (no PAM_TEXT_INFO emitted,
  one prompt containing all the text, credential flows through).

## Testing

- **Distro(s) tested:** Debian 12, Debian 13
- **Steps performed:** `make test`; built the Debian packages (`make debian12`,
  `make debian13`) and installed them on a test host; connected to MariaDB
  (10.11, `auth_pam` + pam_himmelblau in the `mariadb` PAM service).
- **Results observed:** the password prompt now reaches the client and the PAM
  conversation proceeds where it previously aborted with "unexpected response
  from failed conversation function"; SSH/sudo prompts behave as before, with
  the info text delivered inside the prompt message.

## Automated Checks

- [x] I ran `make test` (all crates green, incl. 2 new tests for this change)
- [x] I ran the distro package build target (`make debian12`, `make debian13`)
- [x] I ran `make test-selinux` — no SELinux changes; policy passes on
  rocky8/9/10, fedora43/44, tumbleweed; sle16 skipped (needs SUSE SCC creds)

## System Integration Impact

PAM only. The password branch's conversation changes from
PAM_TEXT_INFO + PAM_PROMPT_ECHO_OFF to a single PAM_PROMPT_ECHO_OFF whose
message includes the info text. No NSS, systemd, SELinux/AppArmor, filesystem
path, or credential handling changes.

## Checklist

- [x] I manually tested this change on a test VM
- [x] PR scope is focused and linked to an issue/enhancement/discussion