### PR TITLE
Add configurable OIDC account ID claims

### DIFF
--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -120,6 +120,52 @@ grant continue to use the device flow.
 Example: oidc_issuer_url = https://login.microsoftonline.com/0656e57d-a8fc-4aa4-8366-8045787115ca/v2.0
 
 .TP
+.B oidc_account_id_claims
+.RE
+A comma-separated, ordered list of OIDC userinfo claim names to use as the
+Linux account name for generic OIDC providers.
+
+When this option is set, Himmelblau tries each named claim in order and uses
+the first claim that is present as a non-empty string. The claim names are not
+limited to standard OpenID Connect claims; provider-specific userinfo claims
+may also be listed.
+
+If none of the configured claims match a non-empty string claim in userinfo,
+Himmelblau logs a warning and falls back to the default account-name selection:
+.B preferred_username
+first, then
+.B email.
+
+.P
+Example: oidc_account_id_claims = uid,username,preferred_username,email
+
+.TP
+.B oidc_account_id_strip_at_suffix
+.RE
+A boolean option that removes any suffix beginning with
+.B @
+from the OIDC account name selected by
+.B oidc_account_id_claims
+or by the default
+.B preferred_username
+then
+.B email
+fallback.
+
+This is useful when the selected OIDC claim is scoped, such as
+.B user@example.com,
+but the desired Linux account name is only the local portion.
+Only enable this when the remaining local portion is unique across all accepted
+OIDC issuers/domains; otherwise distinct identities that differ only by suffix
+can collide on the same Linux account name.
+
+.P
+Default: false
+
+.P
+Example: oidc_account_id_strip_at_suffix = true
+
+.TP
 .B debug
 .RE
 A boolean option that enables debug-level logging. When set to

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -348,8 +348,9 @@ PAM_SERVICE \- If the service name matches entries in
 PAM_TTY \- If the terminal name contains "ssh" (fallback check)
 .RE
 
-This option requires the device to be domain-joined, matching the behavior of Microsoft-managed devices. Users can still
-use Hello PIN authentication if it is configured. To require MFA for all logins
+For Microsoft Entra ID, this option requires the device to be domain-joined,
+matching the behavior of Microsoft-managed devices. Users can still use Hello
+PIN authentication if it is configured. To require MFA for all logins
 (including local console), set this option to
 .B false.
 
