### PR TITLE
Bound custom compliance script execution and stop mokutil hanging himmelblaud-tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,7 @@ dependencies = [
  "async-trait",
  "base64 0.23.1",
  "himmelblau_unix_common",
+ "libc",
  "libhimmelblau",
  "os-release",
  "regex",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7440,6 +7440,10 @@ rec {
             packageId = "himmelblau_unix_common";
           }
           {
+            name = "libc";
+            packageId = "libc";
+          }
+          {
             name = "libhimmelblau";
             packageId = "libhimmelblau";
             features = [ "broker" "changepassword" "on_behalf_of" "mfa_method_selection" "optional_mfa" "intune_portal_vers_selection" "redirect_uri" "pop_support" "ipvers" "set_timeout" ];

--- a/scripts/gen_servicefiles.py
+++ b/scripts/gen_servicefiles.py
@@ -40,6 +40,7 @@ MINVER = {
     "ProtectKernelLogs": 244,
     "ProtectControlGroups": 232,
     "MemoryDenyWriteExecute": 231,
+    "InaccessiblePaths": 231,
     "CacheRuntimeStateDirs": 235,  # CacheDirectory/RuntimeDirectory/StateDirectory
     "ConditionPathExists": 12,
     "LoadCredentialEncrypted": 250,
@@ -266,6 +267,27 @@ WantedBy=multi-user.target
     rw_paths = "/home /run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib /var/cache/nss-himmelblau /var/cache/himmelblau-policies"
     rw_line = f"ReadWritePaths={rw_paths}" if rw_paths_available else ""
 
+    # Intune CustomCompliance discovery scripts commonly shell out to `mokutil`
+    # (Microsoft's stock Secure Boot compliance script runs `mokutil --db`).
+    #
+    # mokutil's mok_get_variable() reads /sys/firmware/efi/mok-variables/<name>
+    # first and only falls back to efivarfs if that open() fails. Those files are
+    # mode 0400 root:root, so this unit (User=root) opens them successfully - but
+    # the kernel's efi_mokvar_sysfs_read() returns 0 rather than -EPERM when the
+    # reader lacks CAP_SYS_ADMIN, which our CapabilityBoundingSet drops. mokutil's
+    # read loop has no ssz==0 guard, so it spins at 100% CPU forever, blocks the
+    # task daemon's watchdog pings, and WatchdogSec SIGABRTs the whole service.
+    #
+    # Hiding the directory makes that open() fail so mokutil takes its normal
+    # efivarfs fallback - the same path unprivileged callers already use. This is
+    # preferable to granting CAP_SYS_ADMIN, and does not affect `mokutil
+    # --sb-state`, which uses efi_get_variable() and never touches mok-variables.
+    tasks_inaccessible = (
+        "InaccessiblePaths=-/sys/firmware/efi/mok-variables"
+        if supported("InaccessiblePaths")
+        else ""
+    )
+
     tasks_unit = f"""\
 # You should not need to edit this file. Instead, use a drop-in file:
 #   systemctl edit himmelblaud-tasks.service
@@ -299,6 +321,7 @@ AmbientCapabilities=CAP_SETUID CAP_SETGID
 {rw_line}
 {os.linesep.join([h for h in tasks_hardening if not h.startswith('ProtectSystem=')])}
 {tasks_private_devices}
+{tasks_inaccessible}
 
 [Install]
 WantedBy=multi-user.target

--- a/src/policies/Cargo.toml
+++ b/src/policies/Cargo.toml
@@ -27,6 +27,7 @@ os-release = "0.1.0"
 semver = "1.0.28"
 libhimmelblau.workspace = true
 tempfile = "3.27.0"
+libc = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["libhimmelblau"]

--- a/src/policies/src/custom_compliance_ext.rs
+++ b/src/policies/src/custom_compliance_ext.rs
@@ -23,11 +23,268 @@ use base64::Engine;
 use himmelblau::intune::{ComplianceState, IntuneStatus, PolicyStatus};
 use himmelblau_unix_common::config::HimmelblauConfig;
 use std::fs::Permissions;
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::process::{ChildStderr, ChildStdout, Command, Output, Stdio};
+use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, TempPath};
 use tracing::{debug, error};
+
+/// Maximum wall-clock time a tenant-supplied discovery script may run for.
+const SCRIPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Minimum extra time allowed for the pipes to drain after the script has
+/// exited. Only whatever is still sitting in the pipe buffers remains at that
+/// point, so this is generous; it exists so that a script finishing right on
+/// the deadline does not lose its output.
+const READER_GRACE: Duration = Duration::from_secs(5);
+
+/// How long a single `poll()` waits before the loop re-checks the child and the
+/// deadline. Bounds how late a timeout can fire, nothing else.
+const POLL_INTERVAL_MS: libc::c_int = 50;
+
+/// Upper bound on how much a script may write to each stream. A discovery
+/// script is expected to emit a small JSON object; anything beyond this is
+/// runaway output and must not be allowed to grow the daemon's heap without
+/// limit for the whole timeout budget.
+const MAX_STREAM_BYTES: usize = 16 * 1024 * 1024;
+
+/// A child pipe read without blocking.
+///
+/// Reader *threads* are deliberately avoided. A thread parked in `read_to_end()`
+/// cannot be cancelled and only returns once every writer has closed the pipe -
+/// which a process that escaped the child's process group (e.g. via `setsid()`)
+/// can prevent for as long as it chooses to live. Abandoning such threads leaks
+/// a thread, its stack and an unbounded buffer per invocation, so instead the
+/// descriptors are drained non-blockingly from the one loop that owns them and
+/// closed when the budget expires.
+struct Pipe {
+    /// `None` once EOF (or an error) has been seen, or once it is dropped.
+    src: Option<ChildStream>,
+    buf: Vec<u8>,
+    truncated: bool,
+}
+
+/// The two child streams are distinct types but are only ever used as raw fds.
+enum ChildStream {
+    Out(ChildStdout),
+    Err(ChildStderr),
+}
+
+impl AsRawFd for ChildStream {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            ChildStream::Out(s) => s.as_raw_fd(),
+            ChildStream::Err(s) => s.as_raw_fd(),
+        }
+    }
+}
+
+impl Pipe {
+    fn new(src: ChildStream) -> Result<Self> {
+        // SAFETY: `src` owns the descriptor for the lifetime of this struct.
+        let fd = src.as_raw_fd();
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Err(anyhow!(
+                "Failed to make script pipe non-blocking: {}",
+                io::Error::last_os_error()
+            ));
+        }
+        Ok(Pipe {
+            src: Some(src),
+            buf: Vec::new(),
+            truncated: false,
+        })
+    }
+
+    fn open(&self) -> bool {
+        self.src.is_some()
+    }
+
+    /// Close the read end. Any process still holding the write end - including
+    /// one that escaped the process group - gets `EPIPE`/`SIGPIPE` on its next
+    /// write rather than an audience for the rest of its life.
+    fn close(&mut self) {
+        self.src = None;
+    }
+
+    /// Read everything currently buffered. Returns without blocking.
+    fn drain(&mut self) {
+        let Some(src) = self.src.as_ref() else {
+            return;
+        };
+        let fd = src.as_raw_fd();
+        let mut chunk = [0u8; 8192];
+        loop {
+            // SAFETY: `fd` is owned by `self.src` and `chunk` is valid for
+            // `chunk.len()` bytes.
+            let n = unsafe { libc::read(fd, chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
+            if n > 0 {
+                let n = n as usize;
+                let room = MAX_STREAM_BYTES.saturating_sub(self.buf.len());
+                if room == 0 {
+                    // Keep draining so the writer never blocks (which would
+                    // stall a script that is merely verbose), but stop growing.
+                    self.truncated = true;
+                    continue;
+                }
+                self.buf.extend_from_slice(&chunk[..n.min(room)]);
+                self.truncated |= n > room;
+                continue;
+            }
+            if n == 0 {
+                // EOF: every writer closed.
+                self.close();
+                return;
+            }
+            let err = io::Error::last_os_error();
+            match err.kind() {
+                io::ErrorKind::Interrupted => continue,
+                io::ErrorKind::WouldBlock => return,
+                _ => {
+                    self.close();
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Run `cmd` to completion, killing its entire process group if it exceeds
+/// `timeout`.
+///
+/// `Command::output()` waits forever. Because `execute_script()` is called from
+/// the async `apply_compliance()`, a script that hangs parks a Tokio worker,
+/// which stops `himmelblaud_tasks` from pinging its systemd watchdog, and
+/// `WatchdogSec` then SIGABRTs the whole service - taking down Kerberos, policy
+/// application and compliance reporting along with it.
+///
+/// The process *group* is signalled rather than just the direct child: discovery
+/// scripts are shells, and the process that actually hangs is typically a
+/// grandchild. Killing only the child would leave that grandchild orphaned and
+/// still running (in the case that motivated this, spinning at 100% CPU).
+fn output_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // Give the child its own process group so the whole tree can be signalled.
+        .process_group(0);
+
+    let mut child = cmd.spawn().context("Failed to spawn script")?;
+    let pgid = child.id() as libc::pid_t;
+
+    // Both pipes are drained non-blockingly below. A script writing more than
+    // one pipe buffer would otherwise block in write() while we block in
+    // try_wait().
+    let mut out = Pipe::new(ChildStream::Out(
+        child.stdout.take().context("Missing stdout pipe")?,
+    ))?;
+    let mut err = Pipe::new(ChildStream::Err(
+        child.stderr.take().context("Missing stderr pipe")?,
+    ))?;
+
+    let deadline = Instant::now() + timeout;
+    let mut status = None;
+    // Set once the child has exited; bounds how long we keep reading pipes that
+    // some process it left behind is still holding open.
+    let mut drain_deadline = None;
+
+    loop {
+        poll_readable(&[&out, &err], POLL_INTERVAL_MS);
+        out.drain();
+        err.drain();
+
+        if status.is_none() {
+            status = child.try_wait().context("Failed to wait on script")?;
+            if status.is_some() {
+                drain_deadline = Some(deadline.max(Instant::now() + READER_GRACE));
+            }
+        }
+
+        if status.is_some() && !out.open() && !err.open() {
+            // Clean finish: child reaped, both pipes at EOF.
+            break;
+        }
+
+        let now = Instant::now();
+        match drain_deadline {
+            // Still running. Out of budget: kill the whole group and give up.
+            None if now >= deadline => {
+                // SAFETY: `pgid` is the group created for this child by
+                // `process_group(0)` above, so this cannot signal anything
+                // outside the script's own process tree.
+                unsafe {
+                    libc::killpg(pgid, libc::SIGKILL);
+                }
+                let _ = child.wait();
+                // Dropping the pipes closes the read ends, so any process that
+                // escaped the group via setsid() cannot hold us here.
+                return Err(anyhow!(
+                    "Script exceeded {}s timeout and was killed",
+                    timeout.as_secs()
+                ));
+            }
+            // Exited, but something it left behind still holds a pipe open.
+            // Take what was read rather than discarding a possibly complete
+            // result; truncated output fails JSON validation downstream anyway.
+            Some(drain_deadline) if now >= drain_deadline => {
+                debug!(
+                    stdout_open = out.open(),
+                    stderr_open = err.open(),
+                    "Script exited but left a process holding its pipes open; using partial output"
+                );
+                // Best effort: anything still in the group gets cleaned up. A
+                // process that called setsid() is out of reach, but closing our
+                // read ends means we never block on it either way.
+                unsafe {
+                    libc::killpg(pgid, libc::SIGKILL);
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    if out.truncated || err.truncated {
+        debug!(
+            max_bytes = MAX_STREAM_BYTES,
+            "Script output exceeded the per-stream limit and was truncated"
+        );
+    }
+
+    Ok(Output {
+        // Set in the loop before any path that reaches here.
+        status: status.context("Script did not report an exit status")?,
+        stdout: out.buf,
+        stderr: err.buf,
+    })
+}
+
+/// Wait up to `timeout_ms` for any still-open pipe to become readable.
+///
+/// Purely a throttle for the drain loop: errors are not actionable, since the
+/// subsequent `read()` reports anything that matters.
+fn poll_readable(pipes: &[&Pipe], timeout_ms: libc::c_int) {
+    let mut fds: Vec<libc::pollfd> = pipes
+        .iter()
+        .filter_map(|p| p.src.as_ref())
+        .map(|s| libc::pollfd {
+            fd: s.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        })
+        .collect();
+
+    // SAFETY: `fds` is valid for `fds.len()` entries. With no open pipes left
+    // this degenerates to a plain sleep, which is what we want while waiting
+    // for a child that has closed its output to exit.
+    unsafe {
+        libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, timeout_ms);
+    }
+}
 
 fn execute_script(script: &[u8]) -> Result<String> {
     // Check if the content is valid UTF-8 text and, if so, whether it
@@ -62,16 +319,16 @@ fn execute_script(script: &[u8]) -> Result<String> {
     let temp_path: TempPath = file.into_temp_path();
 
     // Execute: directly if it has a shebang, via /bin/sh otherwise
+    let started = Instant::now();
     let output = if has_shebang {
-        Command::new(&temp_path)
-            .output()
+        output_with_timeout(Command::new(&temp_path), SCRIPT_TIMEOUT)
             .context("Failed to execute script directly")?
     } else {
-        Command::new("/bin/sh")
-            .arg(&temp_path)
-            .output()
-            .context("Failed to execute script via /bin/sh")?
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg(&temp_path);
+        output_with_timeout(cmd, SCRIPT_TIMEOUT).context("Failed to execute script via /bin/sh")?
     };
+    let elapsed = started.elapsed();
 
     // Remove the temp file (best-effort)
     let _ = temp_path.close();
@@ -81,6 +338,7 @@ fn execute_script(script: &[u8]) -> Result<String> {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     debug!(
         exit_code = ?output.status.code(),
+        elapsed_ms = elapsed.as_millis(),
         stdout_len = stdout.len(),
         stderr_len = stderr.len(),
         "Custom compliance script execution finished"
@@ -178,7 +436,7 @@ impl CustomComplianceCSE {
         );
 
         // Decode and execute the script
-        let result = (|| -> Result<String> {
+        let decoded = (|| -> Result<Vec<u8>> {
             let decoded = STANDARD
                 .decode(detail.expected_value.clone())
                 .map_err(|e| anyhow!("Failed to decode CSE: {}", e))?;
@@ -195,8 +453,18 @@ impl CustomComplianceCSE {
                     "CustomComplianceCSE: decoded binary discovery CSE content"
                 );
             }
-            execute_script(&decoded)
+            Ok(decoded)
         })();
+
+        // The script runs on a blocking thread. It is bounded by
+        // SCRIPT_TIMEOUT, but even a bounded minute parked on a Tokio worker
+        // would keep himmelblaud_tasks from pinging its systemd watchdog.
+        let result = match decoded {
+            Ok(decoded) => tokio::task::spawn_blocking(move || execute_script(&decoded))
+                .await
+                .unwrap_or_else(|e| Err(anyhow!("Compliance script task failed: {}", e))),
+            Err(e) => Err(e),
+        };
 
         match result {
             Ok(output) => {
@@ -224,5 +492,221 @@ impl CustomComplianceCSE {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::thread;
+    use tempfile::tempdir;
+
+    fn sh(script: &str) -> Command {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg(script);
+        cmd
+    }
+
+    #[test]
+    fn passes_through_status_and_streams() {
+        let out = output_with_timeout(
+            sh("echo to-stdout; echo to-stderr >&2; exit 3"),
+            Duration::from_secs(30),
+        )
+        .expect("script should run");
+
+        assert_eq!(out.status.code(), Some(3));
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "to-stdout");
+        assert_eq!(String::from_utf8_lossy(&out.stderr).trim(), "to-stderr");
+    }
+
+    /// Output larger than a pipe buffer must not deadlock: the child blocks in
+    /// write() until we drain the pipe, while we are polling try_wait().
+    #[test]
+    fn large_output_does_not_deadlock() {
+        let out = output_with_timeout(
+            sh("head -c 5000000 /dev/zero | tr '\\0' 'x'"),
+            Duration::from_secs(60),
+        )
+        .expect("script should run");
+
+        assert_eq!(out.stdout.len(), 5_000_000);
+    }
+
+    #[test]
+    fn hanging_script_is_killed_at_timeout() {
+        let started = Instant::now();
+        let err = output_with_timeout(sh("sleep 300"), Duration::from_secs(1))
+            .expect_err("script should have timed out");
+
+        assert!(
+            err.to_string().contains("timeout"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "timeout was not enforced promptly: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// Is `pid` still alive? Uses kill(0) rather than parsing ps output, so it
+    /// needs no external tools and cannot be confused by name collisions.
+    fn pid_alive(pid: i32) -> bool {
+        unsafe { libc::kill(pid, 0) == 0 }
+    }
+
+    /// Run `script`, expecting it to time out, and return the PID the script
+    /// recorded in `$PIDFILE`.
+    fn timed_out_with_pidfile(script: &str, timeout: Duration) -> (anyhow::Error, i32) {
+        let dir = tempdir().expect("tempdir");
+        let pidfile = dir.path().join("child.pid");
+        let script = script.replace("$PIDFILE", &pidfile.display().to_string());
+
+        let err =
+            output_with_timeout(sh(&script), timeout).expect_err("script should have timed out");
+
+        let pid: i32 = fs::read_to_string(&pidfile)
+            .expect("script should have written a pidfile")
+            .trim()
+            .parse()
+            .expect("pidfile should contain a pid");
+        (err, pid)
+    }
+
+    /// The real-world case that motivated this: the script is a shell and the
+    /// process that hangs is its *grandchild* (here, `mokutil`). Killing only
+    /// the direct child would leave that grandchild orphaned and still running.
+    #[test]
+    fn timeout_kills_grandchildren() {
+        // POSIX sh: no `exec -a`, no bashisms - this also runs under dash.
+        let (err, pid) = timed_out_with_pidfile(
+            "sleep 300 & echo $! > $PIDFILE; wait",
+            Duration::from_secs(1),
+        );
+        assert!(
+            err.to_string().contains("timeout"),
+            "unexpected error: {err}"
+        );
+
+        // Orphans are reparented to init before being reaped, so poll briefly
+        // rather than sampling once.
+        for _ in 0..50 {
+            if !pid_alive(pid) {
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        panic!("grandchild {pid} survived the process-group kill");
+    }
+
+    /// A script that exits promptly but leaves a background process holding the
+    /// inherited stdout pipe open must not wedge the drain step forever - and
+    /// must still return the output it already read, since that is typically
+    /// the complete result.
+    ///
+    /// No setsid here: the holder stays in the process group, so this is purely
+    /// about the *success* path, where nothing is killed until we give up.
+    #[test]
+    fn exited_script_leaving_a_pipe_holder_does_not_hang() {
+        let started = Instant::now();
+        // 2s budget, so the drain wait is governed by the READER_GRACE floor.
+        let out = output_with_timeout(
+            sh("echo '{\"ok\":true}'; sleep 300 & exit 0"),
+            Duration::from_secs(2),
+        )
+        .expect("partial output should still be returned");
+
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            "{\"ok\":true}",
+            "output read before the holder wedged the pipe must be preserved"
+        );
+        // Bounded by the budget + grace, not by the holder's 300s lifetime.
+        assert!(
+            started.elapsed() < READER_GRACE + Duration::from_secs(10),
+            "drain step was not bounded: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// Execution must leave nothing behind, however many times a script leaves
+    /// a process holding a pipe open. Draining from the owning loop means there
+    /// is no parked reader thread, and no buffer growing behind it, to leak.
+    #[test]
+    fn repeated_pipe_holders_leak_no_threads() {
+        let before = thread_count();
+        for _ in 0..5 {
+            let _ = output_with_timeout(sh("sleep 300 & exit 0"), Duration::from_secs(1));
+        }
+        let after = thread_count();
+        assert!(
+            after <= before + 1,
+            "threads leaked across invocations: {before} -> {after}"
+        );
+    }
+
+    /// Threads of the current process, via /proc. Returns 0 where unavailable,
+    /// which makes the assertion above vacuous rather than flaky.
+    fn thread_count() -> usize {
+        fs::read_dir("/proc/self/task")
+            .map(|d| d.count())
+            .unwrap_or(0)
+    }
+
+    /// A script that never stops talking must not be able to grow the daemon's
+    /// heap for the whole timeout budget.
+    #[test]
+    fn runaway_output_is_capped() {
+        let out = output_with_timeout(
+            sh("yes 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' | head -c 40000000"),
+            Duration::from_secs(60),
+        )
+        .expect("script should run");
+
+        assert!(
+            out.stdout.len() <= MAX_STREAM_BYTES,
+            "output was not capped: {} bytes",
+            out.stdout.len()
+        );
+    }
+
+    /// A process that escapes the process group via setsid() keeps the stdout
+    /// pipe open even after the group kill. The timeout path must still return
+    /// promptly rather than blocking forever draining that pipe.
+    #[test]
+    fn timeout_returns_even_if_a_process_escapes_the_group() {
+        if !have("setsid") {
+            eprintln!("skipping: setsid not available");
+            return;
+        }
+
+        let started = Instant::now();
+        let err = output_with_timeout(sh("setsid sleep 30 & wait"), Duration::from_secs(1))
+            .expect_err("script should have timed out");
+        assert!(
+            err.to_string().contains("timeout"),
+            "unexpected error: {err}"
+        );
+
+        // Must be governed by the 1s budget, not by the escaped process's 30s
+        // lifetime holding the inherited stdout pipe open.
+        assert!(
+            started.elapsed() < Duration::from_secs(15),
+            "timeout path blocked on the inherited pipe: {:?}",
+            started.elapsed()
+        );
+    }
+
+    fn have(tool: &str) -> bool {
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!("command -v {tool}"))
+            .stdout(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1602

`himmelblaud_tasks` runs Intune CustomCompliance discovery scripts with an
unbounded `Command::output()`. A script that never returns parks a Tokio worker,
the service stops pinging its systemd watchdog, and `WatchdogSec=120s` SIGABRTs
the whole task daemon — taking Kerberos, policy application and compliance
reporting with it. The only symptom is `compliance check: task error: channel closed`.

Because the check never completes, Intune silently retains the *previous*
verdict forever. Here that meant the portal kept reporting "Secure Boot is not
enabled" for two days after Secure Boot was actually enabled, with a
"device will lose access to company resources" warning.

## What Changed

Two commits, each independently useful:

**1. `systemd: hide mok-variables from himmelblaud-tasks`** — removes the trigger.

Microsoft's stock Secure Boot compliance script runs `mokutil --db`, which under
this unit never returns. The cause spans three layers:

1. `efi_mokvar_sysfs_read()` returns `0`, not `-EPERM`, when the reader lacks
   `CAP_SYS_ADMIN` — indistinguishable from EOF.
2. mokutil's `mok_get_variable()` read loop has no `ssz == 0` guard, so it spins
   at 100% CPU forever.
3. `himmelblaud-tasks` runs `User=root` with a `CapabilityBoundingSet` that
   excludes `CAP_SYS_ADMIN` — exactly the state that triggers 1 and 2.

Counter-intuitively, *less* privilege works. The files are mode `0400`, so an
unprivileged caller's `open()` fails `EACCES` and mokutil takes its efivarfs
fallback. Only *partial* privilege hangs:

| context | `open()` on `mok-variables/db` | result |
|---|---|---|
| non-root | fails `EACCES` | efivarfs fallback, works, ~0.04s |
| root + `CAP_SYS_ADMIN` | succeeds, returns data | works |
| **root without `CAP_SYS_ADMIN`** | succeeds, `read()` returns `0` forever | **spins at 100% CPU** |

`InaccessiblePaths` forces that same fallback. Preferred over granting
`CAP_SYS_ADMIN`, which would be a near-root hardening regression. It does not
affect `mokutil --sb-state`, which uses `efi_get_variable()` and never touches
`mok-variables`. Gated on systemd >= 231 via the existing `MINVER` mechanism;
the `-` prefix makes it a no-op on non-EFI systems.

Filed upstream separately for layers 1 and 2 (kernel, mokutil).

**2. `policies: bound custom compliance script execution`** — fixes the class of bug.

These scripts are tenant-supplied and arbitrary; a hostile or merely buggy one
should not be able to kill the daemon. Adds `output_with_timeout()` with a 60s
budget (under `WatchdogSec`, with headroom). Three details matter:

- **Signal the process *group*.** The script is a shell and the process that
  hangs is a grandchild; killing only the child leaves it orphaned and spinning.
- **Don't wait on the pipe readers after the group kill.** `read_to_end()`
  returns only once every writer closes the pipe, and a process that escaped via
  `setsid()` holds the inherited write end open for as long as it lives —
  reintroducing the exact hang being fixed.
- **Bound the drain on the success path too**, for the same reason: a script can
  exit cleanly having backgrounded a process that still holds the pipe.

Implementing the first two without the third still hangs; we hit that while testing.

Also logs the script's runtime, which previously gave no hint that a script was
the thing that stalled.

`Cargo.nix` is regenerated for the new `libc` dependency (hand-applied in the
generated form; `crate2nix` wasn't available on this host — worth a re-run by
someone with nix).

## Testing

- **Distro(s) tested:** Fedora Linux 44 (Workstation), kernel 7.1.8-200.fc44,
  mokutil 0.7.2-3.fc44, himmelblau 4.0.0-1. Test suite additionally exercised
  under Debian/dash in the `make test` container.
- **Steps performed:**
  1. Reproduced deterministically with `aad-tool compliance-check` — watchdog
     SIGABRT every cycle, `NRestarts` climbing.
  2. Caught `mokutil` live: `State: R`, 99.7% CPU — a busy loop, not blocked I/O.
  3. Bisected the unit's hardening one directive at a time via `systemd-run`;
     only `CapabilityBoundingSet` reproduced it.
  4. Binary-searched the 35 capabilities absent from the unit's set → `CAP_SYS_ADMIN`.
  5. Confirmed `InaccessiblePaths` fixes rule 2 (`mokutil --db`) under the unit's
     full hardening set, and that rule 1 (`mokutil --sb-state`) still works.
  6. Applied as a drop-in on the live host and re-ran the real compliance check.
  7. Built `make fedora44` and confirmed the directive is present in the shipped
     `himmelblaud-tasks.service` inside the RPM.
- **Results observed:**
  - Before: `Watchdog timeout (limit 2min)!` → `status=6/ABRT`, script never finished.
  - After: `Custom compliance script execution finished | exit_code: Some(0)`,
    `{"SecureBootEnabled":"true","SecureBootCA2023":"Present",...}`,
    `Intune compliance status | device_info.compliance_state: Compliant`,
    `aad-tool compliance-check` → `compliance check passed`, `NRestarts=0`,
    no further watchdog kills. Intune portal now reports the device compliant.

Each of the six new unit tests was mutation-tested — I reverted each fix
individually and confirmed the corresponding test fails, and fails *fast*
rather than hanging:

| test | regression it pins |
|---|---|
| `passes_through_status_and_streams` | exit status / stdout / stderr still propagate |
| `large_output_does_not_deadlock` | >64KB output doesn't deadlock on the pipe buffer |
| `hanging_script_is_killed_at_timeout` | the timeout fires at all |
| `timeout_kills_grandchildren` | `killpg` vs. `child.kill()` — orphan left spinning |
| `timeout_returns_even_if_a_process_escapes_the_group` | no `join()` on the timeout path |
| `exited_script_leaving_a_pipe_holder_does_not_hang` | bounded drain on the success path |

## Automated Checks

- [x] I ran `make test` (full suite green)
- [x] I ran the distro package build target (`make fedora44`; verified the
      generated unit inside the resulting RPM)
- [x] I ran `make test-selinux` (if applicable) — **N/A**, no SELinux policy
      files touched

## System Integration Impact

Touches systemd. `himmelblaud-tasks.service` gains one directive:

```ini
InaccessiblePaths=-/sys/firmware/efi/mok-variables
```

- Emitted only for systemd >= 231; older systemd is unaffected.
- The `-` prefix makes it a no-op where the path doesn't exist (non-EFI, BIOS,
  containers, systems without shim).
- Narrows the sandbox rather than widening it — no new privileges are granted.
- Only affects processes started by `himmelblaud-tasks`. `mokutil` invoked from
  anywhere else is untouched.
- Behaviour change for compliance scripts: `mokutil --db` now returns via the
  efivarfs path instead of hanging. `--sb-state` is unaffected.
- No PAM/NSS/authselect, SELinux/AppArmor, filesystem path or credential changes.
- New runtime dependency for `himmelblau_policies`: `libc` (already in the
  workspace), reflected in `Cargo.lock`/`Cargo.nix`.

## Checklist

- [x] I manually tested this change on a test VM — tested on real hardware
      (Fedora 44 laptop) rather than a VM; the bug is firmware/EFI-dependent and
      does not reproduce in a VM without matching Secure Boot + MOK state.
- [x] PR scope is focused and linked to an issue/enhancement/discussion (#1602)

Happy to split this into two PRs if you'd prefer the systemd change and the
timeout hardening reviewed separately — they're independent commits.
