### PR TITLE
feat: add Arch Linux packaging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,8 +40,8 @@ Prefer `make` targets over ad-hoc manual commands when guiding users.
 Common targets:
 
 - `make` / `make all` — auto-detect host distro and build packages for this host
-- `make install` — install packages from `./packaging/` (apt/dnf/yum/zypper auto-detected)
-- `make uninstall` — uninstall Himmelblau packages (apt/dnf/yum/zypper auto-detected)
+- `make install` — install packages from `./packaging/` (apt/dnf/yum/zypper/pacman auto-detected)
+- `make uninstall` — uninstall Himmelblau packages (apt/dnf/yum/zypper/pacman auto-detected)
 - `make test` — run cargo tests in a container
 - `make test-selinux` — ensure SELinux policy builds
 - `make clean` — remove cargo artifacts
@@ -56,7 +56,8 @@ Common targets:
 
 Per-distro targets (build only one):
 `make ubuntu22.04`, `ubuntu24.04`, `debian12`, `debian13`, `rocky8`, `rocky9`, `rocky10`,
-`tumbleweed`, `rawhide`, `fedora43`, `fedora44`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`.
+`tumbleweed`, `rawhide`, `fedora43`, `fedora44`, `sle15sp6`, `sle15sp7`, `sle16`, `gentoo`,
+`arch`.
 
 Tips / conventions:
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,9 @@ platform/opensuse/himmelblau-compliance-check.timer
 platform/el/authselect
 scripts/__pycache__
 
+# makepkg artifacts, when building in place instead of with `make arch`
+platform/arch/pkg/
+platform/arch/src/
+platform/arch/*.pkg.tar.*
+
 .claude/

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	    esac ;; \
 	  opensuse-tumbleweed) TARGET="tumbleweed" ;; \
 	  gentoo)         TARGET="gentoo" ;; \
+	  arch|archlinux) TARGET="arch" ;; \
 	  amzn)          case "$$VER" in 2023) TARGET="amzn2023" ;; esac ;; \
 	esac; \
 	\
@@ -126,7 +127,8 @@ DEB_TARGETS := ubuntu22.04 ubuntu24.04 ubuntu25.10 ubuntu26.04 debian12 debian13
 RPM_TARGETS := rocky8 rocky9 rocky10 tumbleweed rawhide fedora43 fedora44 amzn2023
 SLE_TARGETS := sle15sp6 sle15sp7 sle16
 GENTOO_TARGETS := gentoo
-ALL_PACKAGE_TARGETS := $(DEB_TARGETS) $(RPM_TARGETS) $(SLE_TARGETS) $(GENTOO_TARGETS)
+ARCH_TARGETS := arch
+ALL_PACKAGE_TARGETS := $(DEB_TARGETS) $(RPM_TARGETS) $(SLE_TARGETS) $(GENTOO_TARGETS) $(ARCH_TARGETS)
 
 # ARM64 (aarch64) targets — rocky8 excluded (EOL, no aarch64 builds)
 DEB_ARM64_TARGETS := $(addprefix arm64-,$(DEB_TARGETS))
@@ -134,7 +136,7 @@ RPM_ARM64_TARGETS := $(addprefix arm64-,$(filter-out rocky8,$(RPM_TARGETS)))
 SLE_ARM64_TARGETS := $(addprefix arm64-,$(SLE_TARGETS))
 ALL_ARM64_TARGETS := $(DEB_ARM64_TARGETS) $(RPM_ARM64_TARGETS) $(SLE_ARM64_TARGETS)
 
-install: ## Install packages from ./packaging onto this host (apt/dnf/yum/zypper auto-detected)
+install: ## Install packages from ./packaging onto this host (apt/dnf/yum/zypper/pacman auto-detected)
 	@set -euo pipefail; \
 	. /etc/os-release; \
 	ID="$${ID}"; VER="$${VERSION_ID}"; \
@@ -148,18 +150,25 @@ install: ## Install packages from ./packaging onto this host (apt/dnf/yum/zypper
 		                            (command -v zypper >/dev/null && zypper --non-interactive --no-gpg-checks in ./packaging/*.rpm)';; \
 	  gentoo) \
 		PKGTYPE="gentoo"; INSTALL_CMD='python3 scripts/install_local.py --no-build --destdir $(DESTDIR)/';; \
+	  arch|archlinux|manjaro) \
+		PKGTYPE="arch"; INSTALL_CMD='pacman -U --noconfirm ./packaging/himmelblau-*.pkg.tar.zst';; \
 	esac; \
+	if [ -z "$$PKGTYPE" ] && command -v pacman >/dev/null 2>&1; then \
+		PKGTYPE="arch"; INSTALL_CMD='pacman -U --noconfirm ./packaging/himmelblau-*.pkg.tar.zst'; \
+	fi; \
 	if [ -z "$$PKGTYPE" ]; then echo "Error: unknown distro family for install"; exit 2; fi; \
 	if [ "$$PKGTYPE" = "deb" ]; then \
 	  ls ./packaging/*.deb >/dev/null 2>&1 || { echo "Error: no .deb packages in ./packaging/ — run 'make' first"; exit 4; }; \
 	elif [ "$$PKGTYPE" = "rpm" ]; then \
 	  ls ./packaging/*.rpm >/dev/null 2>&1 || { echo "Error: no .rpm packages in ./packaging/ — run 'make' first"; exit 4; }; \
+	elif [ "$$PKGTYPE" = "arch" ]; then \
+	  ls ./packaging/himmelblau-*.pkg.tar.zst >/dev/null 2>&1 || { echo "Error: no Arch packages in ./packaging/ — run 'make arch' first"; exit 4; }; \
 	fi; \
 	echo "Installing..."; \
 	sh -c "$$INSTALL_CMD"; \
 	echo "Install complete."
 
-uninstall: ## Uninstall Himmelblau packages from this host (apt/dnf/yum/zypper auto-detected)
+uninstall: ## Uninstall Himmelblau packages from this host (apt/dnf/yum/zypper/pacman auto-detected)
 	@set -e; \
 	PM=""; PKGTYPE=""; \
 	if command -v apt-get >/dev/null 2>&1; then \
@@ -170,10 +179,16 @@ uninstall: ## Uninstall Himmelblau packages from this host (apt/dnf/yum/zypper a
 		PKGTYPE="rpm"; PM="sudo yum remove -y"; \
 	elif command -v zypper >/dev/null 2>&1; then \
 		PKGTYPE="rpm"; PM="sudo zypper rm -y"; \
+	elif command -v pacman >/dev/null 2>&1; then \
+		PKGTYPE="arch"; PM="sudo pacman -Rns --noconfirm"; \
 	else \
-		echo "Error: no supported package manager found (apt/dnf/yum/zypper)."; exit 2; \
+		echo "Error: no supported package manager found (apt/dnf/yum/zypper/pacman)."; exit 2; \
 	fi; \
-	pkgs="himmelblau himmelblau-orchestrator himmelblau-apparmor himmelblau-broker himmelblau-qr-greeter himmelblau-selinux himmelblau-sshd-config himmelblau-sso himmelblau-sso-policies nss-himmelblau pam-himmelblau"; \
+	if [ "$$PKGTYPE" = "arch" ]; then \
+		pkgs="himmelblau"; \
+	else \
+		pkgs="himmelblau himmelblau-orchestrator himmelblau-apparmor himmelblau-broker himmelblau-qr-greeter himmelblau-selinux himmelblau-sshd-config himmelblau-sso himmelblau-sso-policies nss-himmelblau pam-himmelblau"; \
+	fi; \
 	echo "Removing: $$pkgs"; \
 	$$PM $$pkgs; \
 	echo "Uninstall complete."
@@ -196,7 +211,7 @@ rpm-servicefiles:
 authselect:
 	python3 ./scripts/gen_authselect.py --root=./ --aad-tool=./target/release/aad-tool --output-dir=./platform/el/authselect/
 
-.PHONY: package deb rpm $(DEB_TARGETS) $(RPM_TARGETS) ${SLE_TARGETS} $(GENTOO_TARGETS) dockerfiles dockerfiles-arm64 orchestrator-container deb-servicefiles rpm-servicefiles authselect conf-examples install uninstall help sbom man arm64 deb-arm64 rpm-arm64 $(ALL_ARM64_TARGETS)
+.PHONY: package deb rpm $(DEB_TARGETS) $(RPM_TARGETS) ${SLE_TARGETS} $(GENTOO_TARGETS) $(ARCH_TARGETS) dockerfiles dockerfiles-arm64 orchestrator-container deb-servicefiles rpm-servicefiles authselect conf-examples install uninstall help sbom man arm64 deb-arm64 rpm-arm64 $(ALL_ARM64_TARGETS)
 
 check-licenses: ## Validate dependant licenses comply with GPLv3
 	cargo deny -V >/dev/null || (echo "cargo-deny required" && cargo install cargo-deny)
@@ -383,6 +398,16 @@ $(GENTOO_TARGETS): %: .packaging dockerfiles
 	cargo build --release --features tpm
 	strip -s target/release/*.so 2>/dev/null || true
 	strip -s target/release/aad-tool target/release/himmelblaud target/release/himmelblaud_tasks target/release/broker target/release/linux-entra-sso 2>/dev/null || true
+
+$(ARCH_TARGETS): %: .packaging dockerfiles
+	@echo "Building $@ package"
+	mkdir -p target/$@
+	$(DOCKER) build $(LIBHIMMELBLAU_BUILD_ARG) -t himmelblau-$@-build -f images/Dockerfile.$@ .
+	$(DOCKER) run --rm --security-opt label=disable \
+		-v $(CURDIR):/himmelblau \
+		-v $(CURDIR)/target/$@:/himmelblau/target \
+		$(LIBHIMMELBLAU_MOUNT) \
+		himmelblau-$@-build
 
 # ---- ARM64 (aarch64) build targets -------------------------------------------
 # Uses docker buildx with QEMU emulation to build natively for arm64.

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,13 @@ all: .packaging dockerfiles ## Auto-detect host distro and build packages just f
 	    esac ;; \
 	  opensuse-tumbleweed) TARGET="tumbleweed" ;; \
 	  gentoo)         TARGET="gentoo" ;; \
-	  arch|archlinux) TARGET="arch" ;; \
+	  arch|archlinux|manjaro) TARGET="arch" ;; \
 	  amzn)          case "$$VER" in 2023) TARGET="amzn2023" ;; esac ;; \
 	esac; \
+	\
+	if [ -z "$$TARGET" ] && command -v pacman >/dev/null 2>&1; then \
+	  TARGET="arch"; \
+	fi; \
 	\
 	if [ -z "$$TARGET" ]; then \
 	  echo "Error: unsupported or unmapped distro: $$ID $$VER"; \

--- a/platform/arch/PKGBUILD
+++ b/platform/arch/PKGBUILD
@@ -1,0 +1,223 @@
+# Maintainer: David Mulder <dmulder@suse.com>
+#
+# Builds every component the DEB/RPM packages ship for Entra authentication:
+# daemon, PAM, NSS, broker, browser SSO, sshd drop-in and the GNOME QR greeter.
+#
+# This PKGBUILD builds from the surrounding git checkout rather than a release
+# tarball, matching how the other distro targets build (see `make arch`).
+#
+#   make arch                                   # containerized build
+#   HIMMELBLAU_SRC=/path/to/himmelblau makepkg  # native build on Arch
+
+# Without HIMMELBLAU_SRC, fall back to the checkout this PKGBUILD lives in.
+_repo="${HIMMELBLAU_SRC:-${startdir:-$PWD}}"
+_repo="${_repo%/platform/arch}"
+
+# The workspace version, read the way .github/workflows/version-check.yml does,
+# but with shell builtins so that the PKGBUILD stays parseable by namcap.
+_workspace_version() {
+  local line
+  while IFS= read -r line; do
+    if [[ $line == 'version = '* ]]; then
+      line=${line#*\"}
+      printf '%s' "${line%\"*}"
+      return
+    fi
+  done < "$_repo/Cargo.toml"
+}
+
+pkgname=himmelblau
+pkgver="$(_workspace_version)"
+pkgrel=1
+pkgdesc="Azure Entra ID authentication for Linux (daemon, PAM, NSS, broker, SSO)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/himmelblau-idm/himmelblau"
+license=('GPL-3.0-or-later')
+depends=(
+  'bash'
+  'dbus'
+  'gcc-libs'
+  'glibc'
+  'libunistring'
+  'openssl'
+  'pam'
+  'sqlite'
+  'systemd'
+  'tpm2-tss'
+)
+makedepends=(
+  'clang'
+  'cmake'
+  'gettext'
+  'libcap'
+  'pcre2'
+  'python'
+  'rust'
+)
+# Mirrors the recommends and suggests the DEB and RPM packages declare.
+optdepends=(
+  'apparmor: AppArmor profile snippets in /etc/apparmor.d'
+  'chromium: browser SSO via native messaging'
+  'cronie: Intune policy scripts'
+  'dconf: enables the QR greeter extension at install time'
+  'firefox: browser SSO via native messaging'
+  'gnome-shell: QR greeter extension'
+  'google-chrome: browser SSO via native messaging'
+  'krb5: Kerberos ticket support'
+  'openssh: SSH logon with MFA'
+  'tpm2-tools: TPM backed HSM pin'
+)
+# Single package: the DEB/RPM split has no equivalent on Arch, so the
+# subpackage names are recorded as provides.
+provides=(
+  'himmelblau-broker'
+  'himmelblau-qr-greeter'
+  'himmelblau-sshd-config'
+  'himmelblau-sso'
+  'himmelblau-sso-policies'
+  'linux-entra-sso'
+  'nss-himmelblau'
+  'pam-himmelblau'
+)
+backup=('etc/himmelblau/himmelblau.conf')
+install=himmelblau.install
+# !lto: LTO is configured by cargo, not CFLAGS.
+# !debug: the release binaries are packaged stripped, as on the other distros.
+options=('!lto' '!debug')
+source=()
+
+build() {
+  cd "$_repo"
+
+  python3 src/common/scripts/gen_param_code.py \
+    --gen-man --man-output man/man5/himmelblau.conf.5
+
+  python3 src/common/scripts/gen_param_code.py \
+    --gen-conf-example \
+    --conf-example-output target/config/himmelblau.conf.example \
+    --xml-dir src/common/docs-xml/himmelblauconf
+
+  python3 scripts/gen_servicefiles.py --out ./platform/opensuse/
+
+  # `tpm` is defined by himmelblau_unix_common, so with an explicit package
+  # selection it has to be requested as <crate>/<feature>.
+  cargo build --release --locked --features himmelblau_unix_common/tpm \
+    -p aad-tool \
+    -p broker \
+    -p himmelblaud \
+    -p nss_himmelblau \
+    -p pam_himmelblau \
+    -p qr-greeter \
+    -p sso
+}
+
+package() {
+  cd "$_repo"
+
+  # Daemon and CLI. Arch has no /usr/sbin, it is a symlink to /usr/bin, so the
+  # /usr/sbin paths in the systemd units still resolve.
+  install -Dm755 target/release/aad-tool "$pkgdir/usr/bin/aad-tool"
+  install -Dm755 target/release/himmelblaud "$pkgdir/usr/bin/himmelblaud"
+  install -Dm755 target/release/himmelblaud_tasks "$pkgdir/usr/bin/himmelblaud_tasks"
+  install -Dm755 src/daemon/scripts/himmelblau-init-hsm-pin \
+    "$pkgdir/usr/libexec/himmelblau-init-hsm-pin"
+  install -Dm644 target/config/himmelblau.conf.example \
+    "$pkgdir/etc/himmelblau/himmelblau.conf"
+
+  install -Dm644 platform/opensuse/himmelblaud.service \
+    "$pkgdir/usr/lib/systemd/system/himmelblaud.service"
+  install -Dm644 platform/opensuse/himmelblaud-tasks.service \
+    "$pkgdir/usr/lib/systemd/system/himmelblaud-tasks.service"
+  install -Dm644 platform/opensuse/himmelblau-hsm-pin-init.service \
+    "$pkgdir/usr/lib/systemd/system/himmelblau-hsm-pin-init.service"
+  install -Dm644 platform/opensuse/himmelblau-compliance-check.service \
+    "$pkgdir/usr/lib/systemd/user/himmelblau-compliance-check.service"
+  install -Dm644 platform/opensuse/himmelblau-compliance-check.timer \
+    "$pkgdir/usr/lib/systemd/user/himmelblau-compliance-check.timer"
+  install -Dm644 src/config/gdm3_service_override.conf \
+    "$pkgdir/usr/lib/systemd/system/display-manager.service.d/override.conf"
+
+  install -Dm644 src/daemon/src/himmelblaud.tmpfiles.conf \
+    "$pkgdir/usr/lib/tmpfiles.d/himmelblaud.conf"
+  install -Dm644 src/daemon/src/himmelblau-policies.tmpfiles.conf \
+    "$pkgdir/usr/lib/tmpfiles.d/himmelblau-policies.conf"
+
+  install -Dm644 man/man1/aad-tool.1 "$pkgdir/usr/share/man/man1/aad-tool.1"
+  install -Dm644 man/man5/himmelblau.conf.5 "$pkgdir/usr/share/man/man5/himmelblau.conf.5"
+  install -Dm644 man/man8/himmelblaud.8 "$pkgdir/usr/share/man/man8/himmelblaud.8"
+  install -Dm644 man/man8/himmelblaud_tasks.8 "$pkgdir/usr/share/man/man8/himmelblaud_tasks.8"
+
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README"
+  install -Dm644 target/config/himmelblau.conf.example \
+    "$pkgdir/usr/share/doc/$pkgname/himmelblau.conf.example"
+
+  # Translation catalogs, compiled from po/LINGUAS by src/common/build.rs
+  if [[ ! -d target/release/locale ]]; then
+    echo "error: target/release/locale is missing; is gettext installed?" >&2
+    return 1
+  fi
+  local mo rel
+  while IFS= read -r -d '' mo; do
+    rel="${mo#target/release/locale/}"
+    install -Dm644 "$mo" "$pkgdir/usr/share/locale/$rel"
+  done < <(find target/release/locale -type f -name '*.mo' -print0)
+
+  # NSS and PAM. Arch has no lib64, so these land in /usr/lib.
+  install -Dm755 target/release/libnss_himmelblau.so \
+    "$pkgdir/usr/lib/libnss_himmelblau.so.2"
+  install -Dm644 src/nss/src/nss-himmelblau.tmpfiles.conf \
+    "$pkgdir/usr/lib/tmpfiles.d/nss-himmelblau.conf"
+  install -Dm755 target/release/libpam_himmelblau.so \
+    "$pkgdir/usr/lib/security/pam_himmelblau.so"
+
+  # Broker
+  install -Dm755 target/release/broker "$pkgdir/usr/bin/himmelblau_broker"
+  install -Dm644 src/broker/platform/com.microsoft.identity.broker1.service \
+    "$pkgdir/usr/share/dbus-1/services/com.microsoft.identity.broker1.service"
+  install -Dm644 src/broker/platform/himmelblau-broker.service \
+    "$pkgdir/usr/lib/systemd/user/himmelblau-broker.service"
+
+  # Browser SSO
+  install -Dm755 target/release/linux-entra-sso "$pkgdir/usr/bin/linux-entra-sso"
+  install -Dm644 src/sso/src/firefox/linux_entra_sso.json \
+    "$pkgdir/usr/lib/mozilla/native-messaging-hosts/linux_entra_sso.json"
+  install -Dm644 src/sso/src/chrome/linux_entra_sso.json \
+    "$pkgdir/etc/opt/chrome/native-messaging-hosts/linux_entra_sso.json"
+  install -Dm644 src/sso/src/chrome/linux_entra_sso.json \
+    "$pkgdir/etc/chromium/native-messaging-hosts/linux_entra_sso.json"
+  install -Dm644 src/sso/src/chrome/extension.json \
+    "$pkgdir/usr/share/google-chrome/extensions/jlnfnnolkbjieggibinobhkjdfbpcohn.json"
+  install -Dm644 src/sso-policies/src/chrome/policies.json \
+    "$pkgdir/etc/opt/chrome/policies/managed/himmelblau.json"
+  install -Dm644 src/sso-policies/src/chrome/policies.json \
+    "$pkgdir/etc/chromium/policies/managed/himmelblau.json"
+  install -Dm644 src/sso-policies/src/firefox/policies.json \
+    "$pkgdir/usr/share/doc/$pkgname/firefox-policies.json.example"
+  install -Dm644 src/sso-policies/src/thunderbird/policies.json \
+    "$pkgdir/usr/share/doc/$pkgname/thunderbird-policies.json.example"
+
+  # sshd drop-in. The EL variant is used because Arch also ships a recent sshd.
+  install -Dm644 platform/el/sshd_config \
+    "$pkgdir/etc/ssh/sshd_config.d/30-himmelblau.conf"
+
+  # GNOME QR greeter extension
+  local greeter='qr-greeter@himmelblau-idm.org'
+  local asset
+  for asset in extension.js qrcodegen.js qrselection.js metadata.json \
+               stylesheet.css security-key.svg security-key-touch.svg; do
+    install -Dm644 "target/release/qr-greeter-build/$greeter/$asset" \
+      "$pkgdir/usr/share/gnome-shell/extensions/$greeter/$asset"
+  done
+
+  # AppArmor profiles, used only when the optional apparmor package is present
+  install -Dm644 platform/debian/apparmor.himmelblau-orchestrator-container \
+    "$pkgdir/etc/apparmor.d/himmelblau-orchestrator-container"
+  install -Dm644 platform/debian/apparmor.crun.local \
+    "$pkgdir/etc/apparmor.d/local/crun"
+  install -Dm644 platform/debian/apparmor.cupsd.local \
+    "$pkgdir/etc/apparmor.d/local/usr.sbin.cupsd"
+  install -Dm644 platform/debian/apparmor.unix-chkpwd.local \
+    "$pkgdir/etc/apparmor.d/local/unix-chkpwd"
+  install -Dm644 platform/debian/apparmor.fusermount3.local \
+    "$pkgdir/etc/apparmor.d/local/fusermount3"
+}

--- a/platform/arch/himmelblau.install
+++ b/platform/arch/himmelblau.install
@@ -1,0 +1,133 @@
+# Wires up NSS, PAM, the GNOME keyring and the QR greeter, the same way the
+# Debian postinst and RPM scriptlets do.
+#
+# Enabling units, reloading systemd and replaying tmpfiles are left to the
+# pacman hooks shipped by systemd, so this script does not do any of that.
+
+_configure_nss() {
+    local conf=/etc/nsswitch.conf
+
+    [ -f "$conf" ] || return 0
+
+    sed -i '/^passwd:/ {/himmelblau/! s/$/ himmelblau/}' "$conf"
+    sed -i '/^group:/ {/himmelblau/! s/$/ himmelblau/}' "$conf"
+    sed -i '/^shadow:/ {/himmelblau/! s/$/ himmelblau/}' "$conf"
+}
+
+_configure_pam() {
+    if ! aad-tool configure-pam --really >/dev/null 2>&1; then
+        echo "warning: 'aad-tool configure-pam --really' failed, PAM is unconfigured"
+    fi
+}
+
+_configure_keyring() {
+    local conf=/etc/pam.d/gdm-password
+    local tmp
+
+    [ -f "$conf" ] || return 0
+
+    # Hand the auth token to pam_gnome_keyring, so the keyring unlocks the way
+    # it does on a local password login.
+    sed -i -E '/^[[:space:]]*auth[[:space:]]+optional[[:space:]]+pam_gnome_keyring\.so/ {/use_authtok/! s/$/ use_authtok/}' "$conf"
+
+    grep -q 'himmelblau-keyring-prelude' "$conf" && return 0
+
+    tmp=$(mktemp) || return 0
+
+    # The line patched above sits after `auth include system-local-login`, where
+    # aad-tool puts pam_himmelblau as `sufficient`. A successful Hello PIN login
+    # therefore returns from the whole auth stack before pam_gnome_keyring is
+    # reached, and the keyring never sees the PIN. Run the pair up front instead,
+    # and jump over it for anyone pam_himmelblau does not claim, so local
+    # password logins keep unlocking via the line further down.
+    awk '
+        !ins && /^[[:space:]]*auth[[:space:]]/ {
+            print "# himmelblau-keyring-prelude"
+            print "auth       [success=ok ignore=2 default=2] pam_himmelblau.so ignore_unknown_user set_authtok"
+            print "auth       optional                        pam_gnome_keyring.so use_authtok"
+            print "auth       [default=done]                  pam_permit.so"
+            ins = 1
+        }
+        { print }
+    ' "$conf" > "$tmp" && cat "$tmp" > "$conf"
+
+    rm -f "$tmp"
+}
+
+_enable_extension() {
+    cat > "$1" <<'EOF'
+[org/gnome/shell]
+enabled-extensions=['qr-greeter@himmelblau-idm.org']
+EOF
+}
+
+_enable_greeter() {
+    # The QR greeter is a GNOME Shell extension, and an extension stays inert
+    # until it is named in the dconf databases the greeter and the session read.
+    command -v dconf >/dev/null 2>&1 || return 0
+
+    install -d /etc/dconf/profile
+
+    if getent passwd gdm >/dev/null 2>&1; then
+        if [ ! -f /etc/dconf/profile/gdm ]; then
+            printf '%s\n' 'user-db:user' 'system-db:gdm' \
+                'file-db:/usr/share/gdm/greeter-dconf-defaults' \
+                > /etc/dconf/profile/gdm
+        fi
+
+        install -d /etc/dconf/db/gdm.d
+        _enable_extension /etc/dconf/db/gdm.d/01-himmelblau-qr-greeter
+    fi
+
+    # The same extension draws the QR code on the lock screen of a running
+    # session, which reads the local database instead of the greeter one.
+    if [ ! -f /etc/dconf/profile/user ]; then
+        printf '%s\n' 'user-db:user' 'system-db:local' > /etc/dconf/profile/user
+    fi
+
+    install -d /etc/dconf/db/local.d
+    _enable_extension /etc/dconf/db/local.d/01-himmelblau-qr-greeter
+
+    dconf update || echo "warning: 'dconf update' failed, the QR greeter is not enabled"
+}
+
+_disable_greeter() {
+    rm -f /etc/dconf/db/gdm.d/01-himmelblau-qr-greeter \
+        /etc/dconf/db/local.d/01-himmelblau-qr-greeter
+
+    if command -v dconf >/dev/null 2>&1; then
+        dconf update || :
+    fi
+}
+
+post_install() {
+    _configure_nss
+    _configure_pam
+    _configure_keyring
+    _enable_greeter
+
+    cat <<'EOF'
+Set your Entra ID domain in /etc/himmelblau/himmelblau.conf, then start the
+daemons:
+
+    systemctl enable --now himmelblaud himmelblaud-tasks
+EOF
+}
+
+post_upgrade() {
+    # PAM is not reconfigured here, to preserve local edits to /etc/pam.d.
+    _configure_nss
+    _configure_keyring
+    _enable_greeter
+
+    echo "Restart the daemons to run the new version:"
+    echo "    systemctl try-restart himmelblaud himmelblaud-tasks"
+}
+
+post_remove() {
+    _disable_greeter
+
+    echo "The pam_himmelblau.so lines in /etc/pam.d and the himmelblau entries in"
+    echo "/etc/nsswitch.conf are left in place, remove them by hand if Entra ID"
+    echo "logon is no longer wanted."
+}

--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -9,6 +9,7 @@ This follows a config-driven pattern inspired by Samba's bootstrap/config.py:
 - deb family => cargo deb chain with per-package feature flags and --deb-revision=<distro>
 - rpm/zypper family => cargo build + strip + cargo generate-rpm chain
 - ebuild family => generates Gentoo ebuild file via gen_ebuild.py
+- arch family => makepkg via scripts/package_arch.py (platform/arch/PKGBUILD)
 """
 
 import argparse
@@ -85,6 +86,29 @@ RUN dnf -y update && dnf -y install \\\n    {pkgs} \\\n && dnf clean all\n"""
 ZYPPER_BOOTSTRAP = """\
 RUN zypper --non-interactive refresh && \\\n    zypper --non-interactive update && \\\n    zypper --non-interactive install --no-recommends \\\n        {pkgs} && \\\n    zypper clean --all\n"""
 
+PACMAN_BOOTSTRAP = """\
+RUN pacman -Syu --noconfirm && \\\n    pacman -S --noconfirm --needed \\\n        {pkgs} && \\\n    pacman -Scc --noconfirm\n"""
+
+ARCH_PKGS = [
+    "base-devel",
+    "clang",
+    "cmake",
+    "dbus",
+    "gettext",
+    "git",
+    "krb5",
+    "libcap",
+    "libunistring",
+    "openssl",
+    "pam",
+    "pcre2",
+    "python",
+    "rust",
+    "sqlite",
+    "systemd",
+    "tpm2-tss",
+]
+
 FAMILIES = {
     "deb": {
         "bootstrap": APT_BOOTSTRAP,
@@ -105,6 +129,11 @@ FAMILIES = {
         # Minimal bootstrap for ebuild generation - just needs Python (in base image)
         "bootstrap": "# No additional packages needed - Python is in the base image",
         "pkgs": [],
+        "env": None,
+    },
+    "arch": {
+        "bootstrap": PACMAN_BOOTSTRAP,
+        "pkgs": ARCH_PKGS,
         "env": None,
     },
 }
@@ -195,6 +224,11 @@ def build_rpm_final_cmd(features: list, selinux: bool, apparmor: bool) -> str:
 def build_gentoo_final_cmd(features: list, repo_root: Path) -> str:
     """Build command for Gentoo - generates an ebuild file."""
     return f'CMD ["/bin/sh", "-c", "{GEN_MANPAGE} && python3 scripts/gen_ebuild.py --out ./packaging/"]'
+
+
+def build_arch_final_cmd() -> str:
+    """Build command for Arch - runs makepkg on platform/arch/PKGBUILD."""
+    return 'CMD ["/bin/sh", "-c", "python3 scripts/package_arch.py --out ./packaging/"]'
 
 
 # ---- Distro targets ----------------------------------------------------------
@@ -402,6 +436,15 @@ DISTS = {
     "gentoo": {
         "family": "ebuild",
         "image": "python:3.11-slim",
+        "extra_prep": [],
+        "tpm": True,
+        "selinux": False,
+    },
+    # ---- Arch Linux family ----
+    # Containerized makepkg; produces himmelblau-*.pkg.tar.zst in ./packaging/
+    "arch": {
+        "family": "arch",
+        "image": "archlinux:base-devel",
         "extra_prep": [],
         "tpm": True,
         "selinux": False,
@@ -701,6 +744,8 @@ def render(
         # Ebuild generation - lightweight, just runs gen_ebuild.py
         repo_root = Path(__file__).parent.parent.resolve()
         final_cmd = build_gentoo_final_cmd(features, repo_root)
+    elif dist_cfg["family"] == "arch":
+        final_cmd = build_arch_final_cmd()
     else:
         final_cmd = build_rpm_final_cmd(features, selinux, bool(dist_cfg.get("apparmor", False)))
 
@@ -732,7 +777,12 @@ def render(
         return df
 
     # Select Rust install method and tooling stage based on architecture
-    if arch != "amd64":
+    if dist_cfg["family"] == "arch":
+        # Arch installs rust with pacman and packages with makepkg, so it needs
+        # neither a rustup toolchain nor cargo-deb/cargo-generate-rpm.
+        rust_install = ""
+        tooling_stage = ""
+    elif arch != "amd64":
         # arm64 RPM/zypper: cross-compile packaging tools on amd64, copy into arm64 stage
         rust_install = RUST_INSTALL_EMULATED
         tooling_stage = TOOLING_STAGE_TPL

--- a/scripts/package_arch.py
+++ b/scripts/package_arch.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Himmelblau Arch Linux package builder
+
+Usage:
+  python package_arch.py --out ./packaging/
+
+Runs makepkg on platform/arch/PKGBUILD and copies the resulting package into
+the output directory. Called by `make arch` inside the Arch build container.
+
+makepkg refuses to run as root, so when this script is root (the container
+case) the build is handed to an unprivileged account. makepkg itself writes
+to BUILD_ROOT, outside the repository; the generated man pages, service files
+and cargo artifacts land in the checkout, as they do for the other targets,
+which is why the build account is given the uid that owns it.
+"""
+
+import argparse
+import os
+import pwd
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BUILDER_USER = "himmelblau-builder"
+BUILD_ROOT = Path("/var/tmp/himmelblau-arch")
+
+
+def run(cmd, **kwargs):
+    print("+", " ".join(shlex.quote(str(arg)) for arg in cmd), flush=True)
+    subprocess.run(cmd, check=True, **kwargs)
+
+
+def makepkg_env(repo: Path, pkgdest: Path, home: Path) -> dict:
+    """Environment shared by the root and non-root build paths."""
+    return {
+        "HIMMELBLAU_SRC": str(repo),
+        "HOME": str(home),
+        "BUILDDIR": str(BUILD_ROOT / "build"),
+        "SRCDEST": str(BUILD_ROOT / "src"),
+        "PKGDEST": str(pkgdest),
+        # Pinned because the Makefile and the README name the extension.
+        "PKGEXT": ".pkg.tar.zst",
+        # Kept in the mounted target directory so crates survive between runs.
+        "CARGO_HOME": str(repo / "target" / "cargo-home"),
+    }
+
+
+def uid_is_free(uid: int) -> bool:
+    try:
+        pwd.getpwuid(uid)
+    except KeyError:
+        return True
+    return False
+
+
+def create_builder_user(uid: int) -> pwd.struct_passwd:
+    """
+    Create the build account.
+
+    It is given the uid owning the checkout where possible, so that the files
+    the build generates in the source tree keep the ownership the host expects.
+    """
+    try:
+        return pwd.getpwnam(BUILDER_USER)
+    except KeyError:
+        pass
+
+    useradd = ["useradd", "--create-home", "--shell", "/bin/bash"]
+    if uid > 0 and uid_is_free(uid):
+        useradd += ["--uid", str(uid)]
+    run(useradd + [BUILDER_USER])
+    return pwd.getpwnam(BUILDER_USER)
+
+
+def create_build_dirs(env: dict) -> list:
+    """Create the directories makepkg and cargo write to."""
+    paths = [Path(env[key]) for key in ("BUILDDIR", "SRCDEST", "PKGDEST", "CARGO_HOME")]
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def build_as_builder(pkgbuild_dir: Path, env: dict, builder: pwd.struct_passwd) -> None:
+    """Run makepkg as BUILDER_USER, which needs to own its writable directories."""
+    for path in create_build_dirs(env):
+        os.chown(path, builder.pw_uid, builder.pw_gid)
+
+    # cargo writes below target/, which is a mount of the host target/arch.
+    os.chown(Path(env["CARGO_HOME"]).parent, builder.pw_uid, builder.pw_gid)
+
+    assignments = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+    run([
+        "su",
+        BUILDER_USER,
+        "-c",
+        f"cd {shlex.quote(str(pkgbuild_dir))} && "
+        # --nodeps: the container image already provides the makedepends.
+        f"exec env {assignments} makepkg --force --noconfirm --nodeps",
+    ])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parent.parent,
+        type=Path,
+        help="Himmelblau checkout to build (default: the parent of scripts/)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Where to copy the built package (default: <repo-root>/packaging)",
+    )
+    args = parser.parse_args()
+
+    repo = args.repo_root.resolve()
+    out = args.out.resolve() if args.out else repo / "packaging"
+    pkgbuild_dir = repo / "platform" / "arch"
+
+    if not (pkgbuild_dir / "PKGBUILD").is_file():
+        print(f"error: {pkgbuild_dir / 'PKGBUILD'} not found", file=sys.stderr)
+        return 1
+
+    out.mkdir(parents=True, exist_ok=True)
+    pkgdest = BUILD_ROOT / "pkgdest"
+
+    if os.geteuid() == 0:
+        builder = create_builder_user(repo.stat().st_uid)
+        env = makepkg_env(repo, pkgdest, Path(builder.pw_dir))
+        build_as_builder(pkgbuild_dir, env, builder)
+    else:
+        env = makepkg_env(repo, pkgdest, Path.home())
+        create_build_dirs(env)
+        run(
+            ["makepkg", "--force", "--noconfirm"],
+            cwd=pkgbuild_dir,
+            env={**os.environ, **env},
+        )
+
+    packages = sorted(pkgdest.glob("himmelblau-*.pkg.tar.*"))
+    if not packages:
+        print(f"error: makepkg produced no package in {pkgdest}", file=sys.stderr)
+        return 1
+
+    for package in packages:
+        print(f"copying {package.name} to {out}")
+        shutil.copy2(package, out / package.name)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/package_arch.py
+++ b/scripts/package_arch.py
@@ -128,6 +128,9 @@ def main() -> int:
     out.mkdir(parents=True, exist_ok=True)
     pkgdest = BUILD_ROOT / "pkgdest"
 
+    for stale in (*pkgdest.glob("himmelblau-*.pkg.tar.*"), *out.glob("himmelblau-*.pkg.tar.*")):
+        stale.unlink()
+
     if os.geteuid() == 0:
         builder = create_builder_user(repo.stat().st_uid)
         env = makepkg_env(repo, pkgdest, Path(builder.pw_dir))
@@ -146,9 +149,9 @@ def main() -> int:
         print(f"error: makepkg produced no package in {pkgdest}", file=sys.stderr)
         return 1
 
-    for package in packages:
-        print(f"copying {package.name} to {out}")
-        shutil.copy2(package, out / package.name)
+    package = packages[-1]
+    print(f"copying {package.name} to {out}")
+    shutil.copy2(package, out / package.name)
 
     return 0
 

--- a/src/qr-greeter/build.rs
+++ b/src/qr-greeter/build.rs
@@ -140,6 +140,41 @@ fn detect_from_apt_cache() -> Option<u32> {
     None
 }
 
+/// Detect GNOME version from installed pacman package (Arch Linux)
+fn detect_from_pacman_installed() -> Option<u32> {
+    let output = Command::new("pacman")
+        .args(["-Q", "gnome-shell"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let version_str = String::from_utf8_lossy(&output.stdout);
+        let version_part = version_str.split_whitespace().nth(1)?;
+        return parse_major_version(version_part);
+    }
+    None
+}
+
+/// Detect GNOME version from pacman sync DB (Arch Linux)
+fn detect_from_pacman_repo() -> Option<u32> {
+    let output = Command::new("pacman")
+        .args(["-Si", "gnome-shell"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let info_str = String::from_utf8_lossy(&output.stdout);
+        for line in info_str.lines() {
+            if line.trim_start().starts_with("Version") {
+                if let Some((_, version_part)) = line.split_once(':') {
+                    return parse_major_version(version_part);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Read /etc/os-release and return key-value pairs
 fn read_os_release() -> Option<std::collections::HashMap<String, String>> {
     let content = fs::read_to_string("/etc/os-release").ok()?;
@@ -172,6 +207,8 @@ fn infer_from_os_release() -> Option<u32> {
         "opensuse-tumbleweed" => return Some(47),
         // Fedora Rawhide - rolling release, always latest
         "fedora" if pretty_name.to_lowercase().contains("rawhide") => return Some(47),
+        // Arch Linux - rolling release, always latest
+        "arch" => return Some(47),
         _ => {}
     }
 
@@ -276,6 +313,11 @@ fn infer_from_os_release() -> Option<u32> {
         return detect_from_zypper_repo();
     }
 
+    if id_like.contains("arch") {
+        // Unknown Arch derivative - rolling release, assume modern
+        return Some(47);
+    }
+
     None
 }
 
@@ -316,6 +358,13 @@ fn detect_gnome_version() -> Option<u32> {
         );
         return Some(v);
     }
+    if let Some(v) = detect_from_pacman_installed() {
+        println!(
+            "cargo:warning=Detected GNOME version from installed pacman package: {}",
+            v
+        );
+        return Some(v);
+    }
 
     // Strategy 4: Try querying package repositories (works without package installed)
     if let Some(v) = detect_from_dnf_repo() {
@@ -331,6 +380,13 @@ fn detect_gnome_version() -> Option<u32> {
     }
     if let Some(v) = detect_from_apt_cache() {
         println!("cargo:warning=Detected GNOME version from APT cache: {}", v);
+        return Some(v);
+    }
+    if let Some(v) = detect_from_pacman_repo() {
+        println!(
+            "cargo:warning=Detected GNOME version from pacman sync DB: {}",
+            v
+        );
         return Some(v);
     }
 

--- a/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/extension.js
+++ b/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/extension.js
@@ -75,17 +75,18 @@ function extractUserCode(message) {
     return null;
 }
 
-// Generate SVG content from a QR code, with an optional user code overlay
-// rendered as a dark strip appended below the QR code (including its border /
-// quiet-zone), so the QR modules and their quiet-zone remain unchanged for scanning.
-function qrCodeToSvg(qr, border, lightColor, darkColor, userCode = null) {
+// Generate SVG content from a QR code.
+//
+// The SVG must never contain a <text> element. GNOME rasterizes CSS background
+// images out of process in the glycin sandbox, and any text makes librsvg pull
+// in pango/fontconfig; when fontconfig has no usable cache it calls symlink(),
+// which the sandbox's seccomp filter answers with SIGSYS. The loader dies and
+// the greeter shows an empty container instead of the QR code. The device code
+// is rendered as a separate St.Label, in process, where fonts are already up.
+function qrCodeToSvg(qr, border, lightColor, darkColor) {
     const qrSize = qr.size + border * 2;
-    // 6 extra SVG units give ~15 rendered px at typical scale - comfortably readable.
-    // 0 when no user code is needed (TOTP enrollment QR).
-    const labelRows = userCode ? 6 : 0;
-    const totalHeight = qrSize + labelRows;
     let svg = `<?xml version="1.0" encoding="UTF-8"?>\n`;
-    svg += `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${qrSize} ${totalHeight}" width="${qrSize * 4}" height="${totalHeight * 4}">`;
+    svg += `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${qrSize} ${qrSize}" width="${qrSize * 4}" height="${qrSize * 4}">`;
     svg += `<rect width="100%" height="100%" fill="${lightColor}"/>`;
     svg += `<path d="`;
     for (let y = 0; y < qr.size; y++) {
@@ -96,23 +97,6 @@ function qrCodeToSvg(qr, border, lightColor, darkColor, userCode = null) {
         }
     }
     svg += `" fill="${darkColor}"/>`;