@@ -360,9 +361,10 @@ When a generic OIDC provider is configured (see
 Password Credentials (ROPC) grant. It is only offered when the provider
 advertises the
 .B password
-grant type in its discovery document; providers that disable this grant fall
-back to the device-authorization (browser) flow. If the provider additionally
-requires MFA, authentication falls back to the device flow automatically.
+grant type in its discovery document and does not require the device to be
+domain-joined; providers that disable this grant fall back to the
+device-authorization (browser) flow. If the provider additionally requires MFA,
+authentication falls back to the device flow automatically.
 
 .P
 Default: true

--- a/src/common/docs-xml/himmelblauconf/base/oidc_account_id_claims.xml
+++ b/src/common/docs-xml/himmelblauconf/base/oidc_account_id_claims.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="oidc_account_id_claims"
+           section="global"
+           type="string_list"
+           rust_type="Vec&lt;String&gt;"
+           documented="true"
+           domain_specific="false"
+           order="210">
+<description>
+A comma-separated, ordered list of OIDC userinfo claim names to use as the
+Linux account name for generic OIDC providers.
+
+When this option is set, Himmelblau tries each named claim in order and uses
+the first claim that is present as a non-empty string. The claim names are not
+limited to standard OpenID Connect claims; provider-specific userinfo claims
+may also be listed.
+
+If none of the configured claims match a non-empty string claim in userinfo,
+Himmelblau logs a warning and falls back to the default account-name selection:
+.B preferred_username
+first, then
+.B email.
+</description>
+<conf_description>Ordered OIDC userinfo claims used for Linux account names.</conf_description>
+<default></default>
+<example>oidc_account_id_claims = uid,username,preferred_username,email</example>
+</parameter>

--- a/src/common/docs-xml/himmelblauconf/base/oidc_account_id_strip_at_suffix.xml
+++ b/src/common/docs-xml/himmelblauconf/base/oidc_account_id_strip_at_suffix.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="oidc_account_id_strip_at_suffix"
+           section="global"
+           type="bool"
+           rust_type="bool"
+           documented="true"
+           domain_specific="false"
+           order="211">
+<description>
+A boolean option that removes any suffix beginning with
+.B @
+from the OIDC account name selected by
+.B oidc_account_id_claims
+or by the default
+.B preferred_username
+then
+.B email
+fallback.
+
+This is useful when the selected OIDC claim is scoped, such as
+.B user@example.com,
+but the desired Linux account name is only the local portion.
+Only enable this when the remaining local portion is unique across all accepted
+OIDC issuers/domains; otherwise distinct identities that differ only by suffix
+can collide on the same Linux account name.
+</description>
+<conf_description>Strip @suffix from selected OIDC Linux account names.</conf_description>
+<default>false</default>
+<example>oidc_account_id_strip_at_suffix = true</example>
+</parameter>

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -59,16 +59,18 @@ use openidconnect::core::{
     CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
     CoreGenderClaim, CoreGrantType, CoreJsonWebKey, CoreJweContentEncryptionAlgorithm,
     CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType,
-    CoreSubjectIdentifierType, CoreUserInfoClaims,
+    CoreSubjectIdentifierType,
 };
 use openidconnect::{
-    AdditionalProviderMetadata, AuthType, ClientId, DeviceAuthorizationResponse,
+    AdditionalClaims, AdditionalProviderMetadata, AuthType, ClientId, DeviceAuthorizationResponse,
     DeviceAuthorizationUrl, EmptyAdditionalClaims, EmptyExtraDeviceAuthorizationFields,
     EndpointMaybeSet, EndpointNotSet, EndpointSet, IdTokenFields, IssuerUrl, OAuth2TokenResponse,
-    ProviderMetadata, Scope,
+    ProviderMetadata, Scope, UserInfoClaims,
 };
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::net::UnixStream;
@@ -869,11 +871,11 @@ fn orchestrator_inputs_from_pam_request(
 #[cfg(test)]
 mod tests {
     use super::{
-        auth_request_from_orchestrator_inputs, mfa_from_oidc_device,
+        auth_request_from_orchestrator_inputs, mfa_from_oidc_device, oidc_account_id_from_userinfo,
         oidc_should_prompt_hello_setup, orchestrator_inputs_from_pam_request,
         parse_oidc_mfa_extra_data, ropc_is_invalid_credentials, serialize_oidc_mfa_extra_data,
-        validated_password_cache_action, OidcMfaExtraData, OrchestratorFlowState,
-        OrchestratorInputType, OrchestratorRequiredInput,
+        validated_password_cache_action, OidcMfaExtraData, OidcUserInfoClaims,
+        OrchestratorFlowState, OrchestratorInputType, OrchestratorRequiredInput,
     };
     use crate::idprovider::interface::{AuthCacheAction, AuthRequest, AuthResult};
     use crate::unix_proto::PamAuthRequest;
@@ -919,6 +921,117 @@ mod tests {
         assert!(!oidc_should_prompt_hello_setup(true, true, true, true));
         assert!(!oidc_should_prompt_hello_setup(true, false, false, true));
         assert!(!oidc_should_prompt_hello_setup(true, false, true, false));
+    }
+
+    #[test]
+    fn oidc_account_id_uses_first_matching_configured_claim() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "preferred@example.com",
+                "email": "email@example.com",
+                "uid": "linuxuser"
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        let claims = vec![
+            "missing".to_string(),
+            "uid".to_string(),
+            "email".to_string(),
+        ];
+
+        assert_eq!(
+            oidc_account_id_from_userinfo(&userinfo, &claims, false).unwrap(),
+            "linuxuser"
+        );
+    }
+
+    #[test]
+    fn oidc_account_id_falls_back_when_configured_claims_miss() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "preferred@example.com",
+                "email": "email@example.com"
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        let claims = vec!["uid".to_string(), "username".to_string()];
+
+        assert_eq!(
+            oidc_account_id_from_userinfo(&userinfo, &claims, false).unwrap(),
+            "preferred@example.com"
+        );
+    }
+
+    #[test]
+    fn oidc_account_id_fallback_skips_empty_claims() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "",
+                "email": "email@example.com"
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            oidc_account_id_from_userinfo(&userinfo, &[], false).unwrap(),
+            "email@example.com"
+        );
+    }
+
+    #[test]
+    fn oidc_account_id_fallback_rejects_empty_claims() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "",
+                "email": ""
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        assert!(oidc_account_id_from_userinfo(&userinfo, &[], false).is_err());
+    }
+
+    #[test]
+    fn oidc_account_id_strips_at_suffix_when_configured() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "preferred@example.com",
+                "email": "email@example.com"
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            oidc_account_id_from_userinfo(&userinfo, &[], true).unwrap(),
+            "preferred"
+        );
+    }
+
+    #[test]
+    fn oidc_account_id_rejects_empty_after_stripping_at_suffix() {
+        let userinfo = OidcUserInfoClaims::from_json::<reqwest::Error>(
+            br#"{
+                "sub": "24400320",
+                "preferred_username": "@example.com",
+                "email": "email@example.com"
+            }"#,
+            None,
+        )
+        .unwrap();
+
+        assert!(oidc_account_id_from_userinfo(&userinfo, &[], true).is_err());
     }
 
     #[test]
