### PR TITLE
Reconcile local groups periodically

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -498,6 +498,17 @@ A comma-separated list of local groups that every Entra ID user should be a memb
 Example: local_groups = sudo,admin
 
 .TP
+.B local_groups_reconcile_interval
+.RE
+The interval in seconds for periodically reconciling configured local group membership for cached Entra ID users. This keeps the configured local sudo group in sync with sudo_groups between login attempts. Set to 0 to disable periodic reconciliation.
+
+.P
+Default: 300
+
+.P
+Example: local_groups_reconcile_interval = 300
+
+.TP
 .B sudo_groups
 .RE
 A comma-separated list of Azure Entra ID group object IDs whose members should be granted

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -394,6 +394,15 @@ in
       example = [ "sudo" "admin" ];
     };
 
+    local_groups_reconcile_interval = mkOption {
+      type = types.nullOr (types.ints.unsigned);
+      default = 300;
+      description = ''
+        The interval in seconds for periodically reconciling configured local group membership for cached Entra ID users. This keeps the configured local sudo group in sync with sudo_groups between login attempts. Set to 0 to disable periodic reconciliation.
+      '';
+      example = 300;
+    };
+
     sudo_groups = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;

--- a/src/common/docs-xml/himmelblauconf/base/local_groups_reconcile_interval.xml
+++ b/src/common/docs-xml/himmelblauconf/base/local_groups_reconcile_interval.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="local_groups_reconcile_interval"
+           section="global"
+           type="u64"
+           rust_type="u64"
+           documented="true"
+           domain_specific="false"
+           order="1810">
+<description>
+The interval in seconds for periodically reconciling configured local group membership for cached Entra ID users. This keeps the configured local sudo group in sync with sudo_groups between login attempts. Set to 0 to disable periodic reconciliation.
+</description>
+<conf_description>Interval (seconds) for local group reconciliation; 0 disables it.</conf_description>
+<default>300</default>
+<default_const>DEFAULT_LOCAL_GROUPS_RECONCILE_INTERVAL</default_const>
+<example>local_groups_reconcile_interval = 300</example>
+</parameter>

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -36,13 +36,14 @@ use crate::constants::{
     DEFAULT_CONSOLE_PASSWORD_ONLY, DEFAULT_DB_PATH, DEFAULT_FIDO_TIMEOUT, DEFAULT_HELLO_ENABLED,
     DEFAULT_HELLO_PIN_MIN_LEN, DEFAULT_HELLO_PIN_RETRY_COUNT, DEFAULT_HOME_ALIAS,
     DEFAULT_HOME_ATTR, DEFAULT_HOME_PREFIX, DEFAULT_HSM_PIN_PATH, DEFAULT_ID_ATTR_MAP,
-    DEFAULT_JOIN_TYPE, DEFAULT_LOGON_SCRIPT_TIMEOUT, DEFAULT_MFA_POLL_PROMPT_SERVICES,
-    DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL, DEFAULT_ORCHESTRATOR_SOCK_PATH,
-    DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST, DEFAULT_POLICIES_DB_DIR,
-    DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX, DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL,
-    DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH, DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE,
-    DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE, NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX,
-    RUNTIME_CONFIG_PATH, SERVER_CONFIG_PATH, VENDOR_CONFIG_PATH,
+    DEFAULT_JOIN_TYPE, DEFAULT_LOCAL_GROUPS_RECONCILE_INTERVAL, DEFAULT_LOGON_SCRIPT_TIMEOUT,
+    DEFAULT_MFA_POLL_PROMPT_SERVICES, DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL,
+    DEFAULT_ORCHESTRATOR_SOCK_PATH, DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST,
+    DEFAULT_POLICIES_DB_DIR, DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX,
+    DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
+    DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE, DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE,
+    NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX, RUNTIME_CONFIG_PATH, SERVER_CONFIG_PATH,
+    VENDOR_CONFIG_PATH,
 };
 use crate::mapping::{MappedNameCache, Mode};
 use crate::unix_config::{HomeAttr, HsmType};
