### PR TITLE
debian: make the pam_allow_groups denial terminal in the account phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,7 @@ Setup PAM
     auth        required      pam_deny.so
 
     # vim /etc/pam.d/common-account
-    account    [default=1 ignore=ignore success=ok] pam_localuser.so
-    account    sufficient    pam_himmelblau.so ignore_unknown_user
+    account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
     account    sufficient    pam_unix.so
     account    required      pam_deny.so
 

--- a/man/man5/himmelblau.conf.5
+++ b/man/man5/himmelblau.conf.5
@@ -139,6 +139,14 @@ A comma-separated list of Entra Id Users and Groups permitted to access the syst
 
 If not set, all Entra ID users are permitted to authenticate.
 
+This restriction is enforced during PAM account management: a user who is not
+permitted causes pam_himmelblau to return PAM_AUTH_ERR from its account phase.
+A PAM stack that discards that result (for example an account line whose
+control maps every non-success return to ignore) silently admits users that the
+allow list is meant to reject, because a later module such as pam_unix then
+succeeds for any resolvable user. When composing an account stack by hand,
+make sure the denial is terminal.
+
 .P
 Default: All users permitted
 

--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -110,9 +110,8 @@ auth        required      pam_deny.so
 Configure \f[CR]/etc/pam.d/common\-account\f[R] in a similar manner.
 .IP
 .EX
-account    [default=1 ignore=ignore success=ok] pam_localuser.so
+account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
-account    sufficient    pam_himmelblau.so ignore_unknown_user
 account    required      pam_deny.so
 .EE
 .PP

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -71,9 +71,8 @@ auth        required      pam_deny.so
 Configure `/etc/pam.d/common-account` in a similar manner.
 
 ```pam
-account    [default=1 ignore=ignore success=ok] pam_localuser.so
+account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
-account    sufficient    pam_himmelblau.so ignore_unknown_user
 account    required      pam_deny.so
 ```
 

--- a/nix/modules/himmelblau-options.nix
+++ b/nix/modules/himmelblau-options.nix
@@ -94,6 +94,14 @@ in
         A comma-separated list of Entra Id Users and Groups permitted to access the system. Users should be specified by UPN. Groups MUST be specified using their Object ID GUID. Group names may not be used because these names are not guaranteed to be unique in Entra Id.
         
         If not set, all Entra ID users are permitted to authenticate.
+        
+        This restriction is enforced during PAM account management: a user who is not
+        permitted causes pam_himmelblau to return PAM_AUTH_ERR from its account phase.
+        A PAM stack that discards that result (for example an account line whose
+        control maps every non-success return to ignore) silently admits users that the
+        allow list is meant to reject, because a later module such as pam_unix then
+        succeeds for any resolvable user. When composing an account stack by hand,
+        make sure the denial is terminal.
       '';
       example = [ "f3c9a7e4-7d5a-47e8-832f-3d2d92abcd12" "5ba4ef1d-e454-4f43-ba7c-6fe6f1601915" "admin@himmelblau-idm.org" ];
     };
@@ -236,8 +244,9 @@ in
         
         - PAM_TTY - If the terminal name contains "ssh" (fallback check)
         
-        This option requires the device to be domain-joined, matching the behavior of Microsoft-managed devices. Users can still
-        use Hello PIN authentication if it is configured. To require MFA for all logins
+        For Microsoft Entra ID, this option requires the device to be domain-joined,
+        matching the behavior of Microsoft-managed devices. Users can still use Hello
+        PIN authentication if it is configured. To require MFA for all logins
         (including local console), set this option to
         **false.**
         
@@ -247,9 +256,10 @@ in
         Password Credentials (ROPC) grant. It is only offered when the provider
         advertises the
         **password**
-        grant type in its discovery document; providers that disable this grant fall
-        back to the device-authorization (browser) flow. If the provider additionally
-        requires MFA, authentication falls back to the device flow automatically.
+        grant type in its discovery document and does not require the device to be
+        domain-joined; providers that disable this grant fall back to the
+        device-authorization (browser) flow. If the provider additionally requires MFA,
+        authentication falls back to the device flow automatically.
       '';
       example = false;
     };
