### PR TITLE
Backport to 3.x: 13 commits + 1 dependency update(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,11 +1583,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "serde_json",
  "zbus",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-fuzz"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "arbitrary",
  "himmelblau_unix_common",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "bindgen",
  "cc",
@@ -3260,7 +3260,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "o365"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "anyhow",
  "reqwest 0.12.24",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "3.1.11"
+version = "3.1.12"
 
 [[package]]
 name = "qrcodegen"
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "3.1.11"
+version = "3.1.12"
 
 [[package]]
 name = "semver"
@@ -5180,11 +5180,11 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "3.1.11"
+version = "3.1.12"
 
 [[package]]
 name = "sso"
-version = "3.1.11"
+version = "3.1.12"
 dependencies = [
  "broker-client",
  "clap",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "sso-policies"
-version = "3.1.11"
+version = "3.1.12"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -285,7 +285,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -314,13 +314,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -452,6 +452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,7 +511,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -529,7 +535,7 @@ dependencies = [
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -557,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -663,9 +669,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "c-types"
@@ -700,16 +706,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -792,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -802,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -814,23 +820,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.6"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bf4965940c2382204c0ded6dd3dd48c0c4e872f1e76fb1bf94f45991a2cb6a"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1140,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1153,12 +1159,12 @@ dependencies = [
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1215,7 +1221,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1238,7 +1244,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1249,14 +1255,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1317,7 +1323,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1328,7 +1334,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1348,7 +1354,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1368,7 +1374,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1413,7 +1419,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1492,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1556,7 +1562,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1662,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flagset"
@@ -1740,20 +1746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1766,9 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1776,15 +1772,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1793,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1812,32 +1808,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2067,7 +2063,7 @@ version = "3.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "himmelblau_unix_common",
  "libc",
  "libhimmelblau",
@@ -2090,7 +2086,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "authenticator",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "compact_jwt",
  "configparser",
@@ -2114,7 +2110,7 @@ dependencies = [
  "os-release",
  "pem",
  "qrcodegen",
- "rand 0.10.1",
+ "rand 0.10.2",
  "regex",
  "reqwest 0.12.24",
  "rpassword",
@@ -2139,7 +2135,7 @@ name = "himmelblaud"
 version = "3.1.11"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "clap",
  "console-subscriber",
@@ -2218,9 +2214,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -2725,7 +2721,7 @@ dependencies = [
  "kanidm-hsm-crypto",
  "md-5",
  "md4",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "sha-crypt",
  "sha2 0.11.0-rc.5",
@@ -2856,9 +2852,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -2881,11 +2877,11 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.27"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0c3990110cfb28f4e235ab0cb8e1d4796e74fa99c8f256c3fccd18994dc02b"
+checksum = "27ac5b3c2c565a8561ef291106116270fc7bf545cbb72ca885a6d48f07103de0"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "cbindgen",
  "chrono",
  "compact_jwt",
@@ -3064,9 +3060,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3078,12 +3074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "malloced"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,9 +3081,9 @@ checksum = "6dfebb2f9e0b39509c62eead6ec7ae0c0ed45bb61d12bbcf4e976c566c5400ec"
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -3320,7 +3310,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3372,7 +3362,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3474,7 +3464,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3788,11 +3778,11 @@ checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3852,7 +3842,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3881,7 +3871,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4028,7 +4018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4078,7 +4068,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4157,7 +4147,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.1",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -4222,9 +4212,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -4310,14 +4300,14 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4327,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4574,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4719,9 +4709,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
 dependencies = [
  "cssparser",
  "ego-tree",
@@ -4804,9 +4794,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -4833,9 +4823,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4890,29 +4880,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4949,7 +4939,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5002,7 +4992,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5263,6 +5253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5279,7 +5280,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5334,13 +5335,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -5369,7 +5368,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5380,7 +5379,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5395,9 +5394,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5415,9 +5414,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5466,7 +5465,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5495,7 +5494,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5531,13 +5530,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5736,7 +5736,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5930,12 +5930,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5949,9 +5943,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -6062,7 +6056,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -6097,7 +6091,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6256,7 +6250,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6267,7 +6261,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6598,7 +6592,7 @@ dependencies = [
  "heck",
  "indexmap 2.9.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6614,7 +6608,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6696,15 +6690,15 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.16.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6737,14 +6731,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.16.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6752,13 +6746,22 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.2",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6778,7 +6781,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6798,7 +6801,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6820,7 +6823,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6853,7 +6856,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6864,40 +6867,41 @@ checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zvariant"
-version = "5.12.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.2",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.12.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.4.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 3.0.3",
  "winnow 1.0.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ac5b3c2c565a8561ef291106116270fc7bf545cbb72ca885a6d48f07103de0"
+checksum = "b190520a12cef337e297bd029d059bcd30660d2fe1987b47d2fc5d7aa3e693ec"
 dependencies = [
  "base64 0.23.1",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { version = "^1.50.0", features = ["rt", "macros", "sync", "time", "net"
 tokio-util = { version = "^0.7.18", features = ["codec"] }
 async-trait = "^0.1.89"
 himmelblau_policies = { path = "src/policies" }
-pem = "^3.0.6"
+pem = "^4.0.0"
 chrono = "^0.4.44"
 os-release = "^0.1.0"
 jsonwebtoken = "^9.2.0"
@@ -72,7 +72,7 @@ libkrimes = { version = "0.1.0", features = ["keyring"] }
 # Kanidm deps
 argon2 = { version = "0.5.2", features = ["alloc"] }
 base32 = "^0.5.0"
-base64 = "^0.22.0"
+base64 = "^0.23.1"
 base64urlsafedata = "0.5.5"
 hex = "^0.4.3"
 num_enum = "^0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ paste-1-0-15 = { package = "paste", path = "src/paste" }
 serde_cbor-0-11-2 = { package = "serde_cbor", path = "src/serde_cbor" }
 
 [workspace.package]
-version = "3.1.11"
+version = "3.1.12"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Makefile
+++ b/Makefile
@@ -194,9 +194,9 @@ check-licenses: ## Validate dependant licenses comply with GPLv3
 	cargo deny --all-features check licenses
 
 vet: ## Interactive dependency review with AI analysis
-	cargo vet -V >/dev/null || (echo "cargo-vet required" && cargo install cargo-vet)
-	cargo vet regenerate imports
-	@python3 scripts/cargo_vet_review.py --ai-provider claude
+	/usr/bin/cargo vet -V >/dev/null || (echo "cargo-vet required" && cargo install cargo-vet)
+	/usr/bin/cargo vet regenerate imports
+	@python3 scripts/cargo_vet_review.py
 
 sbom: .packaging ## Generate a Software Bill of Materials
 	cargo sbom -V >/dev/null || (echo "cargo-sbom required" && cargo install cargo-sbom)

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Setup PAM
     auth        required      pam_deny.so
 
     # vim /etc/pam.d/common-account
-    account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+    account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
     account    sufficient    pam_unix.so
     account    required      pam_deny.so
 

--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -92,7 +92,7 @@ auth        required      pam_deny.so
 Configure \f[CR]/etc/pam.d/common\-account\f[R] in a similar manner.
 .IP
 .EX
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 .EE

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -68,7 +68,7 @@ auth        required      pam_deny.so
 Configure `/etc/pam.d/common-account` in a similar manner.
 
 ```pam
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 ```

--- a/nix/modules/himmelblau.nix
+++ b/nix/modules/himmelblau.nix
@@ -227,6 +227,7 @@ in
           path = [
             pkgs.shadow
             pkgs.bash
+            pkgs.util-linux
           ];
           unitConfig = {
             ConditionPathExists = "/var/run/himmelblaud/task_sock";
@@ -236,7 +237,9 @@ in
             Restart = "on-failure";
             User = "root";
             ProtectSystem = "strict";
-            ReadWritePaths = "/home /var/run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib /var/cache/nss-himmelblau";
+            CacheDirectory = "himmelblau-policies"; # /var/cache/himmelblau-policies
+            ReadWritePaths =
+              "/home /var/run/himmelblaud /tmp /etc/krb5.conf.d /etc /var/lib /var/cache/nss-himmelblau /var/cache/himmelblau-policies";
             RestrictAddressFamilies = ["AF_UNIX" "AF_INET" "AF_INET6"];
           };
         };

--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -6,7 +6,7 @@ Auth:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user set_authtok
 Account-Type: Primary
 Account:
-	[success=end auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
+	[success=ok auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
 Password-Type: Primary
 Password:
 	[success=end ignore=ignore default=die]    pam_himmelblau.so ignore_unknown_user set_authtok

--- a/platform/opensuse/pam-config
+++ b/platform/opensuse/pam-config
@@ -5,7 +5,7 @@ Auth: auth     sufficient    pam_himmelblau.so    ignore_unknown_user set_authto
 Auth-Priority: 800
 
 # Account stack
-Account: account        [success=end auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
+Account: account        [success=ok auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
 Account-Priority: 300
 
 # Password stack

--- a/scripts/authselect_README
+++ b/scripts/authselect_README
@@ -15,7 +15,7 @@ PAM (both system-auth and password-auth):
 - Adds at the top of each stack:
     `auth     sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:
-    `account  [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
+    `account  [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
 - Adds:
     `password sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:

--- a/scripts/cargo_vet_review.py
+++ b/scripts/cargo_vet_review.py
@@ -4,13 +4,13 @@ Cargo Vet Review Assistant
 
 Automates the cargo vet workflow by:
 1. Parsing `cargo vet` output to identify unvetted dependencies
-2. Fetching diffs from diff.rs or using local mode
+2. Fetching published crate sources and generating local diffs
 3. Analyzing changes for security concerns (pattern matching + AI)
 4. Providing educated suggestions about safety
 5. Facilitating the certification process
 
 Usage:
-  python scripts/cargo_vet_review.py [--ai-provider gemini|claude] [--no-ai]
+  python scripts/cargo_vet_review.py [--ai-provider codex|gemini|claude] [--no-ai]
 """
 
 import argparse
@@ -20,14 +20,16 @@ import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import urllib.request
-import urllib.error
 from dataclasses import dataclass, field
 from enum import Enum
-from html.parser import HTMLParser
 from pathlib import Path
 from typing import Optional
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class RiskLevel(Enum):
@@ -61,34 +63,16 @@ class DiffAnalysis:
     recommendation: str = ""
     risk_score: RiskLevel = RiskLevel.LOW
     trust_suggestion: Optional[str] = None
-    claude_analysis: Optional[str] = None  # AI-powered analysis
+    ai_analysis: Optional[str] = None  # AI-powered analysis
 
 
-class DiffRsParser(HTMLParser):
-    """Parse diff.rs HTML to extract the actual diff content."""
-    def __init__(self):
-        super().__init__()
-        self.in_code = False
-        self.in_pre = False
-        self.diff_content = []
-        self.current_file = ""
-
-    def handle_starttag(self, tag, attrs):
-        attrs_dict = dict(attrs)
-        if tag == "pre":
-            self.in_pre = True
-        elif tag == "code" and self.in_pre:
-            self.in_code = True
-
-    def handle_endtag(self, tag):
-        if tag == "code":
-            self.in_code = False
-        elif tag == "pre":
-            self.in_pre = False
-
-    def handle_data(self, data):
-        if self.in_code:
-            self.diff_content.append(data)
+@dataclass
+class FetchedDiff:
+    """A locally generated crate diff and the source paths used to create it."""
+    diff: str
+    old_source: Optional[Path]
+    new_source: Path
+    cache_hit: bool
 
 
 class SecurityAnalyzer:
@@ -391,13 +375,12 @@ class SecurityAnalyzer:
         if build_findings:
             recommendations.append("Build script changes detected - verify no malicious build-time behavior.")
 
-        # Add diff URL for easy review
+        # Point reviewers at the local diff/source flow used by this script.
         if analysis.old_version:
-            diff_url = f"https://diff.rs/{analysis.crate_name}/{analysis.old_version}/{analysis.new_version}"
-            recommendations.append(f"Review diff: {diff_url}")
+            recommendations.append("Review the locally generated crate package diff before certifying.")
         else:
             crate_url = f"https://crates.io/crates/{analysis.crate_name}/{analysis.new_version}"
-            recommendations.append(f"Review crate: {crate_url}")
+            recommendations.append(f"Review the published crate package and metadata: {crate_url}")
 
         return "\n".join(f"  - {r}" for r in recommendations)
 
@@ -490,180 +473,236 @@ class CargoVetParser:
 
 
 class DiffFetcher:
-    """Fetch diffs from diff.rs or locally via cargo vet."""
+    """Fetch published crate sources and generate local diffs."""
 
-    def fetch_from_diff_rs(self, crate: str, old_ver: str, new_ver: str, verbose: bool = False) -> Optional[str]:
-        """Fetch diff from diff.rs website."""
-        url = f"https://diff.rs/{crate}/{old_ver}/{new_ver}/"
+    def __init__(self, source_cache_dir: Optional[str] = None):
+        if source_cache_dir:
+            base_cache = Path(source_cache_dir).expanduser()
+        else:
+            xdg_cache = os.environ.get("XDG_CACHE_HOME")
+            base_cache = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
+            base_cache = base_cache / "cargo-vet-review"
 
+        self.source_cache_dir = base_cache
+        self.extracted_dir = self.source_cache_dir / "src"
+        self.crate_archive_dir = self.source_cache_dir / "crates"
+
+    def fetch(self, crate: str, old_ver: Optional[str], new_ver: str, verbose: bool = False) -> Optional[FetchedDiff]:
+        """Fetch published crate sources and generate a unified local diff."""
         try:
-            if verbose:
-                print(f"    Debug: Fetching from {url}")
+            new_source, new_cache_hit = self._ensure_source(crate, new_ver, verbose)
+            old_source = None
+            cache_hit = new_cache_hit
 
-            req = urllib.request.Request(url, headers={
-                'User-Agent': 'cargo-vet-review/1.0 (security audit tool)',
-                'Accept': 'text/html',
-            })
-            with urllib.request.urlopen(req, timeout=60) as response:
-                html = response.read().decode('utf-8')
-
-            if verbose:
-                print(f"    Debug: Got {len(html)} bytes of HTML")
-
-            # Parse HTML to extract diff
-            parser = DiffRsParser()
-            parser.feed(html)
-
-            if verbose:
-                print(f"    Debug: Parsed {len(parser.diff_content)} content blocks")
-
-            if parser.diff_content:
-                return '\n'.join(parser.diff_content)
-
-            # If parsing failed, return None to fall back to local mode
-            if verbose:
-                print("    Debug: No content extracted from HTML")
-            return None
-
-        except (urllib.error.URLError, urllib.error.HTTPError) as e:
-            print(f"    Warning: Could not fetch from diff.rs: {e}")
-            return None
-        except Exception as e:
-            print(f"    Warning: Error fetching from diff.rs: {e}")
-            return None
-
-    def fetch_local(self, crate: str, old_ver: Optional[str], new_ver: str, verbose: bool = False) -> Optional[str]:
-        """Fetch diff using cargo vet's local mode."""
-        timeout = 60
-        cmd: list[str] = []
-        try:
             if old_ver:
-                cmd = ["cargo", "vet", "diff", crate, old_ver, new_ver, "--mode=local"]
-                timeout = 60  # Diffs are usually fast
+                old_source, old_cache_hit = self._ensure_source(crate, old_ver, verbose)
+                cache_hit = new_cache_hit and old_cache_hit
+                diff = self._git_diff_no_index(old_source, new_source, old_source, new_source, verbose)
             else:
-                cmd = ["cargo", "vet", "inspect", crate, new_ver, "--mode=local"]
-                timeout = 180  # Full crate downloads can be slow
+                with tempfile.TemporaryDirectory(prefix="cargo-vet-review-empty-") as empty_dir:
+                    empty_source = Path(empty_dir)
+                    diff = self._git_diff_no_index(empty_source, new_source, empty_source, new_source, verbose)
 
-            if verbose:
-                print(f"    Debug: Running command: {' '.join(cmd)}")
-
-            # For inspect (new crate), first check if the cache already exists
-            if not old_ver:
-                cache_dir = Path.home() / ".cache" / "cargo-vet" / "src" / f"{crate}-{new_ver}"
-                if cache_dir.exists():
-                    if verbose:
-                        print(f"    Debug: Cache already exists at {cache_dir}")
-                    return self._generate_inspect_diff(cache_dir, crate, new_ver, verbose)
-
-            # cargo vet inspect/diff --mode=local prompts "(press ENTER to inspect locally)"
-            # and then opens an interactive shell. We need to:
-            # 1. Send ENTER to proceed past the prompt
-            # 2. Immediately send 'exit' to close the nested shell
-            # 3. Read the source files directly from the cache
-            result = subprocess.run(
-                cmd,
-                input="\nexit\n",  # ENTER to proceed, then exit the shell
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=timeout,
+            return FetchedDiff(
+                diff=diff,
+                old_source=old_source,
+                new_source=new_source,
+                cache_hit=cache_hit,
             )
-
+        except Exception as e:
+            print(f"    Warning: Could not generate local crate diff: {e}")
             if verbose:
-                print(f"    Debug: Command returned {result.returncode}")
-                if result.stderr:
-                    print(f"    Debug: stderr: {result.stderr[:200]}")
+                import traceback
+                traceback.print_exc()
+            return None
 
-            # For 'inspect' command, the source is downloaded to ~/.cache/cargo-vet/src/{crate}-{version}/
-            # We need to generate a diff-like output from the source files
-            if not old_ver:
-                cache_dir = Path.home() / ".cache" / "cargo-vet" / "src" / f"{crate}-{new_ver}"
-                if cache_dir.exists():
-                    if verbose:
-                        print(f"    Debug: Reading source from {cache_dir}")
-                    return self._generate_inspect_diff(cache_dir, crate, new_ver, verbose)
-                else:
-                    if verbose:
-                        print(f"    Debug: Cache dir not found: {cache_dir}")
-                    # Fall back to stdout if available
-                    if result.stdout:
-                        return result.stdout
+    def _ensure_source(self, crate: str, version: str, verbose: bool = False) -> tuple[Path, bool]:
+        """Return an extracted source directory for a published crate version."""
+        managed_source = self.extracted_dir / f"{crate}-{version}"
+        if managed_source.exists():
+            if verbose:
+                print(f"    Debug: Using cached extracted source {managed_source}")
+            return managed_source, True
 
-            if result.returncode == 0:
-                return result.stdout
+        cargo_source = self._find_cargo_registry_source(crate, version)
+        if cargo_source:
+            if verbose:
+                print(f"    Debug: Using Cargo registry source {cargo_source}")
+            return cargo_source, True
+
+        archive = self._find_cargo_registry_archive(crate, version)
+        cache_hit = True
+        if archive:
+            if verbose:
+                print(f"    Debug: Using Cargo registry archive {archive}")
+        else:
+            archive = self.crate_archive_dir / f"{crate}-{version}.crate"
+            if archive.exists():
+                if verbose:
+                    print(f"    Debug: Using cached downloaded archive {archive}")
             else:
-                # cargo vet diff sometimes returns non-zero but still produces output
-                if result.stdout:
-                    return result.stdout
-                print(f"    Warning: cargo vet command failed: {result.stderr}")
-                return None
+                archive = self._download_crate(crate, version, verbose)
+                cache_hit = False
 
-        except subprocess.TimeoutExpired:
-            print(f"    Warning: cargo vet command timed out ({timeout}s)")
+        self._extract_crate_archive(archive, managed_source, crate, version, verbose)
+        return managed_source, cache_hit
+
+    def _cargo_home(self) -> Path:
+        return Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")).expanduser()
+
+    def _find_cargo_registry_source(self, crate: str, version: str) -> Optional[Path]:
+        registry_src = self._cargo_home() / "registry" / "src"
+        if not registry_src.exists():
             return None
-        except FileNotFoundError:
-            print("    Error: cargo-vet not found. Install with: cargo install cargo-vet")
+
+        crate_dir = f"{crate}-{version}"
+        for registry_root in registry_src.iterdir():
+            candidate = registry_root / crate_dir
+            if candidate.is_dir():
+                return candidate
+        return None
+
+    def _find_cargo_registry_archive(self, crate: str, version: str) -> Optional[Path]:
+        registry_cache = self._cargo_home() / "registry" / "cache"
+        if not registry_cache.exists():
             return None
 
-    def _generate_inspect_diff(self, cache_dir: Path, crate: str, version: str, verbose: bool = False) -> str:
-        """Generate a unified diff-like output for a full crate inspection.
+        archive_name = f"{crate}-{version}.crate"
+        for registry_root in registry_cache.iterdir():
+            candidate = registry_root / archive_name
+            if candidate.is_file():
+                return candidate
+        return None
 
-        This creates output similar to what 'git diff' would show, treating all
-        files as new additions. This allows the security analyzer to process
-        the crate source using the same logic as version diffs.
-        """
-        diff_lines = []
+    def _download_crate(self, crate: str, version: str, verbose: bool = False) -> Path:
+        self.crate_archive_dir.mkdir(parents=True, exist_ok=True)
+        archive = self.crate_archive_dir / f"{crate}-{version}.crate"
+        url = f"https://crates.io/api/v1/crates/{crate}/{version}/download"
+        if verbose:
+            print(f"    Debug: Downloading {url}")
 
-        # Find all source files (prioritize important files)
-        important_files = ['Cargo.toml', 'build.rs', 'src/lib.rs', 'src/main.rs']
-        all_files = []
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "cargo-vet-review/1.0 (security audit tool)",
+        })
+        with urllib.request.urlopen(req, timeout=120) as response:
+            data = response.read()
+        archive.write_bytes(data)
+        return archive
 
-        for pattern in ['**/*.rs', '**/*.toml', '**/build.rs']:
-            all_files.extend(cache_dir.glob(pattern))
+    def _extract_crate_archive(
+        self,
+        archive: Path,
+        destination: Path,
+        crate: str,
+        version: str,
+        verbose: bool = False,
+    ) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="cargo-vet-review-extract-") as tmp:
+            tmp_path = Path(tmp)
+            root_name = f"{crate}-{version}"
 
-        # Remove duplicates and sort (important files first)
-        seen = set()
-        sorted_files = []
+            with tarfile.open(archive, "r:gz") as tar:
+                self._safe_extract(tar, tmp_path)
 
-        for important in important_files:
-            full_path = cache_dir / important
-            if full_path.exists() and full_path not in seen:
-                sorted_files.append(full_path)
-                seen.add(full_path)
+            extracted_root = tmp_path / root_name
+            if not extracted_root.is_dir():
+                entries = [p for p in tmp_path.iterdir() if p.is_dir()]
+                if len(entries) == 1:
+                    extracted_root = entries[0]
+                else:
+                    raise RuntimeError(f"archive {archive} did not contain expected root {root_name}")
 
-        for f in sorted(all_files):
-            if f not in seen and f.is_file():
-                sorted_files.append(f)
-                seen.add(f)
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.move(str(extracted_root), str(destination))
 
         if verbose:
-            print(f"    Debug: Found {len(sorted_files)} source files")
+            print(f"    Debug: Extracted {archive} to {destination}")
 
-        for file_path in sorted_files:
+    def _safe_extract(self, tar: tarfile.TarFile, destination: Path) -> None:
+        destination = destination.resolve()
+        for member in tar.getmembers():
+            member_path = destination / member.name
             try:
-                rel_path = file_path.relative_to(cache_dir)
-                content = file_path.read_text(encoding='utf-8', errors='replace')
-                lines = content.split('\n')
+                member_path.resolve().relative_to(destination)
+            except ValueError as e:
+                raise RuntimeError(f"unsafe path in crate archive: {member.name}") from e
+        try:
+            tar.extractall(destination, filter="data")
+        except TypeError:
+            tar.extractall(destination)
 
-                # Generate unified diff header (treating as new file)
-                diff_lines.append(f"diff --git a/{rel_path} b/{rel_path}")
-                diff_lines.append(f"new file mode 100644")
-                diff_lines.append(f"--- /dev/null")
-                diff_lines.append(f"+++ b/{rel_path}")
-                diff_lines.append(f"@@ -0,0 +1,{len(lines)} @@")
+    def _git_diff_no_index(
+        self,
+        old_source: Path,
+        new_source: Path,
+        old_display_root: Path,
+        new_display_root: Path,
+        verbose: bool = False,
+    ) -> str:
+        cmd = [
+            "git",
+            "diff",
+            "--no-index",
+            "--no-ext-diff",
+            "--",
+            str(old_source),
+            str(new_source),
+        ]
+        if verbose:
+            print(f"    Debug: Running command: {' '.join(cmd)}")
 
-                # Add all lines as additions
-                for line in lines:
-                    diff_lines.append(f"+{line}")
-                diff_lines.append("")  # Empty line between files
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+        )
 
-            except Exception as e:
-                if verbose:
-                    print(f"    Debug: Could not read {file_path}: {e}")
+        if result.returncode not in (0, 1):
+            raise RuntimeError(result.stderr.strip() or f"git diff failed with code {result.returncode}")
+
+        return self._normalize_diff_paths(result.stdout, old_display_root, new_display_root)
+
+    def _normalize_diff_paths(self, diff: str, old_root: Path, new_root: Path) -> str:
+        old_root_str = str(old_root)
+        new_root_str = str(new_root)
+        normalized = []
+
+        for line in diff.splitlines():
+            if line.startswith("diff --git "):
+                match = re.match(r"diff --git a/(.+) b/(.+)$", line)
+                if match:
+                    old_rel = self._relative_diff_path(match.group(1), old_root_str, new_root_str)
+                    new_rel = self._relative_diff_path(match.group(2), new_root_str, old_root_str)
+                    normalized.append(f"diff --git a/{old_rel} b/{new_rel}")
+                    continue
+            elif line.startswith("--- a/"):
+                normalized.append(f"--- a/{self._relative_diff_path(line[6:], old_root_str, new_root_str)}")
+                continue
+            elif line.startswith("+++ b/"):
+                normalized.append(f"+++ b/{self._relative_diff_path(line[6:], new_root_str, old_root_str)}")
                 continue
 
-        return '\n'.join(diff_lines)
+            normalized.append(line)
+
+        return "\n".join(normalized)
+
+    def _relative_diff_path(self, path: str, *roots: str) -> str:
+        for root in roots:
+            candidates = {root.rstrip("/"), root.lstrip("/").rstrip("/")}
+            for candidate in candidates:
+                if not candidate:
+                    continue
+                if path == candidate:
+                    return Path(path).name
+                root_prefix = candidate + "/"
+                if path.startswith(root_prefix):
+                    return path[len(root_prefix):]
+        return path
 
 
 class AIAnalyzer:
@@ -854,6 +893,31 @@ Keep your response focused and actionable.
                 if result.returncode == 0 and result.stdout and len(result.stdout.strip()) > 10:
                     return result.stdout.strip()
 
+            elif self.provider == 'codex':
+                with tempfile.NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as output:
+                    output_file = output.name
+
+                try:
+                    result = subprocess.run(
+                        [
+                            self.cli_path,
+                            "exec",
+                            "--cd", str(PROJECT_ROOT),
+                            "--sandbox", "read-only",
+                            "--dangerously-bypass-approvals-and-sandbox",
+                            "--output-last-message", output_file,
+                            "-",
+                        ],
+                        input=prompt, capture_output=True, text=True, timeout=180,
+                    )
+                    if result.returncode == 0:
+                        with open(output_file, "r", encoding="utf-8") as f:
+                            output_text = f.read().strip()
+                        if len(output_text) > 10:
+                            return output_text
+                finally:
+                    if os.path.exists(output_file):
+                        os.unlink(output_file)
 
             # If all methods failed, print debug info
             print(f"    Warning: All {self.provider} invocation methods failed")
@@ -890,30 +954,6 @@ def print_color(text: str, color: str):
         'bold': '\033[1m',
     }
     print(f"{colors.get(color, '')}{text}{colors['reset']}")
-
-
-def generate_diff_url(crate_name: str, old_version: Optional[str], new_version: str) -> str:
-    """Generate a diff.rs URL for reviewing changes.
-
-    Note: File-specific URLs don't work reliably because browsers decode %2F
-    in the URL bar, which breaks diff.rs links. So we only generate base URLs.
-
-    For full crate reviews (no old_version), we use the same version twice
-    which shows the entire crate as "new" code on diff.rs.
-
-    Args:
-        crate_name: Name of the crate
-        old_version: Previous version (None for full crate review)
-        new_version: New version being reviewed
-
-    Returns:
-        URL to diff.rs for reviewing
-    """
-    if old_version:
-        return f"https://diff.rs/{crate_name}/{old_version}/{new_version}"
-    else:
-        # For full crate review, use same version twice to show all code as "new"
-        return f"https://diff.rs/{crate_name}/{new_version}/{new_version}"
 
 
 def print_finding(finding: SecurityFinding):
@@ -986,8 +1026,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s                    # Interactive review with Gemini AI analysis
+  %(prog)s                    # Interactive review with Codex AI analysis
   %(prog)s --ai-provider claude # Use Claude AI instead
+  %(prog)s --ai-provider gemini # Use Gemini AI instead
   %(prog)s --no-ai            # Review without AI (pattern matching only)
   %(prog)s --skip-large 5000  # Skip diffs larger than 5000 lines
   %(prog)s --dry-run          # Analyze without certifying
@@ -1019,20 +1060,26 @@ Examples:
     parser.add_argument(
         "--ai-provider",
         type=str,
-        default="gemini",
-        choices=["gemini", "claude"],
-        help="The AI provider to use for analysis (default: gemini)",
+        default="codex",
+        choices=["codex", "gemini", "claude"],
+        help="The AI provider to use for analysis (default: codex)",
     )
     parser.add_argument(
         "--ai-provider-path",
         type=str,
         default=None,
-        help="Path to the AI provider's CLI binary (e.g., /path/to/gemini)",
+        help="Path to the AI provider's CLI binary (e.g., /path/to/codex)",
     )
     parser.add_argument(
         "--no-ai",
         action="store_true",
         help="Disable AI analysis (use pattern matching only)",
+    )
+    parser.add_argument(
+        "--source-cache-dir",
+        type=str,
+        default=None,
+        help="Directory for downloaded/extracted crate sources (default: XDG cache)",
     )
     parser.add_argument(
         "--verbose", "-v",
@@ -1085,7 +1132,7 @@ Examples:
     ai_analyzer = None
     if not args.no_ai:
         ai_analyzer = AIAnalyzer(provider=args.ai_provider, path=args.ai_provider_path)
-    fetcher = DiffFetcher()
+    fetcher = DiffFetcher(source_cache_dir=args.source_cache_dir)
     analyses = []
 
     # Check AI availability
@@ -1114,10 +1161,6 @@ Examples:
         print(f"    Size: {item.audit_size}")
         print(f"    Type: {review_type}")
 
-        # Show diff URL prominently
-        diff_url = generate_diff_url(item.crate_name, item.old_version, item.new_version)
-        print_color(f"    Review: {diff_url}", "cyan")
-
         if item.trust_note:
             print_color(f"    Trust suggestion: cargo vet trust {item.crate_name} {item.trust_note}", "cyan")
         print()
@@ -1131,15 +1174,17 @@ Examples:
             print(f"    Consider: cargo vet trust {item.crate_name} {item.trust_note or item.publisher}")
             continue
 
-        # Fetch diff using cargo vet (gets ALL files, unlike diff.rs which only shows one)
-        print("    Fetching source changes...")
-        diff_content = fetcher.fetch_local(
+        print("    Fetching published crate sources and generating local diff...")
+        fetched_diff = fetcher.fetch(
             item.crate_name, item.old_version, item.new_version, verbose=args.verbose
         )
 
-        if not diff_content:
+        if not fetched_diff or not fetched_diff.diff:
             print_color("    Could not fetch source content", "red")
             continue
+
+        diff_content = fetched_diff.diff
+        print_color(f"    Source: {fetched_diff.new_source}", "cyan")
 
         # Pattern-based analysis
         print("    Running pattern-based security analysis...")
@@ -1171,7 +1216,7 @@ Examples:
                 is_full_crate=is_full_crate,
                 verbose=args.verbose,
             )
-            analysis.claude_analysis = ai_result
+            analysis.ai_analysis = ai_result
 
         analyses.append(analysis)
 
@@ -1203,14 +1248,14 @@ Examples:
             print_color("    No pattern-based concerns found in added code.", "green")
 
         # AI analysis output
-        if analysis.claude_analysis:
+        if analysis.ai_analysis:
             print()
             print_color("-" * 50, "magenta")
             print_color("AI ANALYSIS", "bold")
             print_color("-" * 50, "magenta")
             print()
             # Indent the response
-            for line in analysis.claude_analysis.split('\n'):
+            for line in analysis.ai_analysis.split('\n'):
                 print(f"    {line}")
             print()
 
@@ -1228,12 +1273,12 @@ Examples:
             print("      [c] Certify this crate")
             print("      [v] View full diff in pager (less)")
             print("      [d] View diff inline (first 200 lines)")
-            print("      [u] Show diff.rs URL")
+            print("      [p] Show local source paths")
             if item.trust_note:
                 print(f"      [t] Trust publisher '{item.trust_note}'")
             if use_ai:
                 print("      [a] Re-run AI analysis")
-            if analysis.claude_analysis:
+            if analysis.ai_analysis:
                 print("      [r] Re-display AI analysis")
             print("      [s] Skip to next crate")
             print("      [q] Quit")
@@ -1275,13 +1320,12 @@ Examples:
                     if len(diff_content.split('\n')) > 200:
                         print_color(f"\n    ... [{len(diff_content.split(chr(10))) - 200} more lines, use 'v' to view all]", "yellow")
                     print()
-                elif choice == 'u':
-                    # Show URL for manual access
-                    if item.old_version:
-                        url = f"https://diff.rs/{item.crate_name}/{item.old_version}/{item.new_version}/"
-                    else:
-                        url = f"https://crates.io/crates/{item.crate_name}/{item.new_version}"
-                    print(f"\n    URL: {url}\n")
+                elif choice == 'p':
+                    print()
+                    if fetched_diff.old_source:
+                        print(f"    Old source: {fetched_diff.old_source}")
+                    print(f"    New source: {fetched_diff.new_source}")
+                    print()
                 elif choice == 't' and item.trust_note:
                     subprocess.run(["cargo", "vet", "trust", item.crate_name, item.trust_note])
                     break
@@ -1297,7 +1341,7 @@ Examples:
                         verbose=True,  # Always verbose on re-run for debugging
                     )
                     if ai_result:
-                        analysis.claude_analysis = ai_result
+                        analysis.ai_analysis = ai_result
                         print()
                         print_color("-" * 50, "magenta")
                         print_color("AI ANALYSIS (refreshed)", "bold")
@@ -1308,13 +1352,13 @@ Examples:
                         print()
                     else:
                         print_color("    AI analysis failed", "red")
-                elif choice == 'r' and analysis.claude_analysis:
+                elif choice == 'r' and analysis.ai_analysis:
                     print()
                     print_color("-" * 50, "magenta")
                     print_color("AI ANALYSIS", "bold")
                     print_color("-" * 50, "magenta")
                     print()
-                    for line in analysis.claude_analysis.split('\n'):
+                    for line in analysis.ai_analysis.split('\n'):
                         print(f"    {line}")
                     print()
                 elif choice == 's':
@@ -1346,7 +1390,8 @@ Examples:
                     for f in a.findings
                 ],
                 "recommendation": a.recommendation,
-                "claude_analysis": a.claude_analysis,
+                "ai_analysis": a.ai_analysis,
+                "claude_analysis": a.ai_analysis,
             })
         print(json.dumps(output, indent=2))
 
@@ -1360,7 +1405,7 @@ Examples:
     print(f"  Skipped: {len(items) - len(analyses)} crates (too large or fetch failed)")
 
     if use_ai:
-        ai_analyzed = sum(1 for a in analyses if a.claude_analysis)
+        ai_analyzed = sum(1 for a in analyses if a.ai_analysis)
         print(f"  AI-analyzed: {ai_analyzed} crates")
 
     # Count full crate reviews vs diffs

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -310,7 +310,7 @@ fn configure_pam(
     for account_file in &account_files {
         insert_module_line(
             account_file,
-            "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
+            "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
             None,
             Some(&|l: &str| {
                 (l.contains("pam_unix.so") && l.contains("account"))
@@ -2310,7 +2310,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const ACCOUNT_LINE: &str =
-        "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
+        "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
 
     fn temp_pam_file(name: &str, content: &str) -> anyhow::Result<PathBuf> {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
@@ -2387,7 +2387,7 @@ mod tests {
     #[test]
     fn skips_already_correct_account_line() -> anyhow::Result<()> {
         let existing = concat!(
-            "account   [success=end auth_err=die default=ignore]   ",
+            "account   [success=ok auth_err=die default=ignore]   ",
             "pam_himmelblau.so   ignore_unknown_user\n",
             "account required pam_unix.so\n"
         );
@@ -2404,6 +2404,34 @@ mod tests {
 
         let content = read_to_string(&path)?;
         assert_eq!(content, existing);
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn replaces_success_end_account_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "success-end",
+            concat!(
+                "account [success=end auth_err=die default=ignore] ",
+                "pam_himmelblau.so ignore_unknown_user\n",
+                "account required pam_unix.so\n"
+            ),
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            format!("{}\naccount required pam_unix.so\n", ACCOUNT_LINE)
+        );
         remove_temp_file(&path)
     }
 

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -3651,7 +3651,7 @@ impl IdProvider for HimmelblauProvider {
 
                 nested_auth_handle_mfa_resp!(flow, cred)
             }
-            (change_password, PamAuthRequest::Password { mut cred }) => {
+            (change_password, PamAuthRequest::Password { cred }) => {
                 let mut reauth_hello_pin: Option<Zeroizing<String>> = None;
                 if let AuthCredHandler::ReauthPassword {
                     reauth_hello_pin: pin,
@@ -3661,8 +3661,8 @@ impl IdProvider for HimmelblauProvider {
                 }
 
                 if let AuthCredHandler::ChangePassword { old_cred } = change_password {
-                    // Report errors, but don't bail out. If the password change fails,
-                    // we'll make another run at it in a moment.
+                    // If the password change fails, show the provider error and
+                    // prompt for another new password while keeping the old password.
                     let _ = net_down_check!(
                         self.client
                             .lock()
@@ -3672,7 +3672,16 @@ impl IdProvider for HimmelblauProvider {
                         Ok(_) => {},
                         Err(e) => {
                             error!("Failed to change user password: {:?}", e);
-                            cred = old_cred.to_string();
+                            *cred_handler = AuthCredHandler::ChangePassword { old_cred: old_cred.to_string() };
+                            return Ok((
+                                AuthResult::Next(
+                                    AuthRequest::ChangePassword { msg: format!(
+                                        "Failed to change user password: {}",
+                                        msal_error_to_user_message(&e),
+                                    )}
+                                ),
+                                AuthCacheAction::None,
+                            ));
                         }
                     );
                 }

--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -381,6 +381,9 @@ async fn handle_client(
                                             let account_id = account_id.to_lowercase();
                                             match resp {
                                                 PamAuthResponse::Success => {
+                                                    let is_oidc_auth =
+                                                        cfg.get_oidc_issuer_url().is_some();
+
                                                     if cfg.get_logon_script().is_some() {
                                                         let scopes = cfg.get_logon_token_scopes();
                                                         let domain = split_username(&account_id)
@@ -447,114 +450,62 @@ async fn handle_client(
                                                     }
 
                                                     // Initialize the user Kerberos ccache
-                                                    if let Some((uid, gid, tgt_cloud, tgt_ad, top_level_names, tenant_id)) =
-                                                        cachelayer
-                                                            .get_user_tgts(Id::Name(
-                                                                account_id.to_string(),
-                                                            ))
-                                                            .await
-                                                    {
-                                                        let (tx, rx) = oneshot::channel();
-                                                        match task_channel_tx
-                                                            .send_timeout(
-                                                                (
-                                                                    TaskRequest::KerberosConfig(top_level_names, tenant_id),
-                                                                    tx,
-                                                                ),
-                                                                Duration::from_millis(100),
-                                                            )
-                                                            .await
-                                                        {
-                                                            Ok(()) => {
-                                                                // Now wait for the other end OR timeout.
-                                                                match time::timeout_at(
-                                                                    time::Instant::now()
-                                                                        + Duration::from_secs(60),
-                                                                    rx,
-                                                                )
+                                                    if !is_oidc_auth {
+                                                        if let Some((uid, gid, tgt_cloud, tgt_ad, top_level_names, tenant_id)) =
+                                                            cachelayer
+                                                                .get_user_tgts(Id::Name(
+                                                                    account_id.to_string(),
+                                                                ))
                                                                 .await
-                                                                {
-                                                                    Ok(Ok(status)) => {
-                                                                        if status != 0 {
-                                                                            error!("Kerberos config failed for {}: Status code: {}", account_id, status);
-                                                                        }
-                                                                    }
-                                                                    Ok(Err(e)) => {
-                                                                        error!("Kerberos config failed for {}: {:?}", account_id, e);
-                                                                    }
-                                                                    Err(e) => {
-                                                                        error!("Kerberos config failed for {}: {:?}", account_id, e);
-                                                                    }
-                                                                }
-                                                            }
-                                                            Err(e) => {
-                                                                error!("Kerberos config failed for {}: {:?}", account_id, e);
-                                                            }
-                                                        }
-
-                                                        let (tx, rx) = oneshot::channel();
-
-                                                        match task_channel_tx
-                                                            .send_timeout(
-                                                                (
-                                                                    TaskRequest::KerberosTGTs(
-                                                                        uid,
-                                                                        gid,
-                                                                        tgt_cloud,
-                                                                        tgt_ad,
+                                                        {
+                                                            let (tx, rx) = oneshot::channel();
+                                                            match task_channel_tx
+                                                                .send_timeout(
+                                                                    (
+                                                                        TaskRequest::KerberosConfig(top_level_names, tenant_id),
+                                                                        tx,
                                                                     ),
-                                                                    tx,
-                                                                ),
-                                                                Duration::from_millis(100),
-                                                            )
-                                                            .await
-                                                        {
-                                                            Ok(()) => {
-                                                                // Now wait for the other end OR timeout.
-                                                                match time::timeout_at(
-                                                                    time::Instant::now()
-                                                                        + Duration::from_secs(60),
-                                                                    rx,
+                                                                    Duration::from_millis(100),
                                                                 )
                                                                 .await
-                                                                {
-                                                                    Ok(Ok(status)) => {
-                                                                        if status != 0 {
-                                                                            error!("Kerberos credential cache load failed for {}: Status code: {}", account_id, status);
+                                                            {
+                                                                Ok(()) => {
+                                                                    // Now wait for the other end OR timeout.
+                                                                    match time::timeout_at(
+                                                                        time::Instant::now()
+                                                                            + Duration::from_secs(60),
+                                                                        rx,
+                                                                    )
+                                                                    .await
+                                                                    {
+                                                                        Ok(Ok(status)) => {
+                                                                            if status != 0 {
+                                                                                error!("Kerberos config failed for {}: Status code: {}", account_id, status);
+                                                                            }
+                                                                        }
+                                                                        Ok(Err(e)) => {
+                                                                            error!("Kerberos config failed for {}: {:?}", account_id, e);
+                                                                        }
+                                                                        Err(e) => {
+                                                                            error!("Kerberos config failed for {}: {:?}", account_id, e);
                                                                         }
                                                                     }
-                                                                    Ok(Err(e)) => {
-                                                                        error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
-                                                                    }
-                                                                    Err(e) => {
-                                                                        error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
-                                                                    }
+                                                                }
+                                                                Err(e) => {
+                                                                    error!("Kerberos config failed for {}: {:?}", account_id, e);
                                                                 }
                                                             }
-                                                            Err(e) => {
-                                                                error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
-                                                            }
-                                                        }
-                                                    }
 
-                                                    // Fetch the user Profile picture
-                                                    if let Some(token) = cachelayer
-                                                        .get_user_accesstoken(
-                                                            Id::Name(account_id.to_string()),
-                                                            vec![],
-                                                            None,
-                                                        )
-                                                        .await
-                                                    {
-                                                        if let Some(access_token) = &token.access_token {
                                                             let (tx, rx) = oneshot::channel();
 
                                                             match task_channel_tx
                                                                 .send_timeout(
                                                                     (
-                                                                        TaskRequest::LoadProfilePhoto(
-                                                                            account_id.to_string(),
-                                                                            access_token.to_string(),
+                                                                        TaskRequest::KerberosTGTs(
+                                                                            uid,
+                                                                            gid,
+                                                                            tgt_cloud,
+                                                                            tgt_ad,
                                                                         ),
                                                                         tx,
                                                                     ),
@@ -571,23 +522,79 @@ async fn handle_client(
                                                                     )
                                                                     .await
                                                                     {
-                                                                        Ok(_) => {
-                                                                            info!("Fetching user profile picture succeeded");
+                                                                        Ok(Ok(status)) => {
+                                                                            if status != 0 {
+                                                                                error!("Kerberos credential cache load failed for {}: Status code: {}", account_id, status);
+                                                                            }
                                                                         }
-                                                                        _ => {
-                                                                            error!("Fetching user profile picture failed");
+                                                                        Ok(Err(e)) => {
+                                                                            error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
+                                                                        }
+                                                                        Err(e) => {
+                                                                            error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
                                                                         }
                                                                     }
                                                                 }
-                                                                Err(_) => {
-                                                                    error!("Fetching user profile picture failed");
+                                                                Err(e) => {
+                                                                    error!("Kerberos credential cache load failed for {}: {:?}", account_id, e);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    // Fetch the user Profile picture
+                                                    if !is_oidc_auth {
+                                                        if let Some(token) = cachelayer
+                                                            .get_user_accesstoken(
+                                                                Id::Name(account_id.to_string()),
+                                                                vec![],
+                                                                None,
+                                                            )
+                                                            .await
+                                                        {
+                                                            if let Some(access_token) = &token.access_token {
+                                                                let (tx, rx) = oneshot::channel();
+
+                                                                match task_channel_tx
+                                                                    .send_timeout(
+                                                                        (
+                                                                            TaskRequest::LoadProfilePhoto(
+                                                                                account_id.to_string(),
+                                                                                access_token.to_string(),
+                                                                            ),
+                                                                            tx,
+                                                                        ),
+                                                                        Duration::from_millis(100),
+                                                                    )
+                                                                    .await
+                                                                {
+                                                                    Ok(()) => {
+                                                                        // Now wait for the other end OR timeout.
+                                                                        match time::timeout_at(
+                                                                            time::Instant::now()
+                                                                                + Duration::from_secs(60),
+                                                                            rx,
+                                                                        )
+                                                                        .await
+                                                                        {
+                                                                            Ok(_) => {
+                                                                                info!("Fetching user profile picture succeeded");
+                                                                            }
+                                                                            _ => {
+                                                                                error!("Fetching user profile picture failed");
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                    Err(_) => {
+                                                                        error!("Fetching user profile picture failed");
+                                                                    }
                                                                 }
                                                             }
                                                         }
                                                     }
 
                                                     // Apply Intune policies
-                                                    if cfg.get_apply_policy() {
+                                                    if !is_oidc_auth && cfg.get_apply_policy() {
                                                         spawn_intune_policy_application(
                                                             cachelayer.clone(),
                                                             cfg.clone(),

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -90,7 +90,7 @@ fix_pam_config_account_line() {
     # Make explicit himmelblau account denials terminal while preserving
     # PAM_IGNORE fall-through for local users.
     sed -i -E \
-        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=end auth_err=die default=ignore]\3#' \
+        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=ok auth_err=die default=ignore]\3#' \
         "$plain" || return 1
 
     return 0

--- a/src/qr-greeter/Cargo.toml
+++ b/src/qr-greeter/Cargo.toml
@@ -44,6 +44,7 @@ assets = [
   { source = "target/release/qr-greeter-build/qr-greeter@himmelblau-idm.org/ms-consumer-dag.png", dest = "/usr/share/gnome-shell/extensions/qr-greeter@himmelblau-idm.org/ms-consumer-dag.png", mode = "644" },
 ]
 post_install_script = "scripts/postinst"
+post_uninstall_script = "scripts/postrm"
 
 [package.metadata.generate-rpm.requires]
 gnome-shell = "*"

--- a/src/qr-greeter/scripts/postinst
+++ b/src/qr-greeter/scripts/postinst
@@ -3,17 +3,7 @@ set -e
 
 if command -v dconf >/dev/null 2>&1; then
     # Enable extension for GDM user (login screen)
-    debian_major_version=
-    if [ -r /etc/os-release ]; then
-        debian_major_version=$(
-            . /etc/os-release
-            if [ "$ID" = "debian" ]; then
-                echo "$VERSION_ID" | sed 's/[^0-9].*$//'
-            fi
-        )
-    fi
-
-    if [ -n "$debian_major_version" ] && [ "$debian_major_version" -ge 13 ] 2>/dev/null && [ -x /usr/share/gdm/generate-config ]; then
+    if getent passwd Debian-gdm >/dev/null 2>&1 && [ -x /usr/share/gdm/generate-config ]; then
         echo "Enabling Himmelblau QR Greeter GNOME Shell extension for Debian GDM greeter..."
 
         mkdir -p /usr/share/gdm/dconf
@@ -53,7 +43,7 @@ enabled-extensions=['qr-greeter@himmelblau-idm.org']
 EOF
         echo "Created /etc/dconf/db/gdm.d/01-himmelblau-qr-greeter"
     else
-        echo 'Info: gdm user not available; skipping GDM extension enable.' >&2
+        echo 'Info: neither Debian-gdm nor gdm user is available; skipping GDM extension enable.' >&2
     fi
 
     # Enable extension for regular users (lockscreen)

--- a/src/qr-greeter/scripts/postinst
+++ b/src/qr-greeter/scripts/postinst
@@ -3,7 +3,33 @@ set -e
 
 if command -v dconf >/dev/null 2>&1; then
     # Enable extension for GDM user (login screen)
-    if getent passwd gdm >/dev/null 2>&1; then
+    debian_major_version=
+    if [ -r /etc/os-release ]; then
+        debian_major_version=$(
+            . /etc/os-release
+            if [ "$ID" = "debian" ]; then
+                echo "$VERSION_ID" | sed 's/[^0-9].*$//'
+            fi
+        )
+    fi
+
+    if [ -n "$debian_major_version" ] && [ "$debian_major_version" -ge 13 ] 2>/dev/null && [ -x /usr/share/gdm/generate-config ]; then
+        echo "Enabling Himmelblau QR Greeter GNOME Shell extension for Debian GDM greeter..."
+
+        mkdir -p /usr/share/gdm/dconf
+
+        cat > /usr/share/gdm/dconf/01-himmelblau-qr-greeter << 'EOF'
+[org/gnome/shell]
+enabled-extensions=['qr-greeter@himmelblau-idm.org']
+EOF
+        echo "Created /usr/share/gdm/dconf/01-himmelblau-qr-greeter"
+
+        if /usr/share/gdm/generate-config; then
+            echo "Regenerated Debian GDM greeter dconf defaults."
+        else
+            echo 'Warning: Debian GDM greeter dconf generation failed' >&2
+        fi
+    elif getent passwd gdm >/dev/null 2>&1; then
         echo "Enabling Himmelblau QR Greeter GNOME Shell extension for GDM user..."
 
         # Create /etc/dconf/profile/gdm if it doesn't exist

--- a/src/qr-greeter/scripts/postrm
+++ b/src/qr-greeter/scripts/postrm
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+case "${1:-}" in
+    remove|purge|0)
+        rm -f /usr/share/gdm/dconf/01-himmelblau-qr-greeter
+        rm -f /etc/dconf/db/gdm.d/01-himmelblau-qr-greeter
+        rm -f /etc/dconf/db/local.d/01-himmelblau-qr-greeter
+
+        if [ -x /usr/share/gdm/generate-config ]; then
+            if /usr/share/gdm/generate-config; then
+                echo "Regenerated Debian GDM greeter dconf defaults."
+            else
+                echo 'Warning: Debian GDM greeter dconf generation failed' >&2
+            fi
+        fi
+
+        if command -v dconf >/dev/null 2>&1; then
+            if dconf update; then
+                echo "Himmelblau QR Greeter GNOME Shell extension dconf settings removed."
+            else
+                echo 'Warning: dconf update failed' >&2
+            fi
+        fi
+        ;;
+esac

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -159,6 +159,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.2.61 -> 1.2.63"
 
+[[audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.1 -> 1.4.2"
+
 [[audits.cesu8]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -264,7 +269,22 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
+[[audits.futures-channel]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
 [[audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-executor]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -272,9 +292,19 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.futures-executor]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
 [[audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-macro]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -282,9 +312,19 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.futures-macro]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
 [[audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-task]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -292,12 +332,17 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.futures-task]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
-delta = "0.3.31 -> 0.3.32"
+delta = "0.3.33 -> 0.3.34"
 
 [[audits.futures-util]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-util]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
 
 [[audits.getrandom]]
 who = "David Mulder <dmulder@samba.org>"
@@ -449,6 +494,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "3.0.6"
 
+[[audits.pem]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.0.6 -> 4.0.0"
+
 [[audits.picky-asn1-der]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -459,10 +509,20 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.7.1"
 
+[[audits.quinn-proto]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.11.14 -> 0.11.16"
+
 [[audits.rand_core]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.5 -> 0.10.0"
+
+[[audits.rand_pcg]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+version = "0.10.2"
 
 [[audits.reqwest_cookie_store]]
 who = "David Mulder <dmulder@samba.org>"
@@ -844,11 +904,21 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.15.0 -> 5.16.0"
 
+[[audits.zbus_macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.18.0 -> 5.19.0"
+
 [[audits.zbus_names]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "4.2.0 -> 4.3.1"
 
+[[audits.zcheapstr]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+
 [[audits.zvariant]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -864,6 +934,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.11.0 -> 5.12.0"
 
+[[audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.13.1 -> 5.14.0"
+
 [[audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -878,6 +953,11 @@ delta = "5.9.2 -> 5.10.0"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.11.0 -> 5.12.0"
+
+[[audits.zvariant_derive]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.13.1 -> 5.14.0"
 
 [[audits.zvariant_utils]]
 who = "David Mulder <dmulder@samba.org>"
@@ -888,6 +968,11 @@ delta = "3.2.0 -> 3.3.0"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "3.3.1 -> 3.4.0"
+
+[[audits.zvariant_utils]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.5.0 -> 4.0.0"
 
 [[trusted.aho-corasick]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -338,10 +338,6 @@ criteria = "safe-to-deploy"
 version = "4.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.futf]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.futures-lite]]
 version = "2.6.0"
 criteria = "safe-to-deploy"
@@ -488,10 +484,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.lru-slab]]
 version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.mac]]
-version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.malloced]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -44,8 +44,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anyhow]]
-version = "1.0.103"
-when = "2026-06-25"
+version = "1.0.104"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -58,8 +58,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.async-trait]]
-version = "0.1.89"
-when = "2025-08-14"
+version = "0.1.92"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -93,8 +93,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.bytes]]
-version = "1.12.0"
-when = "2026-06-18"
+version = "1.12.1"
+when = "2026-07-08"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -113,29 +113,29 @@ user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
 [[publisher.clap]]
-version = "4.6.1"
-when = "2026-04-15"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_builder]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_complete]]
-version = "4.6.6"
-when = "2026-06-30"
+version = "4.6.9"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_derive]]
-version = "4.6.1"
-when = "2026-04-15"
+version = "4.6.4"
+when = "2026-07-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -479,8 +479,8 @@ user-login = "Firstyear"
 user-name = "Firstyear"
 
 [[publisher.libc]]
-version = "0.2.186"
-when = "2026-04-23"
+version = "0.2.189"
+when = "2026-07-21"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -492,8 +492,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.libhimmelblau]]
-version = "0.8.25"
-when = "2026-07-01"
+version = "0.8.30"
+when = "2026-08-12"
 user-id = 247655
 user-login = "dmulder"
 user-name = "David Mulder"
@@ -680,15 +680,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regex]]
-version = "1.12.4"
-when = "2026-06-09"
+version = "1.13.1"
+when = "2026-07-15"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.regex-automata]]
-version = "0.4.13"
-when = "2025-10-13"
+version = "0.4.18"
+when = "2026-08-04"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -722,8 +722,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.rustls]]
-version = "0.23.41"
-when = "2026-06-22"
+version = "0.23.42"
+when = "2026-07-13"
 user-id = 4556
 user-login = "djc"
 user-name = "Dirkjan Ochtman"
@@ -750,8 +750,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.serde]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -771,22 +771,22 @@ user-login = "Firstyear"
 user-name = "Firstyear"
 
 [[publisher.serde_core]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_derive]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_json]]
-version = "1.0.150"
-when = "2026-05-21"
+version = "1.0.151"
+when = "2026-07-20"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -861,6 +861,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.syn]]
+version = "3.0.3"
+when = "2026-07-22"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.target-lexicon]]
 version = "0.12.16"
 when = "2024-07-30"
@@ -911,8 +918,8 @@ user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.tokio-util]]
-version = "0.7.18"
-when = "2026-01-04"
+version = "0.7.19"
+when = "2026-07-21"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -2100,12 +2107,6 @@ criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
 
-[[audits.bytecode-alliance.audits.utf-8]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
-version = "0.7.6"
-notes = "Small library that uses `unsafe` only around `str::from_utf8_unchecked` after explicitly verifying UTF-8."
-
 [[audits.bytecode-alliance.audits.vcpkg]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -3084,6 +3085,16 @@ See https://crrev.com/c/6323349 for more audit notes.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.himmelblau.audits.base64]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.22.1 -> 0.23.0"
+
+[[audits.himmelblau.audits.base64]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.23.0 -> 0.23.1"
+
 [[audits.himmelblau.audits.bitfield]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3108,6 +3119,16 @@ delta = "1.2.60 -> 1.2.61"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.2.61 -> 1.2.65"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.2.65 -> 1.4.0"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.4.1"
 
 [[audits.himmelblau.audits.chrono]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3139,6 +3160,76 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.10 -> 0.9.11"
 
+[[audits.himmelblau.audits.dbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.11 -> 0.9.12"
+
+[[audits.himmelblau.audits.ego-tree]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.0"
+
+[[audits.himmelblau.audits.event-listener]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.4.0 -> 5.4.2"
+
+[[audits.himmelblau.audits.find-msvc-tools]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.9 -> 0.1.10"
+
+[[audits.himmelblau.audits.futures]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-channel]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-executor]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-macro]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-task]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-util]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.html5ever]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.36.1 -> 0.39.0"
+
 [[audits.himmelblau.audits.lru]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3148,6 +3239,21 @@ delta = "0.16.3 -> 0.16.4"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.16.4 -> 0.18.0"
+
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.18.1"
+
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.18.1 -> 0.18.2"
+
+[[audits.himmelblau.audits.markup5ever]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.36.1 -> 0.39.0"
 
 [[audits.himmelblau.audits.num-conv]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3249,6 +3355,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.11.12 -> 0.11.14"
 
+[[audits.himmelblau.audits.rand]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.1 -> 0.10.2"
+
 [[audits.himmelblau.audits.regex-syntax]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3264,10 +3375,25 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "2.1.1 -> 2.1.2"
 
+[[audits.himmelblau.audits.rustls]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.23.42 -> 0.23.43"
+
+[[audits.himmelblau.audits.scraper]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.25.0 -> 0.27.0"
+
 [[audits.himmelblau.audits.sd-notify]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.5 -> 0.5.0"
+
+[[audits.himmelblau.audits.selectors]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.33.0 -> 0.38.0"
 
 [[audits.himmelblau.audits.semver]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3304,10 +3430,25 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "3.19.0 -> 3.21.0"
 
+[[audits.himmelblau.audits.spin]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.8 -> 0.9.9"
+
+[[audits.himmelblau.audits.tendril]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.5.1"
+
 [[audits.himmelblau.audits.time]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.47 -> 0.3.51"
+
+[[audits.himmelblau.audits.time]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.51 -> 0.3.55"
 
 [[audits.himmelblau.audits.time-core]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3318,6 +3459,11 @@ delta = "0.1.8 -> 0.1.9"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.27 -> 0.2.30"
+
+[[audits.himmelblau.audits.time-macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.30 -> 0.2.32"
 
 [[audits.himmelblau.audits.tonic-types]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3364,7 +3510,22 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.23.1 -> 1.23.4"
 
+[[audits.himmelblau.audits.uuid]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.23.4 -> 1.24.0"
+
 [[audits.himmelblau.audits.zbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.14.0 -> 5.15.0"
+
+[[audits.himmelblau.audits.zbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.16.0 -> 5.18.0"
+
+[[audits.himmelblau.audits.zbus_macros]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.14.0 -> 5.15.0"
@@ -3372,12 +3533,17 @@ delta = "5.14.0 -> 5.15.0"
 [[audits.himmelblau.audits.zbus_macros]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
-delta = "5.14.0 -> 5.15.0"
+delta = "5.16.0 -> 5.18.0"
 
 [[audits.himmelblau.audits.zbus_names]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "4.3.1 -> 4.3.2"
+
+[[audits.himmelblau.audits.zbus_names]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "4.3.2 -> 4.3.4"
 
 [[audits.himmelblau.audits.zeroize]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3394,15 +3560,30 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.10.0 -> 5.11.0"
 
+[[audits.himmelblau.audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.12.0 -> 5.13.1"
+
 [[audits.himmelblau.audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.10.0 -> 5.11.0"
 
+[[audits.himmelblau.audits.zvariant_derive]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.12.0 -> 5.13.1"
+
 [[audits.himmelblau.audits.zvariant_utils]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "3.3.0 -> 3.3.1"
+
+[[audits.himmelblau.audits.zvariant_utils]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.4.0 -> 3.5.0"
 
 [[audits.isrg.audits.base64]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
@@ -3989,6 +4170,13 @@ criteria = "safe-to-deploy"
 delta = "0.35.0 -> 0.36.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.cssparser]]
+who = "Nico Burns <nico@nicoburns.com>"
+criteria = "safe-to-deploy"
+delta = "0.36.0 -> 0.37.0"
+notes = "First-party code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.cssparser-macros]]
 who = "Emilio Cobos Álvarez <emilio@crisal.io>"
 criteria = "safe-to-deploy"
@@ -4003,6 +4191,13 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.6.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cssparser-macros]]
+who = "Nico Burns <nico@nicoburns.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.7.0"
+notes = "First party code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.deranged]]


### PR DESCRIPTION
## Summary
Backport commits to stable-3.x:

- ae154c20: fix(auth): retry failed password changes
- 81dfc576: use debian-gdm user in qr postinst
- a478a84a: check debian-gdm user instead of version
- 7fb79934: add script to remove qr assets
- 141c4417: add qr postrm to fedora
- bc951987: Skip Entra post-auth tasks for OIDC.
- 43d965dc: Use ok for account stack success.
- 893cad14: fix(nix): added `CacheDirectory` and added it to `ReadWritePaths`

### Dependabot Updates Included
- deps(rust): bump the all-cargo-updates group with 25 updates (#1597)


## Test plan
- [ ] Build succeeds
- [ ] `make vet` passes
- [ ] Basic functionality tested

---
Generated with [Claude Code](https://claude.com/claude-code)