@@ -1872,6 +1873,24 @@ mod tests {
         assert_eq!(config.get_local_groups(), expected_groups);
         let config_empty = create_empty_config();
         assert_eq!(config_empty.get_local_groups(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_get_local_groups_reconcile_interval() {
+        let config_data = r#"
+        [global]
+        local_groups_reconcile_interval = 0
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        assert_eq!(config.get_local_groups_reconcile_interval(), 0);
+        let config_empty = create_empty_config();
+        assert_eq!(
+            config_empty.get_local_groups_reconcile_interval(),
+            DEFAULT_LOCAL_GROUPS_RECONCILE_INTERVAL
+        );
     }
 
     #[test]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -52,6 +52,7 @@ pub const DEFAULT_CONN_TIMEOUT: u64 = 30;
 pub const DEFAULT_REQUEST_TIMEOUT: u64 = 10;
 pub const DEFAULT_LOGON_SCRIPT_TIMEOUT: u64 = 60;
 pub const DEFAULT_CACHE_TIMEOUT: u64 = 300;
+pub const DEFAULT_LOCAL_GROUPS_RECONCILE_INTERVAL: u64 = 300;
 pub const DEFAULT_SELINUX: bool = true;
 pub const DEFAULT_HSM_PIN_PATH: &str = "/var/lib/himmelblaud/hsm-pin";
 pub const DEFAULT_HSM_PIN_PATH_ENC: &str = "/var/lib/himmelblaud/hsm-pin-nopcr.enc";

--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -526,6 +526,15 @@ where
         dbtxn.get_accounts().map_err(|_| ())
     }
 
+    pub async fn refresh_cached_usertoken(
+        &self,
+        account_id: &str,
+    ) -> Result<Option<UserToken>, ()> {
+        let id = Id::Name(account_id.to_string());
+        let (_expired, token) = self.get_cached_usertoken(&id).await?;
+        self.refresh_usertoken(&id, token).await
+    }
+
     async fn get_cached_grouptokens(&self) -> Result<Vec<GroupToken>, ()> {
         let mut dbtxn = self.db.write().await;
         dbtxn.get_groups().map_err(|_| ())

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -19,7 +19,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fs::metadata;
 use std::io;
@@ -93,6 +93,8 @@ type AsyncTaskRequest = (TaskRequest, oneshot::Sender<TaskOutcome>);
 type IntunePolicyThrottle = Arc<Mutex<HashMap<String, IntunePolicyThrottleState>>>;
 
 const INTUNE_POLICY_THROTTLE_INTERVAL: Duration = Duration::from_secs(30 * 60);
+const LOCAL_GROUPS_TASK_QUEUE_TIMEOUT: Duration = Duration::from_millis(100);
+const LOCAL_GROUPS_TASK_RESPONSE_TIMEOUT: Duration = Duration::from_millis(1000);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IntunePolicyThrottleState {
@@ -260,6 +262,149 @@ async fn handle_task_client(
 /// (`passwd`, `login`, `sshd`). Any other peer may only change its own PIN.
 fn peer_may_change_hello_pin(peer_uid: u32, target_uid: Option<u32>) -> bool {
     peer_uid == 0 || target_uid == Some(peer_uid)
+}
+
+async fn is_account_sudoer(
+    cachelayer: &Resolver<HimmelblauMultiProvider>,
+    cfg: &HimmelblauConfig,
+    account_id: &str,
+) -> bool {
+    for sudo_group in cfg.get_sudo_groups() {
+        let sudo_group_uuid = match Uuid::parse_str(&sudo_group) {
+            Ok(uuid) => uuid,
+            Err(e) => {
+                debug!("Failed to parse a sudo group: {}", e);
+                continue;
+            }
+        };
+
+        let members = cachelayer.get_groupmembers(sudo_group_uuid).await;
+        if members.iter().any(|member| member == account_id) {
+            return true;
+        }
+    }
+
+    false
+}
+
+async fn submit_local_groups_task(
+    task_channel_tx: &Sender<AsyncTaskRequest>,
+    account_id: String,
+    is_sudoer: bool,
+) -> Result<(), ()> {
+    let (tx, rx) = oneshot::channel();
+
+    task_channel_tx
+        .send_timeout(
+            (TaskRequest::LocalGroups(account_id, is_sudoer), tx),
+            LOCAL_GROUPS_TASK_QUEUE_TIMEOUT,
+        )
+        .await
+        .map_err(|_| ())?;
+
+    match time::timeout(LOCAL_GROUPS_TASK_RESPONSE_TIMEOUT, rx).await {
+        Ok(Ok(TaskOutcome::Status(0))) => Ok(()),
+        _ => Err(()),
+    }
+}
+
+async fn reconcile_local_groups_once(
+    cachelayer: &Resolver<HimmelblauMultiProvider>,
+    task_channel_tx: &Sender<AsyncTaskRequest>,
+    cfg: &HimmelblauConfig,
+) {
+    let sudo_groups = cfg.get_sudo_groups();
+    if cfg.get_local_groups().is_empty() && sudo_groups.is_empty() {
+        trace!("Skipping local group reconciliation; no local groups configured");
+        return;
+    }
+
+    let sudo_group_ids: HashSet<Uuid> = sudo_groups
+        .iter()
+        .filter_map(|sudo_group| match Uuid::parse_str(sudo_group) {
+            Ok(uuid) => Some(uuid),
+            Err(e) => {
+                debug!("Failed to parse a sudo group: {}", e);
+                None
+            }
+        })
+        .collect();
+
+    let accounts = match cachelayer.get_nssaccounts().await {
+        Ok(accounts) => accounts,
+        Err(()) => {
+            warn!("Unable to fetch cached users for local group reconciliation");
+            return;
+        }
+    };
+
+    for account in accounts {
+        let is_sudoer = if sudo_group_ids.is_empty() {
+            false
+        } else {
+            let token = match cachelayer.refresh_cached_usertoken(&account.name).await {
+                Ok(Some(token)) => token,
+                Ok(None) => {
+                    trace!(
+                        account_id = account.name.as_str(),
+                        "Skipping local group reconciliation for missing user"
+                    );
+                    continue;
+                }
+                Err(()) => {
+                    warn!(
+                        account_id = account.name.as_str(),
+                        "Failed to refresh cached user before local group reconciliation"
+                    );
+                    continue;
+                }
+            };
+
+            token
+                .groups
+                .iter()
+                .any(|group| sudo_group_ids.contains(&group.uuid))
+        };
+
+        if submit_local_groups_task(task_channel_tx, account.name.clone(), is_sudoer)
+            .await
+            .is_err()
+        {
+            warn!(
+                account_id = account.name.as_str(),
+                "Failed to reconcile local groups for cached user"
+            );
+        }
+    }
+}
+
+async fn reconcile_local_groups_periodically(
+    cachelayer: Arc<Resolver<HimmelblauMultiProvider>>,
+    task_channel_tx: Arc<Sender<AsyncTaskRequest>>,
+    cfg: HimmelblauConfig,
+    mut shutdown_rx: broadcast::Receiver<bool>,
+) {
+    let interval_secs = cfg.get_local_groups_reconcile_interval();
+    if interval_secs == 0 {
+        info!("Periodic local group reconciliation disabled");
+        return;
+    }
+
+    let mut interval = time::interval(Duration::from_secs(interval_secs));
+    interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                break;
+            }
+            _ = interval.tick() => {
+                reconcile_local_groups_once(&cachelayer, &task_channel_tx, &cfg).await;
+            }
+        }
+    }
+
+    info!("Stopped local group reconciler");
 }
 
 async fn handle_client(
@@ -745,58 +890,21 @@ async fn handle_client(
                                 }
                             };
 
-                            let (tx, rx) = oneshot::channel();
+                            let is_sudoer =
+                                is_account_sudoer(&cachelayer, &cfg, account_id.as_str()).await;
 
-                            let sudo_groups = cfg.get_sudo_groups();
-                            let mut is_sudoer: bool = false;
-
-                            for sudo_group in sudo_groups {
-                                let sudo_group_uuid = match Uuid::parse_str(&sudo_group) {
-                                    Ok(uuid) => uuid,
-                                    Err(e) => {
-                                        debug!("Failed to parse a sudo group: {}", e);
-                                        continue;
-                                    }
-                                };
-
-                                let members = cachelayer.get_groupmembers(sudo_group_uuid).await;
-                                if members.contains(&account_id) {
-                                    is_sudoer = true;
-                                }
-                            }
-
-                            let resp2 = match task_channel_tx
-                                .send_timeout(
-                                    (
-                                        TaskRequest::LocalGroups(account_id.to_string(), is_sudoer),
-                                        tx,
-                                    ),
-                                    Duration::from_millis(100),
-                                )
-                                .await
+                            let resp2 = match submit_local_groups_task(
+                                task_channel_tx,
+                                account_id.to_string(),
+                                is_sudoer,
+                            )
+                            .await
                             {
                                 Ok(()) => {
-                                    // Now wait for the other end OR timeout.
-                                    match time::timeout_at(
-                                        time::Instant::now() + Duration::from_millis(1000),
-                                        rx,
-                                    )
-                                    .await
-                                    {
-                                        Ok(Ok(_)) => {
-                                            trace!("Task completed, returning to pam ...");
-                                            ClientResponse::Ok
-                                        }
-                                        _ => {
-                                            // Timeout or other error.
-                                            ClientResponse::Error
-                                        }
-                                    }
+                                    trace!("Task completed, returning to pam ...");
+                                    ClientResponse::Ok
                                 }
-                                Err(_) => {
-                                    // We could not submit the req. Move on!
-                                    ClientResponse::Error
-                                }
+                                Err(()) => ClientResponse::Error,
                             };
 
                             // Set up subordinate IDs for container support
@@ -1965,6 +2073,20 @@ async fn main() -> ExitCode {
             let (broadcast_tx, mut broadcast_rx) = broadcast::channel(4);
             let mut c_broadcast_rx = broadcast_tx.subscribe();
             let mut d_broadcast_rx = broadcast_tx.subscribe();
+            let local_groups_broadcast_rx = broadcast_tx.subscribe();
+
+            let local_groups_cachelayer = cachelayer.clone();
+            let local_groups_task_channel_tx = task_channel_tx.clone();
+            let local_groups_cfg = cfg.clone();
+            let local_groups_reconciler = tokio::spawn(async move {
+                reconcile_local_groups_periodically(
+                    local_groups_cachelayer,
+                    local_groups_task_channel_tx,
+                    local_groups_cfg,
+                    local_groups_broadcast_rx,
+                )
+                .await;
+            });
 
             let task_b = tokio::spawn(async move {
                 loop {
@@ -2273,6 +2395,7 @@ async fn main() -> ExitCode {
 
             let _ = task_a.await;
             let _ = task_b.await;
+            let _ = local_groups_reconciler.await;
             let _ = task_c.await;
             let _ = task_d.await;
 


### PR DESCRIPTION
Fixes #719

## Summary
- add enabled-by-default periodic reconciliation for configured local group membership
- reuse the existing root task-daemon LocalGroups path so sudo_groups revocation can be reflected between login attempts
- add local_groups_reconcile_interval config, defaulting to 300 seconds; set to 0 to disable
- document the new option in the man page and NixOS options

## systemd-userdb assessment
systemd-userdb is not a direct replacement for the current local group mutation path here. It can publish NSS-style user/group records through systemd-userdbd, but Himmelblau still owns the Entra membership decision and existing NSS integration. For the requested sudo_groups revocation behavior, periodically reconciling cached Entra users through the existing task daemon keeps behavior consistent with login-time reconciliation and avoids requiring operators to replace NSS/group handling with a separate userdb provider.

## Validation
- cargo fmt --all --check
- git diff --check
- generated Rust config accessor checked from XML

Full cargo check/test could not complete in this environment because libdbus-sys requires pkg-config/dbus-1 metadata and pkg-config is not installed.