### PR TITLE
Skip Entra post-auth tasks for OIDC

### DIFF
--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -395,6 +395,9 @@ async fn handle_client(
                                             let account_id = account_id.to_lowercase();
                                             match resp {
                                                 PamAuthResponse::Success => {
+                                                    let is_oidc_auth =
+                                                        cfg.get_oidc_issuer_url().is_some();
+
                                                     if cfg.get_logon_script().is_some() {
                                                         let scopes = cfg.get_logon_token_scopes();
                                                         let domain = split_username(&account_id)
@@ -463,7 +466,9 @@ async fn handle_client(
                                                     }
 
                                                     // Initialize the user Kerberos ccache
-                                                    if cfg.get_enable_kerberos_cache() {
+                                                    if cfg.get_enable_kerberos_cache()
+                                                        && !is_oidc_auth
+                                                    {
                                                         if let Some((uid, gid, tgt_cloud, tgt_ad, top_level_names, tenant_id)) =
                                                             cachelayer
                                                                 .get_user_tgts(Id::Name(
@@ -562,7 +567,9 @@ async fn handle_client(
                                                     }
 
                                                     // Fetch the user Profile picture
-                                                    if cfg.get_fetch_profile_picture() {
+                                                    if cfg.get_fetch_profile_picture()
+                                                        && !is_oidc_auth
+                                                    {
                                                         if let Some(token) = cachelayer
                                                             .get_user_accesstoken(
                                                                 Id::Name(account_id.to_string()),


### PR DESCRIPTION
## Summary
- Skip Kerberos cache population when OIDC authentication is configured.
- Skip Microsoft Graph profile photo fetching for OIDC authentication.

Fixes #1570.

## Testing
- git diff --check
- Not run: cargo fmt --check (cargo is not installed in this environment)