-    if (userCode) {
-        const stripY = qrSize;
-        const stripH = labelRows;
-        // Dark background strip appended below the QR code
-        svg += `<rect x="0" y="${stripY}" width="${qrSize}" height="${stripH}" fill="${darkColor}"/>`;
-        // Centered white monospace text.
-        // 0.65: font-size as fraction of strip height - fills ~65% leaving breathing room.
-        // 0.72: text baseline position within the strip - visually centered with descender space.
-        const fontSize = stripH * 0.65;
-        svg += `<text x="${qrSize / 2}" y="${stripY + stripH * 0.72}" `;
-        svg += `font-family="monospace" font-size="${fontSize}" font-weight="bold" `;
-        svg += `fill="${lightColor}" text-anchor="middle">`;
-        // userCode only contains [A-Z0-9-] (guaranteed by extractUserCode regex),
-        // so no XML entity escaping is needed here.
-        svg += userCode;
-        svg += `</text>`;
-    }
     svg += `</svg>`;
     return svg;
 }
@@ -284,6 +268,15 @@ export default class QrGreeterExtension extends Extension {
                 this._qrContainer = qrContainer;
                 vbox.add_child(qrContainer);
 
+                const qrCodeLabel = new St.Label({
+                    text: "",
+                    style_class: 'qr-user-code',
+                    x_align: Clutter.ActorAlign.CENTER
+                });
+                qrCodeLabel.hide();
+                this._qrCodeLabel = qrCodeLabel;
+                vbox.add_child(qrCodeLabel);
+
                 const qrLabel = new St.Label({
                     text: "Scan with your phone",
                     style_class: 'qr-instruction-label'
@@ -311,11 +304,13 @@ export default class QrGreeterExtension extends Extension {
                     const fileUri = `file://${tempFilePath}`;
                     this._qrContainer.set_style(`background-image: url('${fileUri}'); background-size: contain; background-repeat: no-repeat; background-position: center;`);
                     this._qrContainer.show();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     this._qrLabel.set_text(this._qrBtLabel || "Scan with your authenticator app");
                     this._qrLabel.show();
                 } catch (e) {
                     console.error("Himmelblau QR Greeter: Failed to generate QR code:", e);
                     if (this._qrContainer) this._qrContainer.hide();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     if (this._qrLabel) this._qrLabel.hide();
                 }
                 this._qrBtActive = true;
@@ -386,6 +381,7 @@ export default class QrGreeterExtension extends Extension {
                 this._fidoIcon.show();
                 if (!this._qrBtActive) {
                     if (this._qrContainer) this._qrContainer.hide();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     if (this._qrLabel) this._qrLabel.hide();
                 }
                 return;
@@ -414,6 +410,7 @@ export default class QrGreeterExtension extends Extension {
                     const fileUri = `file://${tempFilePath}`;
                     this._qrContainer.set_style(`background-image: url('${fileUri}'); background-size: contain; background-repeat: no-repeat; background-position: center;`);
                     this._qrContainer.show();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     this._qrLabel.set_text(isTotpQr ? "Scan with your phone to set up TOTP" : "Scan with your phone to set up Hello TOTP");
                     this._qrLabel.show();
                     // Replace the verbose message with a simple instruction
@@ -423,6 +420,7 @@ export default class QrGreeterExtension extends Extension {
                 } catch (e) {
                     console.error("Himmelblau QR Greeter: Failed to generate TOTP QR code:", e);
                     if (this._qrContainer) this._qrContainer.hide();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     if (this._qrLabel) this._qrLabel.hide();
                 }
             } else {
@@ -442,13 +440,21 @@ export default class QrGreeterExtension extends Extension {
                         try {
                             const userCode = extractUserCode(message);
                             const qr = QrCode.encodeText(selection.url, Ecc.MEDIUM);
-                            const svgContent = qrCodeToSvg(qr, 2, '#ffffff', '#000000', userCode);
+                            const svgContent = qrCodeToSvg(qr, 2, '#ffffff', '#000000');
                             const tempFilePath = writeSvgToTempFile(svgContent);
                             this._totpTempFile = tempFilePath;
                             activeTotpTempFiles.add(tempFilePath);
                             const fileUri = `file://${tempFilePath}`;
                             this._qrContainer.set_style(`background-image: url('${fileUri}'); background-size: contain; background-repeat: no-repeat; background-position: center;`);
                             this._qrContainer.show();
+                            if (this._qrCodeLabel) {
+                                if (userCode) {
+                                    this._qrCodeLabel.set_text(userCode);
+                                    this._qrCodeLabel.show();
+                                } else {
+                                    this._qrCodeLabel.hide();
+                                }
+                            }
                             if (selection.usedComplete) {
                                 this._qrLabel.set_text("Scan to continue sign-in");
                             } else {
@@ -464,6 +470,7 @@ export default class QrGreeterExtension extends Extension {
 
                 if (!qrDisplayed) {
                     if (this._qrContainer) this._qrContainer.hide();
+                    if (this._qrCodeLabel) this._qrCodeLabel.hide();
                     if (this._qrLabel) this._qrLabel.hide();
                 }
             }

--- a/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/extension.js
+++ b/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/extension.js
@@ -117,10 +117,16 @@ function qrCodeToSvg(qr, border, lightColor, darkColor, userCode = null) {
     return svg;
 }
 
-// Write SVG to a temporary file with restrictive permissions and return the file path
+// Write SVG under XDG_RUNTIME_DIR (or a 0700 TMPDIR subdir) as 0600.
 function writeSvgToTempFile(svgContent) {
-    const tempDir = GLib.get_tmp_dir();
-    const tempPath = GLib.build_filenamev([tempDir, `himmelblau-totp-qr-${GLib.get_monotonic_time()}.svg`]);
+    let runtimeDir = GLib.getenv('XDG_RUNTIME_DIR');
+    if (runtimeDir) {
+        runtimeDir = GLib.build_filenamev([runtimeDir, 'himmelblau-qr']);
+    } else {
+        runtimeDir = GLib.build_filenamev([GLib.get_tmp_dir(), `himmelblau-qr-${GLib.get_user_name()}`]);
+    }
+    GLib.mkdir_with_parents(runtimeDir, 0o700);
+    const tempPath = GLib.build_filenamev([runtimeDir, `himmelblau-totp-qr-${GLib.get_monotonic_time()}.svg`]);
     const file = Gio.File.new_for_path(tempPath);
     let outputStream = null;
     try {

--- a/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/stylesheet.css
+++ b/src/qr-greeter/src/qr-greeter@himmelblau-idm.org/stylesheet.css
@@ -4,9 +4,9 @@
 
 .qr-code-container {
     width: 128px;
-    height: 156px;
+    height: 128px;
     max-width: 128px;
-    max-height: 156px;
+    max-height: 128px;
     margin-left: auto;
     margin-right: auto;
 
@@ -18,6 +18,21 @@
     border-radius: 6px;
     box-shadow: 0 0 8px rgba(0,0,0,0.3);
     overflow: hidden;
+}
+
+.qr-user-code {
+    width: 128px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 3px 0;
+
+    background-color: #000000;
+    color: #ffffff;
+    font-family: monospace;
+    font-size: 11pt;
+    font-weight: bold;
+    text-align: center;
+    border-radius: 4px;
 }
 
 .qr-instruction-label {


### PR DESCRIPTION
## Summary
- Add first-party Arch packaging (`platform/arch/PKGBUILD`, `.install`, `package_arch.py`) so `make arch` produces a single `.pkg.tar.zst` with the same core pieces as the DEB/RPM builds (daemon, PAM/NSS, broker, SSO, QR greeter, TPM).
- Wire Arch into the existing build system (Dockerfile family, `make arch`, pacman `install`/`uninstall`, including Manjaro / other pacman hosts).
- Detect GNOME via pacman for the QR greeter; write QR SVGs under `XDG_RUNTIME_DIR` (0600) instead of world-readable `/tmp`.
- Fix a blank QR code in the greeter by removing the `<text>` element from the generated SVG. GNOME rasterizes CSS background images out of process in the glycin sandbox, so text makes librsvg initialize pango/fontconfig; when fontconfig has no usable cache it calls `symlink()`, which the sandbox's seccomp filter answers with `SIGSYS`. `glycin-svg` dies, the image never loads, and the container's white background is all the user sees. The device code now renders as an `St.Label` in the shell process, where fonts are already initialized.

Replaces closed #1590 (squashed under the 10-commit triage limit). Related: #1318.

**Scope:** this adds a build target only. `make arch` produces a `.pkg.tar.zst` locally; nothing here publishes. The PKGBUILD builds from the surrounding checkout (no `source=()`, `sha256sums` or `.SRCINFO`), matching the DEB/RPM targets, so it is not an AUR submission. Shipping to the AUR or a pacman repo is left to maintainer release infrastructure, as with OBS for the DEB/RPM builds. Note the AUR already carries two third-party packages — `himmelblau` (3.0.1, flagged out of date) and `himmelblau-git` — which may be worth reconciling with a first-party build.

## Notes on the QR rendering fix

Reproduced on Arch (GNOME Shell 50.4, glycin 2.1.5, fontconfig 2.18.3). The greeter logged:

```
Failed to load file:///tmp/himmelblau-totp-qr-*.svg: Remote error: org.freedesktop.zbus.Error: i/o error
```

with a matching core dump:

```
SIGSYS (SYS_SECCOMP) /usr/lib/glycin-loaders/2+/glycin-svg
symlink → libfontconfig → FcConfigBuildFonts → FcInit → libpangoft2
```

Loading the same SVG as the greeter user with and without the text strip is the A/B: text-free loads, text-bearing is killed. Rebuilding the font cache (`fc-cache -sf`) also clears it, which is why this is invisible on distributions that keep caches warm through package triggers — Ubuntu 26.04 ships the same GNOME 50 and glycin stack but fontconfig 2.17.1 with a complete cache, and renders fine. That makes the SVG the right place to fix it rather than the packaging.

## Test plan
- [ ] `make arch` builds `packaging/himmelblau-*-x86_64.pkg.tar.zst`
- [ ] `sudo pacman -U ./packaging/himmelblau-*.pkg.tar.zst` on Arch (and Manjaro)
- [ ] NSS/PAM wired; with GDM+dconf: greeter enabled, keyring `use_authtok` present
- [ ] QR greeter SVG lands under `$XDG_RUNTIME_DIR/himmelblau-qr/` mode 0600 and still renders
- [ ] Device-code sign-in shows the QR with the code bar beneath it, and no `SIGSYS` from `glycin-svg`, on a host whose fontconfig cache is incomplete
- [ ] TOTP enrollment and QR/Bluetooth FIDO flows still render their QR codes with no code bar
- [ ] `pacman -Rns himmelblau` cleans greeter dconf; PAM/NSS left for manual cleanup
