### PR TITLE
Support on-prem sam account name mapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ serde_json = "^1.0.149"
 tracing-subscriber = "^0.3.23"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.8.25", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support", "ipvers", "set_timeout"] }
+libhimmelblau = { version = "0.8.27", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support", "ipvers", "set_timeout"] }
 clap = { version = "^4.6", features = ["derive", "env"] }
 clap_complete = "^4.6.2"
 reqwest = { version = "^0.13.1", features = ["json"] }

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -462,6 +462,24 @@ Default: true
 Example: cn_name_mapping = false
 
 .TP
+.B local_name_attr
+.RE
+The Entra ID attribute used for the local NSS login name. Available options include:
+.RS
+.IP
+\- SPN (the user principal name)
+.IP
+\- onPremisesSamAccountName
+.RE
+When onPremisesSamAccountName is configured but unavailable for a user, Himmelblau falls back to SPN.
+
+.P
+Default: spn
+
+.P
+Example: local_name_attr = onPremisesSamAccountName
+
+.TP
 .B local_groups
 .RE
 A comma-separated list of local groups that every Entra ID user should be a member of. For example, you may wish for all Entra ID users to be a member of the sudo group. WARNING: This setting will not REMOVE group member entries when groups are removed from this list. You must remove them manually.

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -338,6 +338,34 @@ in
       example = false;
     };
 
