### PR TITLE
Fix PAM account stack success control

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Setup PAM
     auth        required      pam_deny.so
 
     # vim /etc/pam.d/common-account
-    account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+    account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
     account    sufficient    pam_unix.so
     account    required      pam_deny.so
 

--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -110,7 +110,7 @@ auth        required      pam_deny.so
 Configure \f[CR]/etc/pam.d/common\-account\f[R] in a similar manner.
 .IP
 .EX
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 .EE

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -71,7 +71,7 @@ auth        required      pam_deny.so
 Configure `/etc/pam.d/common-account` in a similar manner.
 
 ```pam
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 ```

--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -6,7 +6,7 @@ Auth:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user set_authtok
 Account-Type: Primary
 Account:
-	[success=end auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
+	[success=ok auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
 Password-Type: Primary
 Password:
 	[success=end ignore=ignore default=die]    pam_himmelblau.so ignore_unknown_user set_authtok

--- a/platform/opensuse/pam-config
+++ b/platform/opensuse/pam-config
@@ -5,7 +5,7 @@ Auth: auth     sufficient    pam_himmelblau.so    ignore_unknown_user set_authto
 Auth-Priority: 800
 
 # Account stack
-Account: account        [success=end auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
+Account: account        [success=ok auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
 Account-Priority: 300
 
 # Password stack

--- a/scripts/authselect_README
+++ b/scripts/authselect_README
@@ -15,7 +15,7 @@ PAM (both system-auth and password-auth):
 - Adds at the top of each stack:
     `auth     sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:
-    `account  [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
+    `account  [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
 - Adds:
     `password sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -328,7 +328,7 @@ fn configure_pam(
     for account_file in &account_files {
         insert_module_line(
             account_file,
-            "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
+            "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
             None,
             Some(&|l: &str| {
                 (l.contains("pam_unix.so") && l.contains("account"))
@@ -2438,7 +2438,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const ACCOUNT_LINE: &str =
-        "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
+        "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
 
     fn temp_pam_file(name: &str, content: &str) -> anyhow::Result<PathBuf> {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
@@ -2515,7 +2515,7 @@ mod tests {
     #[test]
     fn skips_already_correct_account_line() -> anyhow::Result<()> {
         let existing = concat!(
-            "account   [success=end auth_err=die default=ignore]   ",
+            "account   [success=ok auth_err=die default=ignore]   ",
             "pam_himmelblau.so   ignore_unknown_user\n",
             "account required pam_unix.so\n"
         );
@@ -2532,6 +2532,34 @@ mod tests {
 
         let content = read_to_string(&path)?;
         assert_eq!(content, existing);
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn replaces_success_end_account_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "success-end",
+            concat!(
+                "account [success=end auth_err=die default=ignore] ",
+                "pam_himmelblau.so ignore_unknown_user\n",
+                "account required pam_unix.so\n"
+            ),
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            format!("{}\naccount required pam_unix.so\n", ACCOUNT_LINE)
+        );
         remove_temp_file(&path)
     }
 

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -91,7 +91,7 @@ fix_pam_config_account_line() {
     # Make explicit himmelblau account denials terminal while preserving
     # PAM_IGNORE fall-through for local users.
     sed -i -E \
-        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=end auth_err=die default=ignore]\3#' \
+        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=ok auth_err=die default=ignore]\3#' \
         "$plain" || return 1
 
     return 0


### PR DESCRIPTION
## Summary
- Change the Himmelblau account stack control from success=end to success=ok so PAM continues into local account modules after a successful Himmelblau account check.
- Update distro PAM config snippets, docs, package repair logic, and CLI regression coverage.

## Validation
- Static search confirms the old account control remains only as regression-test input.
- Not run: cargo test / cargo fmt, because cargo is not installed in this environment.

Fixes #1564.