@@ -1284,6 +1397,12 @@ type OidcTokenResponse = StandardTokenResponse<
     BasicTokenType,
 >;
 
+#[derive(Debug, Deserialize, Serialize)]
+struct OidcAdditionalUserInfoClaims(HashMap<String, Value>);
+impl AdditionalClaims for OidcAdditionalUserInfoClaims {}
+
+type OidcUserInfoClaims = UserInfoClaims<OidcAdditionalUserInfoClaims, CoreGenderClaim>;
+
 pub trait OidcTokenResponseExt {
     fn into_unix_user_token(self) -> Result<UnixUserToken, MsalError>;
 }
@@ -1435,6 +1554,110 @@ fn oidc_should_prompt_hello_setup(
     has_refresh_token: bool,
 ) -> bool {
     hello_enabled && !no_hello_pin && hello_key_missing && has_refresh_token
+}
+
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn oidc_claim_string(userinfo_json: &Value, claim: &str) -> Option<String> {
+    match userinfo_json.get(claim) {
+        Some(Value::String(value)) if !value.is_empty() => Some(value.to_string()),
+        Some(value) => {
+            if matches!(value, Value::String(_)) {
+                warn!(
+                    claim,
+                    "OIDC account ID claim is present but is an empty string"
+                );
+            } else {
+                warn!(
+                    claim,
+                    value_type = value_type_name(value),
+                    "OIDC account ID claim is present but is not a string"
+                );
+            }
+            None
+        }
+        None => None,
+    }
+}
+
+fn oidc_fallback_account_id(userinfo: &OidcUserInfoClaims) -> Option<String> {
+    userinfo
+        .preferred_username()
+        .map(|username| username.to_string())
+        .filter(|username| !username.is_empty())
+        .or_else(|| {
+            userinfo
+                .email()
+                .map(|email| email.to_string())
+                .filter(|email| !email.is_empty())
+        })
+}
+
+fn oidc_account_id_from_userinfo(
+    userinfo: &OidcUserInfoClaims,
+    configured_claims: &[String],
+    strip_at_suffix: bool,
+) -> Result<String, IdpError> {
+    let account_id = if configured_claims.is_empty() {
+        oidc_fallback_account_id(userinfo).ok_or_else(|| {
+            error!("Missing non-empty preferred_username and email claims in userinfo");
+            IdpError::BadRequest
+        })?
+    } else {
+        let userinfo_json = serde_json::to_value(userinfo).map_err(|e| {
+            error!(?e, "Failed to serialize OIDC userinfo claims");
+            IdpError::BadRequest
+        })?;
+
+        let mut configured_account_id = None;
+        for claim in configured_claims {
+            if let Some(account_id) = oidc_claim_string(&userinfo_json, claim) {
+                configured_account_id = Some(account_id);
+                break;
+            }
+        }
+
+        if let Some(account_id) = configured_account_id {
+            account_id
+        } else {
+            warn!(
+                claims = ?configured_claims,
+                "Configured OIDC account ID claims did not match any non-empty string userinfo claim; falling back to preferred_username, then email"
+            );
+
+            oidc_fallback_account_id(userinfo).ok_or_else(|| {
+                error!(
+                    claims = ?configured_claims,
+                    "Configured OIDC account ID claims did not match and fallback preferred_username/email claims are missing or empty"
+                );
+                IdpError::BadRequest
+            })?
+        }
+    };
+
+    if strip_at_suffix {
+        let account_id = account_id
+            .split_once('@')
+            .map(|(local, _)| local.to_string())
+            .unwrap_or(account_id);
+        if account_id.is_empty() {
+            error!("OIDC account ID is empty after stripping @suffix");
+            Err(IdpError::BadRequest)
+        } else {
+            Ok(account_id)
+        }
+    } else {
+        Ok(account_id)
+    }
 }
 
 fn validated_password_cache_action(
@@ -1933,9 +2156,11 @@ impl OidcApplication {
         shell: String,
         idmap: &Mutex<Idmap>,
         tenant_id: &Uuid,
+        account_id_claims: &[String],
+        strip_at_suffix: bool,
     ) -> Result<UserToken, IdpError> {
         let access_token = token.access_token();
-        let userinfo: CoreUserInfoClaims = if let Some(delayed_init) = &*self.client.lock().await {
+        let userinfo: OidcUserInfoClaims = if let Some(delayed_init) = &*self.client.lock().await {
             delayed_init
                 .client
                 .user_info(access_token.clone(), None)
@@ -1954,14 +2179,8 @@ impl OidcApplication {
             return Err(IdpError::BadRequest);
         };
 
-        let account_id = userinfo
-            .preferred_username()
-            .map(|username| username.to_string())
-            .or_else(|| userinfo.email().map(|email| email.to_string()))
-            .ok_or_else(|| {
-                error!("Missing preferred_username and email claims in userinfo");
-                IdpError::BadRequest
-            })?;
+        let account_id =
+            oidc_account_id_from_userinfo(&userinfo, account_id_claims, strip_at_suffix)?;
 
         let subject = userinfo.subject().to_string();
         let object_id = uuid::Uuid::new_v5(tenant_id, subject.as_bytes());
@@ -2379,10 +2598,24 @@ impl OidcProvider {
         token: &OidcTokenResponse,
     ) -> Result<AuthResult, IdpError> {
         let tenant_id = self.tenant_id().await?;
-        let shell = self.config.lock().await.get_shell(None);
+        let (shell, account_id_claims, strip_at_suffix) = {
+            let config = self.config.lock().await;
+            (
+                config.get_shell(None),
+                config.get_oidc_account_id_claims(),
+                config.get_oidc_account_id_strip_at_suffix(),
+            )
+        };
         let token2 = self
             .client
-            .user_token_from_oidc(token, shell, self.idmap.as_ref(), &tenant_id)
+            .user_token_from_oidc(
+                token,
+                shell,
+                self.idmap.as_ref(),
+                &tenant_id,
+                &account_id_claims,
+                strip_at_suffix,
+            )
             .await?;
         if account_id.to_string().to_lowercase() != token2.name.to_string().to_lowercase() {
             let msg = tr_fmt(
@@ -2800,13 +3033,25 @@ impl IdProvider for OidcProvider {
                     }
                 };
                 let tenant_id = self.tenant_id().await?;
-                let shell = self.config.lock().await.get_shell(None);
-                let token2 = self.client.user_token_from_oidc(
-                    &token,
-                    shell,
-                    self.idmap.as_ref(),
-                    &tenant_id,
-                ).await?;
+                let (shell, account_id_claims, strip_at_suffix) = {
+                    let config = self.config.lock().await;
+                    (
+                        config.get_shell(None),
+                        config.get_oidc_account_id_claims(),
+                        config.get_oidc_account_id_strip_at_suffix(),
+                    )
+                };
+                let token2 = self
+                    .client
+                    .user_token_from_oidc(
+                        &token,
+                        shell,
+                        self.idmap.as_ref(),
+                        &tenant_id,
+                        &account_id_claims,
+                        strip_at_suffix,
+                    )
+                    .await?;
                 tpm.seal_data(&win_hello_storage_key, refresh_token_zeroizing)
                     .map_err(|e| {
                         let uuid = token2.uuid.to_string();


### PR DESCRIPTION
## Summary

- add `oidc_account_id_claims` for an ordered, arbitrary list of OIDC userinfo claim names to use as Linux account names
- preserve the default fallback to `preferred_username`, then `email`, with a warning when configured claims do not match
- add `oidc_account_id_strip_at_suffix` to optionally strip scoped suffixes such as `@example.com` from the selected account name
- document the new options in `himmelblau.conf.5` and XML config definitions

Fixes #1326

## Testing

- `cargo fmt --check`
- `git diff --check`
- generated Rust getter check via `src/common/scripts/gen_param_code.py --gen-rust`
- attempted `cargo test -p himmelblau_unix_common oidc_account_id`; blocked by missing container system dependencies (`pkg-config`/DBus development files, then `libudev.h` from hidapi)