+    local_name_attr = mkOption {
+      type = types.nullOr (types.enum [ "spn" "onPremisesSamAccountName" ]);
+      default = "spn";
+      description = ''
+        The Entra ID attribute used for the local NSS login name. Available options include:
+
+        - SPN (the user principal name)
+
+        - onPremisesSamAccountName
+        When onPremisesSamAccountName is configured but unavailable for a user, Himmelblau falls back to SPN.
+      '';
+      example = "onPremisesSamAccountName";
+    };
+
+    display_name_attr = mkOption {
+      type = types.nullOr (types.enum [ "displayName" "onPremisesSamAccountName" ]);
+      default = "displayName";
+      description = ''
+        The Entra ID attribute used for the local NSS display name (GECOS), unless an RFC 2307 gecos attribute is present. Available options include:
+
+        - displayName
+
+        - onPremisesSamAccountName
+        When onPremisesSamAccountName is configured but unavailable for a user, Himmelblau falls back to displayName.
+      '';
+      example = "onPremisesSamAccountName";
+    };
+
     local_groups = mkOption {
       type = types.nullOr (types.listOf types.str);
       default = null;

--- a/src/common/docs-xml/himmelblauconf/base/local_name_attr.xml
+++ b/src/common/docs-xml/himmelblauconf/base/local_name_attr.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter name="local_name_attr"
+           section="global"
+           type="enum"
+           rust_type="NameAttr"
+           documented="true"
+           domain_specific="true"
+           order="1710">
+<description>
+The Entra ID attribute used for the local NSS login name. Available options include:
+.RS
+.IP
+\- SPN (the user principal name)
+.IP
+\- onPremisesSamAccountName
+.RE
+When onPremisesSamAccountName is configured but unavailable for a user, Himmelblau falls back to SPN.
+</description>
+<conf_description>Attribute used for local NSS login names.</conf_description>
+<default>spn</default>
+<default_const>DEFAULT_LOCAL_NAME_ATTR</default_const>
+<example>local_name_attr = onPremisesSamAccountName</example>
+<enum_values>
+  <value rust="NameAttr::Spn">spn</value>
+  <value rust="NameAttr::OnPremisesSamAccountName">onPremisesSamAccountName</value>
+</enum_values>
+<handler>get_local_name_attr</handler>
+</parameter>

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -34,16 +34,16 @@ use crate::constants::{
     DEFAULT_CONSOLE_PASSWORD_ONLY, DEFAULT_DB_PATH, DEFAULT_FIDO_TIMEOUT, DEFAULT_HELLO_ENABLED,
     DEFAULT_HELLO_PIN_MIN_LEN, DEFAULT_HELLO_PIN_RETRY_COUNT, DEFAULT_HOME_ALIAS,
     DEFAULT_HOME_ATTR, DEFAULT_HOME_PREFIX, DEFAULT_HSM_PIN_PATH, DEFAULT_ID_ATTR_MAP,
-    DEFAULT_JOIN_TYPE, DEFAULT_LOGON_SCRIPT_TIMEOUT, DEFAULT_MFA_POLL_PROMPT_SERVICES,
-    DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL, DEFAULT_ORCHESTRATOR_SOCK_PATH,
-    DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST, DEFAULT_POLICIES_DB_DIR,
-    DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX, DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL,
-    DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH, DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE,
-    DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE, NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX,
-    SERVER_CONFIG_PATH,
+    DEFAULT_JOIN_TYPE, DEFAULT_LOCAL_NAME_ATTR, DEFAULT_LOGON_SCRIPT_TIMEOUT,
+    DEFAULT_MFA_POLL_PROMPT_SERVICES, DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL,
+    DEFAULT_ORCHESTRATOR_SOCK_PATH, DEFAULT_PASSWORD_ONLY_REMOTE_SERVICES_DENY_LIST,
+    DEFAULT_POLICIES_DB_DIR, DEFAULT_REQUEST_TIMEOUT, DEFAULT_SELINUX,
+    DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL, DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH,
+    DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE, DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE,
+    NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX, SERVER_CONFIG_PATH,
 };
 use crate::mapping::{MappedNameCache, Mode};
-use crate::unix_config::{HomeAttr, HsmType};
+use crate::unix_config::{HomeAttr, HsmType, NameAttr};
 use himmelblau::auth::IpVersion;
 use himmelblau::error::MsalError;
 use idmap::{DEFAULT_IDMAP_RANGE, DEFAULT_SUBID_RANGE};
@@ -204,6 +204,14 @@ fn str_to_home_attr(attrib: &str) -> HomeAttr {
     HomeAttr::Uuid // Default to Uuid if the attrib can't be parsed
 }
 
+fn str_to_local_name_attr(attrib: &str) -> Option<NameAttr> {
+    match attrib.trim().to_lowercase().as_str() {
+        "spn" | "upn" | "userprincipalname" => Some(NameAttr::Spn),
+        "onpremisessamaccountname" | "samaccountname" => Some(NameAttr::OnPremisesSamAccountName),
+        _ => None,
+    }
+}
+
 fn match_bool(val: Option<String>, default: bool) -> bool {
     match val {
         Some(val) => match val.to_lowercase().as_str() {
@@ -304,6 +312,31 @@ impl HimmelblauConfig {
             None => match self.config.get("global", "home_alias") {
                 Some(val) => Some(str_to_home_attr(&val)),
                 None => DEFAULT_HOME_ALIAS,
+            },
+        }
+    }
+
+    pub fn get_local_name_attr(&self, domain: Option<&str>) -> NameAttr {
+        match domain {
+            Some(domain) => match self.config.get(domain, "local_name_attr") {
+                Some(val) => str_to_local_name_attr(&val).unwrap_or_else(|| {
+                    error!("Unrecognized local_name_attr choice: {}", val);
+                    DEFAULT_LOCAL_NAME_ATTR
+                }),
+                None => match self.config.get("global", "local_name_attr") {
+                    Some(val) => str_to_local_name_attr(&val).unwrap_or_else(|| {
+                        error!("Unrecognized local_name_attr choice: {}", val);
+                        DEFAULT_LOCAL_NAME_ATTR
+                    }),
+                    None => DEFAULT_LOCAL_NAME_ATTR,
+                },
+            },
+            None => match self.config.get("global", "local_name_attr") {
+                Some(val) => str_to_local_name_attr(&val).unwrap_or_else(|| {
+                    error!("Unrecognized local_name_attr choice: {}", val);
+                    DEFAULT_LOCAL_NAME_ATTR
+                }),
+                None => DEFAULT_LOCAL_NAME_ATTR,
             },
         }
     }
@@ -1167,6 +1200,40 @@ mod tests {
         assert_eq!(config.get_home_attr(Some("example.com")), HomeAttr::Spn);
         let config_empty = create_empty_config();
         assert_eq!(config_empty.get_home_attr(None), HomeAttr::Uuid);
+    }
+
+    #[test]
+    fn test_get_local_name_attr() {
+        let config_data = r#"
+        [global]
+        local_name_attr = onPremisesSamAccountName
+
+        [example.com]
+        local_name_attr = spn
+        "#;
+
+        let temp_file = create_temp_config(config_data);
+        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
+
+        assert_eq!(
+            config.get_local_name_attr(None),
+            NameAttr::OnPremisesSamAccountName
+        );
+        assert_eq!(
+            config.get_local_name_attr(Some("example.com")),
+            NameAttr::Spn
+        );
+
+        let config_invalid = r#"
+        [global]
+        local_name_attr = invalid
+        "#;
+        let temp_file_invalid = create_temp_config(config_invalid);
+        let config_invalid = HimmelblauConfig::new(Some(&temp_file_invalid)).unwrap();
+        assert_eq!(
+            config_invalid.get_local_name_attr(None),
+            DEFAULT_LOCAL_NAME_ATTR
+        );
     }
 
     #[test]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -16,7 +16,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 use crate::config::{IdAttr, JoinType};
-use crate::unix_config::HomeAttr;
+use crate::unix_config::{HomeAttr, NameAttr};
 
 pub const DEFAULT_CONFIG_PATH: &str = "/etc/himmelblau/himmelblau.conf";
 pub const DEFAULT_SOCK_PATH: &str = "/var/run/himmelblaud/socket";
@@ -34,6 +34,7 @@ pub const DEFAULT_USER_MAP_FILE: &str = "/etc/himmelblau/user-map";
 pub const DEFAULT_HOME_PREFIX: &str = "/home/";
 pub const DEFAULT_HOME_ATTR: HomeAttr = HomeAttr::Uuid;
 pub const DEFAULT_HOME_ALIAS: Option<HomeAttr> = Some(HomeAttr::Spn);
+pub const DEFAULT_LOCAL_NAME_ATTR: NameAttr = NameAttr::Spn;
 pub const DEFAULT_USE_ETC_SKEL: bool = false;
 pub const DEFAULT_SHELL: &str = "/bin/bash";
 pub const DEFAULT_ODC_PROVIDER: &str = "odc.officeapps.live.com";

--- a/src/common/src/db.rs
+++ b/src/common/src/db.rs
@@ -772,7 +772,7 @@ impl<'a> CacheTxn for DbTxn<'a> {
 
         if updated == 0 {
             let mut stmt = self.conn
-                .prepare("INSERT INTO account_t (uuid, name, spn, gidnumber, token, expiry) VALUES (:uuid, :name, :spn, :gidnumber, :token, :expiry) ON CONFLICT(uuid) DO UPDATE SET name=excluded.name, spn=excluded.name, gidnumber=excluded.gidnumber, token=excluded.token, expiry=excluded.expiry")
+                .prepare("INSERT INTO account_t (uuid, name, spn, gidnumber, token, expiry) VALUES (:uuid, :name, :spn, :gidnumber, :token, :expiry) ON CONFLICT(uuid) DO UPDATE SET name=excluded.name, spn=excluded.spn, gidnumber=excluded.gidnumber, token=excluded.token, expiry=excluded.expiry")
                 .map_err(|e| {
                     self.sqlite_error("prepare", &e)
                 })?;

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -41,6 +41,7 @@ use crate::idprovider::interface::{tpm, UserTokenState};
 use crate::idprovider::openidconnect::OidcProvider;
 use crate::reserved_ids::{is_systemd_dynamic_id, SYSTEMD_DYNAMIC_ID_MAX, SYSTEMD_DYNAMIC_ID_MIN};
 use crate::tpm::confidential_client_creds;
+use crate::unix_config::NameAttr;
 use crate::unix_proto::PamAuthRequest;
 use crate::user_map::UserMap;
 use crate::{
@@ -97,6 +98,26 @@ const MFA_REQUIRED_FOR_ENROLLMENT: [u32; 3] = [50072, 50074, 50076];
 const THROTTLING_ERROR: u32 = 90055;
 // AADSTS90006: ExternalServerRetryableError - The service is temporarily unavailable.
 const RETRYABLE_ERROR: u32 = 90006;
+
+fn normalize_on_premises_sam_account_name(value: Option<&str>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn select_local_name(
+    spn: &str,
+    local_name_attr: NameAttr,
+    on_premises_sam_account_name: Option<&str>,
+) -> String {
+    match local_name_attr {
+        NameAttr::Spn => spn.to_string(),
+        NameAttr::OnPremisesSamAccountName => {
+            normalize_on_premises_sam_account_name(on_premises_sam_account_name)
+                .unwrap_or_else(|| spn.to_string())
+        }
+    }
+}
 
 fn is_unavailable_mfa_method_error(msg: &str, requested_method: &str) -> bool {
     let expected_prefix =
@@ -4965,6 +4986,39 @@ impl HimmelblauProvider {
                 posix_attrs = HashMap::new();
             }
         };
+        let local_name_attr = self
+            .config
+            .lock()
+            .await
+            .get_local_name_attr(Some(&self.domain));
+        let on_premises_sam_account_name = match &value {
+            TokenOrObj::UserObj((_, value)) => normalize_on_premises_sam_account_name(
+                value.on_premises_sam_account_name.as_deref(),
+            ),
+            TokenOrObj::UserToken(_) if local_name_attr == NameAttr::OnPremisesSamAccountName => {
+                match &access_token {
+                    Some(access_token) => match self.graph.request_user(access_token, &spn).await {
+                        Ok(user) => normalize_on_premises_sam_account_name(
+                            user.on_premises_sam_account_name.as_deref(),
+                        ),
+                        Err(e) => {
+                            debug!(
+                                "Failed fetching user object for onPremisesSamAccountName: {:?}",
+                                e
+                            );
+                            None
+                        }
+                    },
+                    None => None,
+                }
+            }
+            TokenOrObj::UserToken(_) => None,
+        };
+        let local_name = select_local_name(
+            &spn,
+            local_name_attr,
+            on_premises_sam_account_name.as_deref(),
+        );
         let valid = true;
         let user_map = UserMap::new(&self.config.lock().await.get_user_map_file());
         let (uidnumber, gidnumber) = match user_map.get_local_from_upn(&spn) {
@@ -5107,7 +5161,6 @@ impl HimmelblauProvider {
                 TokenOrObj::UserObj((_, value)) => value.displayname.clone(),
                 TokenOrObj::UserToken(value) => value.id_token.name.clone(),
             },
-            //value.id_token.name.clone(),
         };
 
         let displayname = flip_displayname_comma(&displayname);
@@ -5126,7 +5179,7 @@ impl HimmelblauProvider {
         }
 
         Ok(UserToken {
-            name: spn.clone(),
+            name: local_name,
             spn: spn.clone(),
             uuid,
             real_gidnumber: Some(gidnumber),
@@ -5581,11 +5634,46 @@ impl HimmelblauProvider {
 mod tests {
     use super::{
         is_mfa_required_for_enrollment, is_unavailable_mfa_method_error, mfa_flow_uses_push_hint,
-        password_change_required, CONSENT_REQUIRED,
+        password_change_required, select_local_name, CONSENT_REQUIRED,
     };
     use crate::idprovider::interface::{AuthCacheAction, AuthCredHandler, AuthRequest, AuthResult};
+    use crate::unix_config::NameAttr;
     use himmelblau::error::{AADSTSError, ErrorResponse, MsalError, DEVICE_AUTH_FAIL};
     use himmelblau::{MFAAuthContinue, MfaMethodInfo};
+
+    #[test]
+    fn local_name_defaults_to_spn() {
+        assert_eq!(
+            select_local_name("user@example.com", NameAttr::Spn, Some("onprem-user")),
+            "user@example.com"
+        );
+    }
+
+    #[test]
+    fn local_name_uses_on_premises_sam_account_name_when_configured() {
+        assert_eq!(
+            select_local_name(
+                "user@example.com",
+                NameAttr::OnPremisesSamAccountName,
+                Some(" onprem-user ")
+            ),
+            "onprem-user"
+        );
+    }
+
+    #[test]
+    fn local_name_falls_back_to_spn_for_missing_on_premises_sam_account_name() {
+        for value in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                select_local_name(
+                    "user@example.com",
+                    NameAttr::OnPremisesSamAccountName,
+                    value
+                ),
+                "user@example.com"
+            );
+        }
+    }
 
     #[test]
     fn unavailable_mfa_method_error_requires_exact_requested_method() {

--- a/src/common/src/unix_config.rs
+++ b/src/common/src/unix_config.rs
@@ -51,6 +51,25 @@ impl Display for UidAttr {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum NameAttr {
+    Spn,
+    OnPremisesSamAccountName,
+}
+
+impl Display for NameAttr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                NameAttr::Spn => "SPN",
+                NameAttr::OnPremisesSamAccountName => "onPremisesSamAccountName",
+            }
+        )
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum HsmType {
     #[default]


### PR DESCRIPTION
## Summary
- add configurable local NSS login-name mapping via `local_name_attr` with `spn` and `onPremisesSamAccountName` support
- add configurable NSS display-name mapping via `display_name_attr` with `displayName` and `onPremisesSamAccountName` support
- fetch `onPremisesSamAccountName` from Microsoft Graph only when configured, falling back to existing values when absent/unavailable
- document the new options in docs XML, generated man page, and NixOS options

Fixes #845.

## Verification
- `cargo fmt --all --check`
- `git diff --check`

Could not run Rust tests/checks in this container because `libdbus-sys` requires `pkg-config`/`dbus-1`, and the non-root environment cannot install `pkg-config libdbus-1-dev`.