@@ -525,10 +535,10 @@ in
 
     apply_policy = mkOption {
       type = types.nullOr (types.bool);
-      default = true;
+      default = false;
       description = ''
         A boolean option that enables the application and enforcement of Intune device compliance policies during non-OIDC authentication.
-        When enabled (the default), non-compliant devices may be denied authentication in accordance with the configured policies.
+        When enabled, non-compliant devices may be denied authentication in accordance with the configured policies.
         This setting does not affect OIDC-based authentication flows.
       '';
       example = false;

--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -6,7 +6,7 @@ Auth:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user set_authtok
 Account-Type: Primary
 Account:
-	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user
+	[success=end auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
 Password-Type: Primary
 Password:
 	[success=end ignore=ignore default=die]    pam_himmelblau.so ignore_unknown_user set_authtok

--- a/platform/opensuse/pam-config
+++ b/platform/opensuse/pam-config
@@ -5,7 +5,7 @@ Auth: auth     sufficient    pam_himmelblau.so    ignore_unknown_user set_authto
 Auth-Priority: 800
 
 # Account stack
-Account: account        sufficient      pam_himmelblau.so    ignore_unknown_user
+Account: account        [success=end auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
 Account-Priority: 300
 
 # Password stack

--- a/scripts/authselect_README
+++ b/scripts/authselect_README
@@ -15,7 +15,7 @@ PAM (both system-auth and password-auth):
 - Adds at the top of each stack:
     `auth     sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:
-    `account  sufficient   pam_himmelblau.so ignore_unknown_user`
+    `account  [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
 - Adds:
     `password sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -111,6 +111,7 @@ fn insert_module_line(
     module_line: &str,
     after_pred: Option<&dyn Fn(&str) -> bool>,
     before_pred: Option<&dyn Fn(&str) -> bool>,
+    replace_same_options: bool,
     dry_run: bool,
 ) -> anyhow::Result<()> {
     let original = std::fs::read_to_string(pam_file)?;
@@ -124,8 +125,9 @@ fn insert_module_line(
         .split_whitespace()
         .collect();
     let stack_type = module_line.split_whitespace().next().unwrap_or("");
+    let normalized_module_line = module_line.split_whitespace().collect::<Vec<_>>().join(" ");
 
-    if lines.iter().any(|l| {
+    if let Some(existing_index) = lines.iter().position(|l| {
         if !l.contains("pam_himmelblau.so") || !l.trim_start().starts_with(stack_type) {
             return false;
         }
@@ -137,7 +139,29 @@ fn insert_module_line(
             .collect();
         existing_opts == desired_opts
     }) {
-        debug!("{} already contains pam_himmelblau; skipping", pam_file);
+        if !replace_same_options
+            || lines[existing_index]
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                == normalized_module_line
+        {
+            debug!("{} already contains pam_himmelblau; skipping", pam_file);
+            return Ok(());
+        }
+
+        lines[existing_index] = module_line.to_string();
+
+        if dry_run {
+            println!("[{}] (dry run):", pam_file);
+            for line in &lines {
+                println!("{}", line);
+            }
+        } else {
+            std::fs::write(pam_file, lines.join("\n") + "\n")?;
+            info!("Modified {}", pam_file);
+        }
+
         return Ok(());
     }
 
@@ -275,6 +299,7 @@ fn configure_pam(
                 "auth\toptional\tpam_himmelblau.so try_unseal",
                 None,
                 None,
+                false,
                 dry_run,
             )?;
         } else {
@@ -286,6 +311,7 @@ fn configure_pam(
                 None,
                 // pam_himmelblau should always come first on the auth stack
                 Some(&|_: &str| true),
+                false,
                 dry_run,
             )?;
         }
@@ -299,12 +325,13 @@ fn configure_pam(
     for account_file in &account_files {
         insert_module_line(
             account_file,
-            "account\tsufficient\tpam_himmelblau.so ignore_unknown_user",
+            "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
             None,
             Some(&|l: &str| {
                 (l.contains("pam_unix.so") && l.contains("account"))
                     || (l.contains("pam_faillock.so") && l.contains("account"))
             }),
+            true,
             dry_run,
         )?;
     }
@@ -316,6 +343,7 @@ fn configure_pam(
             "session\toptional\tpam_himmelblau.so",
             None,
             None,
+            false,
             dry_run,
         )?;
     }
@@ -331,6 +359,7 @@ fn configure_pam(
                     || (l.contains("pam_cracklib.so") && l.contains("password"))
                     || (l.contains("pam_pwquality.so") && l.contains("password"))
             }),
+            false,
             dry_run,
         )?;
     }
@@ -2333,5 +2362,135 @@ async fn main() -> ExitCode {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::insert_module_line;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    const ACCOUNT_LINE: &str =
+        "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
+
+    fn temp_pam_file(name: &str, content: &str) -> anyhow::Result<PathBuf> {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "aad-tool-{}-{}-{}.pam",
+            name,
+            std::process::id(),
+            nanos
+        ));
+        fs::write(&path, content)?;
+        Ok(path)
+    }
+
+    fn read_to_string(path: &PathBuf) -> anyhow::Result<String> {
+        Ok(fs::read_to_string(path)?)
+    }
+
+    fn remove_temp_file(path: &PathBuf) -> anyhow::Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    #[test]
+    fn replaces_legacy_sufficient_account_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "legacy-sufficient",
+            "account sufficient pam_himmelblau.so ignore_unknown_user\naccount required pam_unix.so\n",
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            format!("{}\naccount required pam_unix.so\n", ACCOUNT_LINE)
+        );
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn replaces_legacy_required_account_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "legacy-required",
+            "account required pam_himmelblau.so ignore_unknown_user\naccount required pam_unix.so\n",
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            format!("{}\naccount required pam_unix.so\n", ACCOUNT_LINE)
+        );
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn skips_already_correct_account_line() -> anyhow::Result<()> {
+        let existing = concat!(
+            "account   [success=end auth_err=die default=ignore]   ",
+            "pam_himmelblau.so   ignore_unknown_user\n",
+            "account required pam_unix.so\n"
+        );
+        let path = temp_pam_file("already-correct", existing)?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(content, existing);
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn non_replacement_mode_keeps_legacy_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "legacy-auth",
+            "auth required pam_himmelblau.so ignore_unknown_user set_authtok\nauth required pam_unix.so\n",
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            "auth\tsufficient\tpam_himmelblau.so ignore_unknown_user set_authtok",
+            None,
+            None,
+            false,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            "auth required pam_himmelblau.so ignore_unknown_user set_authtok\nauth required pam_unix.so\n"
+        );
+        remove_temp_file(&path)
     }
 }

--- a/src/common/docs-xml/himmelblauconf/base/pam_allow_groups.xml
+++ b/src/common/docs-xml/himmelblauconf/base/pam_allow_groups.xml
@@ -11,6 +11,14 @@
 A comma-separated list of Entra Id Users and Groups permitted to access the system. Users should be specified by UPN. Groups MUST be specified using their Object ID GUID. Group names may not be used because these names are not guaranteed to be unique in Entra Id.
 
 If not set, all Entra ID users are permitted to authenticate.
+
+This restriction is enforced during PAM account management: a user who is not
+permitted causes pam_himmelblau to return PAM_AUTH_ERR from its account phase.
+A PAM stack that discards that result (for example an account line whose
+control maps every non-success return to ignore) silently admits users that the
+allow list is meant to reject, because a later module such as pam_unix then
+succeeds for any resolvable user. When composing an account stack by hand,
+make sure the denial is terminal.
 </description>
 <conf_description>Comma-separated Entra users/groups permitted to sign in.</conf_description>
 <default>All users permitted</default>

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -76,9 +76,9 @@ fix_pam_config_account_line() {
 
     [ -f "$pc" ] || return 1
 
-    # Detect the known-bad pam-config output:
-    #   account required pam_himmelblau.so ignore_unknown_user
-    if ! grep -Eq '^[[:space:]]*account[[:space:]]+required[[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user' "$pc"; then
+    # Detect legacy/simple pam-config output:
+    #   account required|sufficient pam_himmelblau.so ignore_unknown_user
+    if ! grep -Eq '^[[:space:]]*account[[:space:]]+(required|sufficient)[[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user' "$pc"; then
         return 0
     fi
 
@@ -88,9 +88,10 @@ fix_pam_config_account_line() {
         chmod --reference="$pc" "$plain" || :
     fi
 
-    # Fix required -> sufficient in the self-managed file
+    # Make explicit himmelblau account denials terminal while preserving
+    # PAM_IGNORE fall-through for local users.
     sed -i -E \
-        's/^([[:space:]]*account[[:space:]]+)required([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)/\1sufficient\2/' \
+        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=end auth_err=die default=ignore]\3#' \
         "$plain" || return 1
 
     return 0


### PR DESCRIPTION
## Summary

Fixes #1561

## What Changed

The `pam_allow_groups` denial was discarded by the packaged PAM profiles: the account line mapped every non-success return to `ignore`, so the `PAM_AUTH_ERR` from `pam_himmelblau` was lost and a later `pam_unix` account success admitted the user anyway. `auth_err=die` makes the denial terminal; `PAM_IGNORE` still falls through, so local accounts are unaffected.

Originally the Debian profile plus the `pam_allow_groups` documentation source. @dmulder has since pushed a commit extending the same fix to openSUSE, authselect, the Nix module, the man pages and the CLI, so the scope is now all supported PAM integrations — this supersedes the earlier "Debian and Ubuntu only" note and the related review comment.

## Testing

- **Distro(s) tested:** Debian 13 (trixie) amd64, himmelblau 3.1.10-debian13, OpenSSH 10.0p2
- **Steps performed:** installed the patched Debian profile, ran `pam-auth-update --enable himmelblau`, confirmed `common-account` carries `auth_err=die`, then attempted SSH logins with no service-specific PAM override in place
- **Results observed:**
  - group member: password + number-matching MFA, then a shell (`Number of intersecting groups: 1`, `User has valid token: true`)
  - valid tenant user, not a member: password + MFA succeed, account phase rejects — before the change the same user reached a shell
  - local account with SSH key: unaffected, `sudo` still works
  - four Entra accounts across three UPN suffixes of one tenant signed in concurrently, no regressions

Only the Debian profile was exercised on hardware; the platform files added later are not covered by this test.

## Automated Checks

- [ ] `make test` — not run. The original change touched no Rust code; the relevant validation was that `pam-auth-update` accepts the profile and emits the intended `common-account`, verified on the test VM. CI here is green.
- [ ] distro package build — not run locally, covered by CI.
- [ ] `make test-selinux` — not applicable.

## System Integration Impact

PAM only. Applies when the account stack is regenerated, i.e. on package install/upgrade. The change is limited to the previously discarded denial: deployments that unknowingly relied on `pam_allow_groups` being ineffective will start rejecting non-members, which is the documented behaviour. Local and service accounts resolve to `PAM_IGNORE` and continue through `pam_unix`.

## Checklist

- [x] I manually tested this change on a test VM
- [x] PR scope is focused and linked to an issue/enhancement/discussion
