### PR TITLE
Add aad-tool kinit command

### DIFF
--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -38,9 +38,13 @@ use broker_client::BrokerClient;
 use clap::Parser;
 use himmelblau::{error::MsalError, graph::Graph, AuthOption, BrokerClientApplication};
 use himmelblau::{ConfidentialClientApplication, UserToken};
-use himmelblau_unix_common::auth::{authenticate_async, SimpleMessagePrinter};
+use himmelblau_unix_common::auth::{
+    authenticate_async, authenticate_with_client_for_reuse, wait_for_daemon_client, MessagePrinter,
+    SimpleMessagePrinter,
+};
 use himmelblau_unix_common::auth_handle_mfa_resp;
 use himmelblau_unix_common::client::call_daemon;
+use himmelblau_unix_common::client_sync::DaemonClientBlocking;
 use himmelblau_unix_common::config::{parse_ttl_to_seconds, split_username, HimmelblauConfig};
 use himmelblau_unix_common::constants::{
     CONFIDENTIAL_CLIENT_CERT_KEY_TAG, CONFIDENTIAL_CLIENT_CERT_TAG, CONFIDENTIAL_CLIENT_SECRET_TAG,
@@ -103,6 +107,95 @@ struct BrokerTokenResponse {
 struct Token {
     #[serde(rename = "brokerTokenResponse")]
     response: BrokerTokenResponse,
+}
+
+async fn authenticate_account(
+    cfg: HimmelblauConfig,
+    account_id: String,
+    service: &str,
+    opts: Options,
+) -> Result<String, ExitCode> {
+    let account_id = match cfg.map_name_to_upn(&account_id) {
+        Some(upn) => upn,
+        None => {
+            error!("'{}' is not a valid directory user", account_id);
+            return Err(ExitCode::FAILURE);
+        }
+    };
+
+    let msg_printer = Arc::new(SimpleMessagePrinter::default());
+    match authenticate_async(
+        None,
+        cfg,
+        account_id.clone(),
+        service.to_string(),
+        opts,
+        msg_printer,
+    )
+    .await
+    {
+        PamResultCode::PAM_SUCCESS => Ok(account_id),
+        e => {
+            error!("Authentication failed: {:?}", e);
+            Err(ExitCode::FAILURE)
+        }
+    }
+}
+
+async fn authenticate_account_with_client(
+    cfg: HimmelblauConfig,
+    account_id: String,
+    service: &str,
+    opts: Options,
+) -> Result<(String, DaemonClientBlocking), ExitCode> {
+    let account_id = match cfg.map_name_to_upn(&account_id) {
+        Some(upn) => upn,
+        None => {
+            error!("'{}' is not a valid directory user", account_id);
+            return Err(ExitCode::FAILURE);
+        }
+    };
+
+    let service = service.to_string();
+    tokio::task::spawn_blocking(move || {
+        let msg_printer: Arc<dyn MessagePrinter> = Arc::new(SimpleMessagePrinter::default());
+        let daemon_client =
+            match wait_for_daemon_client(cfg.get_socket_path().as_str(), &msg_printer) {
+                Ok(client) => client,
+                Err(code) => {
+                    error!("Authentication failed: {:?}", code);
+                    return Err(ExitCode::FAILURE);
+                }
+            };
+
+        let (result, daemon_client) = authenticate_with_client_for_reuse(
+            daemon_client,
+            None,
+            cfg,
+            &account_id,
+            service.as_str(),
+            opts,
+            msg_printer,
+        );
+
+        match result {
+            PamResultCode::PAM_SUCCESS => Ok((account_id, daemon_client)),
+            e => {
+                error!("Authentication failed: {:?}", e);
+                Err(ExitCode::FAILURE)
+            }
+        }
+    })
+    .await
+    .map_err(|e| {
+        error!("Authentication failed: {:?}", e);
+        ExitCode::FAILURE
+    })?
+}
+
+fn unsupported_kinit_option(name: &str) -> ExitCode {
+    error!("aad-tool kinit does not support {}", name);
+    ExitCode::FAILURE
 }
 
 #[instrument(skip(after_pred, before_pred))]
@@ -688,6 +781,35 @@ async fn main() -> ExitCode {
             debug,
             account_id: _,
             force_reauth: _,
+        } => debug,
+        HimmelblauUnixOpt::Kinit {
+            debug,
+            verbose: _,
+            forwardable: _,
+            not_forwardable: _,
+            proxiable: _,
+            not_proxiable: _,
+            request_addresses: _,
+            no_addresses: _,
+            canonicalize: _,
+            force_reauth: _,
+            no_hello_pin: _,
+            cache: _,
+            lifetime: _,
+            renewable_life: _,
+            start_time: _,
+            service_name: _,
+            keytab: _,
+            client_keytab: _,
+            anonymous: _,
+            enterprise: _,
+            validate: _,
+            renew: _,
+            keytab_file: _,
+            input_cache: _,
+            armor_cache: _,
+            preauth_attrs: _,
+            principal: _,
         } => debug,
         HimmelblauUnixOpt::CacheClear {
             debug,
@@ -1644,34 +1766,154 @@ async fn main() -> ExitCode {
                 }
             };
 
-            // Map the name
-            let account_id = match cfg.map_name_to_upn(&account_id) {
-                Some(upn) => upn,
-                None => {
-                    error!("'{}' is not a valid directory user", account_id);
+            let opts = Options {
+                force_reauth,
+                ..Default::default()
+            };
+            match authenticate_account(cfg, account_id, "aad-tool", opts).await {
+                Ok(_) => ExitCode::SUCCESS,
+                Err(code) => code,
+            }
+        }
+        HimmelblauUnixOpt::Kinit {
+            debug: _,
+            verbose: _,
+            forwardable: _,
+            not_forwardable: _,
+            proxiable,
+            not_proxiable,
+            request_addresses,
+            no_addresses: _,
+            canonicalize: _,
+            force_reauth,
+            no_hello_pin,
+            cache,
+            lifetime,
+            renewable_life,
+            start_time,
+            service_name,
+            keytab,
+            client_keytab,
+            anonymous,
+            enterprise,
+            validate,
+            renew,
+            keytab_file,
+            input_cache,
+            armor_cache,
+            preauth_attrs,
+            principal,
+        } => {
+            debug!("Starting Kerberos ticket initialization tool ...");
+
+            if proxiable {
+                return unsupported_kinit_option("--proxiable");
+            }
+            if not_proxiable {
+                return unsupported_kinit_option("--not-proxiable");
+            }
+            if request_addresses {
+                return unsupported_kinit_option("--addresses");
+            }
+            if validate {
+                return unsupported_kinit_option("--validate");
+            }
+            if renew {
+                return unsupported_kinit_option("--renew");
+            }
+            if keytab_file.is_some() {
+                return unsupported_kinit_option("--keytab-file");
+            }
+            if input_cache.is_some() {
+                return unsupported_kinit_option("--input-cache");
+            }
+            if armor_cache.is_some() {
+                return unsupported_kinit_option("--armor-cache");
+            }
+            if !preauth_attrs.is_empty() {
+                return unsupported_kinit_option("--preauth-attr");
+            }
+            if cache.is_some() {
+                return unsupported_kinit_option("--cache");
+            }
+            if lifetime.is_some() {
+                return unsupported_kinit_option("--lifetime");
+            }
+            if renewable_life.is_some() {
+                return unsupported_kinit_option("--renewable-life");
+            }
+            if start_time.is_some() {
+                return unsupported_kinit_option("--start-time");
+            }
+            if service_name.is_some() {
+                return unsupported_kinit_option("--service");
+            }
+            if keytab {
+                return unsupported_kinit_option("--keytab");
+            }
+            if client_keytab.is_some() {
+                return unsupported_kinit_option("--client-keytab");
+            }
+            if anonymous {
+                return unsupported_kinit_option("--anonymous");
+            }
+            if enterprise {
+                return unsupported_kinit_option("--enterprise");
+            }
+
+            let cfg = match HimmelblauConfig::new(Some(DEFAULT_CONFIG_PATH)) {
+                Ok(c) => c,
+                Err(_e) => {
+                    error!("Failed to parse {}", DEFAULT_CONFIG_PATH);
                     return ExitCode::FAILURE;
                 }
             };
 
             let opts = Options {
                 force_reauth,
+                no_hello_pin,
                 ..Default::default()
             };
-            let msg_printer = Arc::new(SimpleMessagePrinter::default());
-            match authenticate_async(
-                None,
+            let timeout = cfg.get_unix_sock_timeout();
+            let (account_id, mut daemon_client) = match authenticate_account_with_client(
                 cfg,
-                account_id,
-                "aad-tool".to_string(),
+                principal,
+                "aad-tool-kinit",
                 opts,
-                msg_printer,
             )
             .await
             {
-                PamResultCode::PAM_SUCCESS => return ExitCode::SUCCESS,
-                e => {
-                    error!("Authentication failed: {:?}", e);
-                    return ExitCode::FAILURE;
+                Ok(result) => result,
+                Err(code) => return code,
+            };
+
+            let kinit_result = tokio::task::spawn_blocking(move || {
+                daemon_client
+                    .call_and_wait(&ClientRequest::Kinit(account_id), timeout)
+                    .map_err(|e| format!("{:?}", e))
+            })
+            .await;
+
+            match kinit_result {
+                Ok(Ok(ClientResponse::Ok)) => ExitCode::SUCCESS,
+                Ok(Ok(ClientResponse::NotAuthenticated)) => {
+                    error!(
+                        "Kerberos ticket initialization was not authorized by the authentication session."
+                    );
+                    ExitCode::FAILURE
+                }
+                Ok(Ok(r)) => {
+                    error!("Error: unexpected response -> {:?}", r);
+                    ExitCode::FAILURE
+                }
+                Ok(Err(e)) => {
+                    error!("Error -> {:?}", e);
+                    error!("Is himmelblaud running? Kerberos tickets were NOT initialized.");
+                    ExitCode::FAILURE
+                }
+                Err(e) => {
+                    error!("Error -> {:?}", e);
+                    ExitCode::FAILURE
                 }
             }
         }

--- a/src/cli/src/opt/tool.rs
+++ b/src/cli/src/opt/tool.rs
@@ -16,8 +16,8 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 use clap::Subcommand;
-use libc::uid_t;
 use libc::gid_t;
+use libc::uid_t;
 
 #[derive(Debug, Subcommand)]
 pub enum IdmapOpt {
@@ -48,7 +48,7 @@ pub enum IdmapOpt {
     Clear {
         #[clap(short, long)]
         debug: bool,
-    }
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -179,7 +179,7 @@ pub enum ApplicationOpt {
         client_id: String,
         #[clap(long = "schema-app-object-id")]
         schema_app_object_id: String,
-    }
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -500,6 +500,122 @@ pub enum HimmelblauUnixOpt {
     /// need to be preserved.
     #[clap(subcommand)]
     Idmap(IdmapOpt),
+
+    /// Acquire Kerberos tickets for an Entra ID user.
+    ///
+    /// This mirrors the common MIT kinit invocation shape for Himmelblau-managed
+    /// Kerberos tickets. The principal is an Entra ID account name or UPN accepted
+    /// by the configured Himmelblau name mapper. On success, himmelblaud updates
+    /// the user's Kerberos credential caches through the normal authentication path.
+    ///
+    /// Examples:
+    ///     aad-tool kinit admin@example.com
+    ///     aad-tool kinit --force-reauth admin@example.com
+    ///     aad-tool kinit -C admin@example.com
+    #[command(verbatim_doc_comment)]
+    Kinit {
+        #[clap(short, long)]
+        debug: bool,
+        /// Verbose output.
+        #[clap(short = 'V', long = "verbose")]
+        verbose: bool,
+        /// Request forwardable tickets.
+        ///
+        /// Accepted for MIT kinit command-line compatibility. Himmelblau obtains
+        /// Kerberos tickets from Entra ID and does not currently expose the
+        /// forwardable ticket flag.
+        #[clap(short = 'f', long = "forwardable")]
+        forwardable: bool,
+        /// Validate the user through the daemon but do not request forwardable tickets.
+        ///
+        /// Accepted for MIT kinit command-line compatibility. Himmelblau obtains
+        /// Kerberos tickets from Entra ID and does not currently expose the
+        /// forwardable ticket flag.
+        #[clap(short = 'F', long = "not-forwardable")]
+        not_forwardable: bool,
+        /// Request proxiable tickets.
+        ///
+        /// Unsupported MIT kinit compatibility option.
+        #[clap(short = 'p', long = "proxiable")]
+        proxiable: bool,
+        /// Do not request proxiable tickets.
+        ///
+        /// Unsupported MIT kinit compatibility option.
+        #[clap(short = 'P', long = "not-proxiable")]
+        not_proxiable: bool,
+        /// Request tickets restricted to local addresses.
+        ///
+        /// Unsupported MIT kinit compatibility option.
+        #[clap(short = 'a', long = "addresses")]
+        request_addresses: bool,
+        /// Request addressless tickets.
+        ///
+        /// Accepted for MIT kinit command-line compatibility. Himmelblau obtains
+        /// Kerberos tickets from Entra ID and does not currently expose address
+        /// restrictions.
+        #[clap(short = 'A', long = "no-addresses")]
+        no_addresses: bool,
+        /// Request canonicalization.
+        ///
+        /// Accepted for MIT kinit command-line compatibility. Himmelblau always
+        /// resolves the supplied name through its configured Entra ID mapping.
+        #[clap(short = 'C', long = "canonicalize")]
+        canonicalize: bool,
+        /// Force a full re-authentication (MFA/FIDO/password), bypassing the cached
+        /// Hello key.
+        #[clap(long)]
+        force_reauth: bool,
+        /// Do not use the cached Hello key; require an online authentication flow.
+        #[clap(long)]
+        no_hello_pin: bool,
+        /// Unsupported MIT kinit credential cache option.
+        #[clap(short = 'c', long = "cache", value_name = "CACHE_NAME")]
+        cache: Option<String>,
+        /// Unsupported MIT kinit lifetime option.
+        #[clap(short = 'l', long = "lifetime", value_name = "LIFETIME")]
+        lifetime: Option<String>,
+        /// Unsupported MIT kinit renewable lifetime option.
+        #[clap(short = 'r', long = "renewable-life", value_name = "LIFETIME")]
+        renewable_life: Option<String>,
+        /// Unsupported MIT kinit start time option.
+        #[clap(short = 's', long = "start-time", value_name = "START_TIME")]
+        start_time: Option<String>,
+        /// Unsupported MIT kinit service option.
+        #[clap(short = 'S', long = "service", value_name = "SERVICE_NAME")]
+        service_name: Option<String>,
+        /// Unsupported MIT kinit keytab option.
+        #[clap(short = 'k', long = "keytab")]
+        keytab: bool,
+        /// Unsupported MIT kinit client keytab option.
+        #[clap(short = 'i', long = "client-keytab", value_name = "KEYTAB")]
+        client_keytab: Option<String>,
+        /// Unsupported MIT kinit anonymous option.
+        #[clap(short = 'n', long = "anonymous")]
+        anonymous: bool,
+        /// Unsupported MIT kinit enterprise principal option.
+        #[clap(short = 'E', long = "enterprise")]
+        enterprise: bool,
+        /// Unsupported MIT kinit validate option.
+        #[clap(short = 'v', long = "validate")]
+        validate: bool,
+        /// Unsupported MIT kinit renew option.
+        #[clap(short = 'R', long = "renew")]
+        renew: bool,
+        /// Unsupported MIT kinit keytab name option.
+        #[clap(short = 't', long = "keytab-file", value_name = "KEYTAB")]
+        keytab_file: Option<String>,
+        /// Unsupported MIT kinit input credential cache option.
+        #[clap(short = 'I', long = "input-cache", value_name = "CACHE_NAME")]
+        input_cache: Option<String>,
+        /// Unsupported MIT kinit FAST armor cache option.
+        #[clap(short = 'T', long = "armor-cache", value_name = "CACHE_NAME")]
+        armor_cache: Option<String>,
+        /// Unsupported MIT kinit pre-authentication attribute option.
+        #[clap(short = 'X', long = "preauth-attr", value_name = "ATTR=VALUE")]
+        preauth_attrs: Vec<String>,
+        /// Entra ID account name or UPN to authenticate.
+        principal: String,
+    },
     /// Activate or deactivate Himmelblau's offline breakglass mode.
     ///
     /// This command enables temporary offline password authentication when Azure Entra ID
@@ -560,7 +676,7 @@ pub enum HimmelblauUnixOpt {
     Version {
         #[clap(short, long)]
         debug: bool,
-    }
+    },
 }
 
 #[derive(Debug, clap::Parser)]

--- a/src/common/src/auth.rs
+++ b/src/common/src/auth.rs
@@ -1455,6 +1455,27 @@ pub fn authenticate_with_client(
     opts: Options,
     msg_printer: Arc<dyn MessagePrinter>,
 ) -> PamResultCode {
+    authenticate_with_client_for_reuse(
+        daemon_client,
+        authtok,
+        cfg,
+        account_id,
+        service,
+        opts,
+        msg_printer,
+    )
+    .0
+}
+
+pub fn authenticate_with_client_for_reuse(
+    daemon_client: DaemonClientBlocking,
+    authtok: Option<String>,
+    cfg: HimmelblauConfig,
+    account_id: &str,
+    service: &str,
+    opts: Options,
+    msg_printer: Arc<dyn MessagePrinter>,
+) -> (PamResultCode, DaemonClientBlocking) {
     i18n::init();
     let mut state = AuthenticateState {
         daemon_client,
@@ -1480,7 +1501,7 @@ pub fn authenticate_with_client(
         let res = authenticate_request_response(&mut state, &req);
         match res {
             PamWhatNext::Next(next_request) => req = next_request,
-            PamWhatNext::Finish(pam_result_code) => return pam_result_code,
+            PamWhatNext::Finish(pam_result_code) => return (pam_result_code, state.daemon_client),
         }
     }
 }

--- a/src/common/src/unix_proto.rs
+++ b/src/common/src/unix_proto.rs
@@ -190,6 +190,7 @@ pub enum ClientRequest {
     OfflineBreakGlass(Option<u64>),
     Status,
     ComplianceCheck,
+    Kinit(String),
 }
 
 impl ClientRequest {
@@ -225,6 +226,7 @@ impl ClientRequest {
             ClientRequest::OfflineBreakGlass(ttl) => format!("OfflineBreakGlass({:?})", ttl),
             ClientRequest::Status => "Status".to_string(),
             ClientRequest::ComplianceCheck => "ComplianceCheck".to_string(),
+            ClientRequest::Kinit(account_id) => format!("Kinit({})", account_id),
         }
     }
 }

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -93,6 +93,7 @@ type AsyncTaskRequest = (TaskRequest, oneshot::Sender<TaskOutcome>);
 type IntunePolicyThrottle = Arc<Mutex<HashMap<String, IntunePolicyThrottleState>>>;
 
 const INTUNE_POLICY_THROTTLE_INTERVAL: Duration = Duration::from_secs(30 * 60);
+const KINIT_AUTH_SERVICE: &str = "aad-tool-kinit";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IntunePolicyThrottleState {
@@ -262,6 +263,7 @@ async fn handle_client(
 
     let mut reqs = Framed::new(sock, ClientCodec);
     let mut pam_auth_session_state = None;
+    let mut kinit_authorized_account = None;
 
     // Setup a broadcast channel so that if we have an unexpected disconnection, we can
     // tell consumers to stop work.
@@ -383,6 +385,11 @@ async fn handle_client(
                     trace!("pam authenticate step");
                     match &mut pam_auth_session_state {
                         Some(auth_session) => {
+                            let auth_service = match auth_session {
+                                AuthSession::InProgress { service, .. } => Some(service.clone()),
+                                _ => None,
+                            };
+                            let is_kinit_auth = auth_service.as_deref() == Some(KINIT_AUTH_SERVICE);
                             match cachelayer
                                 .pam_account_authenticate_step(auth_session, pam_next_req)
                                 .await
@@ -395,7 +402,17 @@ async fn handle_client(
                                             let account_id = account_id.to_lowercase();
                                             match resp {
                                                 PamAuthResponse::Success => {
-                                                    if cfg.get_logon_script().is_some() {
+                                                    if let Some(service) = auth_service.as_deref() {
+                                                        kinit_authorized_account =
+                                                            kinit_authorization_from_auth_success(
+                                                                service,
+                                                                &account_id,
+                                                            );
+                                                    }
+
+                                                    if !is_kinit_auth
+                                                        && cfg.get_logon_script().is_some()
+                                                    {
                                                         let scopes = cfg.get_logon_token_scopes();
                                                         let domain = split_username(&account_id)
                                                             .map(|(_, domain)| domain);
@@ -463,7 +480,9 @@ async fn handle_client(
                                                     }
 
                                                     // Initialize the user Kerberos ccache
-                                                    if cfg.get_enable_kerberos_cache() {
+                                                    if !is_kinit_auth
+                                                        && cfg.get_enable_kerberos_cache()
+                                                    {
                                                         if let Some((uid, gid, tgt_cloud, tgt_ad, top_level_names, tenant_id)) =
                                                             cachelayer
                                                                 .get_user_tgts(Id::Name(
@@ -880,6 +899,150 @@ async fn handle_client(
                     ClientResponse::Error
                 }
             }
+            ClientRequest::Kinit(account_id) => {
+                let span = span!(Level::INFO, "kinit");
+                async {
+                    let account_id = account_id.to_lowercase();
+                    trace!("kinit requested for {}", account_id);
+
+                    if !is_kinit_request_authorized(
+                        kinit_authorized_account.as_deref(),
+                        &account_id,
+                    ) {
+                        warn!(
+                            "kinit: request for {} denied; no matching successful authentication on this connection",
+                            account_id
+                        );
+                        return ClientResponse::NotAuthenticated;
+                    }
+
+                    let Some((_uid, _gid, tgt_cloud, tgt_ad, top_level_names, tenant_id)) =
+                        cachelayer
+                            .get_user_tgts(Id::Name(account_id.to_string()))
+                            .await
+                    else {
+                        error!("kinit: failed to fetch Kerberos tickets for {}", account_id);
+                        return ClientResponse::Error;
+                    };
+
+                    let (tx, rx) = oneshot::channel();
+                    match task_channel_tx
+                        .send_timeout(
+                            (
+                                TaskRequest::KerberosConfig(top_level_names, tenant_id),
+                                tx,
+                            ),
+                            Duration::from_millis(100),
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            match time::timeout_at(
+                                time::Instant::now() + Duration::from_secs(60),
+                                rx,
+                            )
+                            .await
+                            {
+                                Ok(Ok(TaskOutcome::Status(0))) => {}
+                                Ok(Ok(TaskOutcome::Status(status))) => {
+                                    error!(
+                                        "kinit: Kerberos config failed for {}: Status code: {}",
+                                        account_id, status
+                                    );
+                                    return ClientResponse::Error;
+                                }
+                                Ok(Ok(TaskOutcome::NonCompliant(_))) => {
+                                    error!("kinit: unexpected NonCompliant task outcome");
+                                    return ClientResponse::Error;
+                                }
+                                Ok(Err(e)) => {
+                                    error!(
+                                        "kinit: Kerberos config failed for {}: {:?}",
+                                        account_id, e
+                                    );
+                                    return ClientResponse::Error;
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "kinit: Kerberos config timed out for {}: {:?}",
+                                        account_id, e
+                                    );
+                                    return ClientResponse::Error;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("kinit: Kerberos config failed for {}: {:?}", account_id, e);
+                            return ClientResponse::Error;
+                        }
+                    }
+
+                    let (tx, rx) = oneshot::channel();
+                    match task_channel_tx
+                        .send_timeout(
+                            (
+                                TaskRequest::KerberosTGTs(
+                                    ucred.uid(),
+                                    ucred.gid(),
+                                    tgt_cloud,
+                                    tgt_ad,
+                                ),
+                                tx,
+                            ),
+                            Duration::from_millis(100),
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            match time::timeout_at(
+                                time::Instant::now() + Duration::from_secs(60),
+                                rx,
+                            )
+                            .await
+                            {
+                                Ok(Ok(TaskOutcome::Status(0))) => {
+                                    kinit_authorized_account = None;
+                                    ClientResponse::Ok
+                                }
+                                Ok(Ok(TaskOutcome::Status(status))) => {
+                                    error!(
+                                        "kinit: credential cache load failed for {}: Status code: {}",
+                                        account_id, status
+                                    );
+                                    ClientResponse::Error
+                                }
+                                Ok(Ok(TaskOutcome::NonCompliant(_))) => {
+                                    error!("kinit: unexpected NonCompliant task outcome");
+                                    ClientResponse::Error
+                                }
+                                Ok(Err(e)) => {
+                                    error!(
+                                        "kinit: credential cache load failed for {}: {:?}",
+                                        account_id, e
+                                    );
+                                    ClientResponse::Error
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "kinit: credential cache load timed out for {}: {:?}",
+                                        account_id, e
+                                    );
+                                    ClientResponse::Error
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!(
+                                "kinit: credential cache load failed for {}: {:?}",
+                                account_id, e
+                            );
+                            ClientResponse::Error
+                        }
+                    }
+                }
+                .instrument(span)
+                .await
+            }
             ClientRequest::ComplianceCheck => {
                 let span = span!(Level::INFO, "compliance check");
                 async {
@@ -1062,6 +1225,19 @@ fn should_start_intune_policy_application(
 
 fn intune_policy_throttle_key(account_id: &str) -> String {
     account_id.to_lowercase()
+}
+
+fn kinit_authorization_from_auth_success(service: &str, account_id: &str) -> Option<String> {
+    if service == KINIT_AUTH_SERVICE {
+        Some(account_id.to_lowercase())
+    } else {
+        None
+    }
+}
+
+fn is_kinit_request_authorized(authorized_account: Option<&str>, account_id: &str) -> bool {
+    let account_id = account_id.to_lowercase();
+    authorized_account == Some(account_id.as_str())
 }
 
 async fn start_intune_policy_application(
@@ -1259,6 +1435,44 @@ mod tests {
     use super::*;
 
     const ACCOUNT_ID: &str = "user@example.com";
+
+    #[test]
+    fn kinit_authz_rejects_without_prior_auth() {
+        assert!(!is_kinit_request_authorized(None, ACCOUNT_ID));
+    }
+
+    #[test]
+    fn kinit_authz_rejects_different_account() {
+        assert!(!is_kinit_request_authorized(
+            Some("other@example.com"),
+            ACCOUNT_ID,
+        ));
+    }
+
+    #[test]
+    fn kinit_authz_allows_same_account() {
+        assert!(is_kinit_request_authorized(Some(ACCOUNT_ID), ACCOUNT_ID));
+    }
+
+    #[test]
+    fn kinit_authz_normalizes_requested_account() {
+        assert!(is_kinit_request_authorized(
+            Some(ACCOUNT_ID),
+            "User@Example.com",
+        ));
+    }
+
+    #[test]
+    fn kinit_authz_only_created_by_kinit_auth_service() {
+        assert_eq!(
+            kinit_authorization_from_auth_success(KINIT_AUTH_SERVICE, "User@Example.com"),
+            Some(ACCOUNT_ID.to_string())
+        );
+        assert_eq!(
+            kinit_authorization_from_auth_success("login", ACCOUNT_ID),
+            None
+        );
+    }
 
     #[test]
     fn intune_policy_throttle_allows_first_run_and_marks_in_flight() {


### PR DESCRIPTION
## Summary
- Add `aad-tool kinit` for initializing Kerberos tickets for a named Entra ID account.
- Authenticate the target account without running normal login ccache side effects, then ask himmelblaud to store the target account's tickets in the calling user's credential cache.
- Parse MIT kinit-compatible argument names where practical and fail explicitly for unsupported options.

Fixes #1568

## Testing
- `rustfmt --edition 2021 src/common/src/unix_proto.rs src/daemon/src/daemon.rs src/cli/src/main.rs src/cli/src/opt/tool.rs`
- `git diff --check`
- `cargo check -p aad-tool -p himmelblaud` (blocked: this environment lacks pkg-config/OpenSSL/dbus development discovery)