### PR TITLE
chore: add donation support messaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,9 @@ jobs:
       - name: "Run tests"
         run: cargo test
         continue-on-error: false
+      - name: "Test aad-tool without donation messages"
+        run: cargo test -p aad-tool --no-default-features
+        continue-on-error: false
       - name: "Check translations"
         run: scripts/i18n-check
         continue-on-error: false

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -334,7 +334,10 @@ rec {
             features = [ "v4" "v5" ];
           }
         ];
-
+        features = {
+          "default" = [ "donation-messages" ];
+        };
+        resolvedDefaultFeatures = [ "default" "donation-messages" ];
       };
       "adler2" = rec {
         crateName = "adler2";

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/himmelblau-idm/himmelblau/badge)](https://scorecard.dev/viewer/?uri=github.com/himmelblau-idm/himmelblau) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11235/badge)](https://www.bestpractices.dev/projects/11235)
 
-[![Donate to Our Collective](https://opencollective.com/yourproject/donate/button.png?color=blue)](https://opencollective.com/himmelblau)
+[![Support Himmelblau](https://opencollective.com/himmelblau/donate/button.png?color=blue)](https://himmelblau-idm.org/donations/)
 
 # Himmelblau
 
@@ -32,11 +32,11 @@ or on the [Samba Technical community matrix channel](https://matrix.to/#/#samba-
 
 ## 💙 Support Himmelblau
 
-Himmelblau is developed and maintained by [SUSE Linux](https://www.suse.com), but the **project’s operating expenses**—including hosting, domain registration, and tooling—are funded by the **community**.
+Himmelblau is developed and maintained with significant support from [SUSE Linux](https://www.suse.com). Community financial support helps sustain project infrastructure, maintenance, and ongoing development.
 
-These costs currently run about **$30–$50 per month**, and while we have a few months of runway, **your support helps keep the project sustainable**. Even small contributions go a long way toward ensuring Himmelblau continues to grow and support Entra ID on Linux.
+Your support helps keep cloud identity for Linux open and available to everyone.
 
-👉 [Become a backer or sponsor](https://himmelblau-idm.org/backers.html)
+👉 [Sponsor Himmelblau or support a development priority](https://himmelblau-idm.org/donations/)
 
 ## Installing
 

--- a/man/aad-tool
+++ b/man/aad-tool
@@ -12,5 +12,15 @@ for arg in "$@"; do
   fi
 done
 
+# The committed man page has its own SUPPORT section. Remove the root-help CTA
+# from help2man's input so regenerating the page does not duplicate the text.
+if [[ ${#args[@]} -eq 1 && ( "${args[0]}" == "--help" || "${args[0]}" == "-h" || "${args[0]}" == "help" ) ]]; then
+  ../target/debug/aad-tool "${args[@]}" \
+    | sed \
+      -e '/^Support Himmelblau: Financial support helps keep cloud identity for Linux open\.$/d' \
+      -e '/^Learn more: https:\/\/himmelblau-idm\.org\/donations\/$/d'
+  exit
+fi
+
 # Call the command with modified arguments
 ../target/debug/aad-tool "${args[@]}"

--- a/man/combine.py
+++ b/man/combine.py
@@ -70,6 +70,10 @@ for file in man_files:
 """
 
 combined_lines.extend([
+    ".SH SUPPORT",
+    "Financial support helps sustain Himmelblau project infrastructure, maintenance, and ongoing development while keeping cloud identity for Linux open and available to everyone.",
+    ".PP",
+    "Learn more: https://himmelblau-idm.org/donations/",
     ".SH SEE ALSO",
     ".BR himmelblau.conf (5),",
     ".BR himmelblaud (8),",

--- a/man/man1/aad-tool.1
+++ b/man/man1/aad-tool.1
@@ -600,6 +600,10 @@ This command must be run from a device that has already been joined to Entra ID.
 \fB\-h\fR, \fB\-\-help\fR
 .IP
 Print help (see a summary with '\-h')
+.SH SUPPORT
+Financial support helps sustain Himmelblau project infrastructure, maintenance, and ongoing development while keeping cloud identity for Linux open and available to everyone.
+.PP
+Learn more: https://himmelblau-idm.org/donations/
 .SH SEE ALSO
 .BR himmelblau.conf (5),
 .BR himmelblaud (8),

--- a/scripts/gen_ebuild.py
+++ b/scripts/gen_ebuild.py
@@ -377,6 +377,8 @@ pkg_postinst() {{
 \tewarn "  1. Override /usr/lib/himmelblau/himmelblau.conf with your own configuration if needed"
 \tewarn "  2. Enable the himmelblaud service: systemctl enable --now himmelblaud"
 \tewarn "  3. Configure PAM and NSS (see documentation)"
+\teinfo "Support Himmelblau: Financial support helps keep cloud identity for Linux open."
+\teinfo "Learn more: https://himmelblau-idm.org/donations/"
 }}
 """
 

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -10,6 +10,10 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+default = ["donation-messages"]
+donation-messages = []
+
 [[bin]]
 name = "aad-tool"
 path = "src/main.rs"

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -2433,6 +2433,8 @@ async fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::insert_module_line;
+    use super::HimmelblauUnixParser;
+    use clap::CommandFactory;
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -2585,5 +2587,34 @@ mod tests {
             "auth required pam_himmelblau.so ignore_unknown_user set_authtok\nauth required pam_unix.so\n"
         );
         remove_temp_file(&path)
+    }
+
+    const DONATIONS_URL: &str = "https://himmelblau-idm.org/donations/";
+
+    #[test]
+    fn donation_message_matches_feature_setting() {
+        let help = HimmelblauUnixParser::command()
+            .render_long_help()
+            .to_string();
+
+        #[cfg(feature = "donation-messages")]
+        assert_eq!(help.matches(DONATIONS_URL).count(), 1);
+
+        #[cfg(not(feature = "donation-messages"))]
+        assert!(!help.contains(DONATIONS_URL));
+    }
+
+    #[test]
+    fn donation_message_is_not_in_subcommand_help() {
+        let command = HimmelblauUnixParser::command();
+        let mut status = command
+            .find_subcommand("status")
+            .expect("status subcommand must exist")
+            .clone();
+
+        assert!(!status
+            .render_long_help()
+            .to_string()
+            .contains(DONATIONS_URL));
     }
 }

--- a/src/cli/src/opt/tool.rs
+++ b/src/cli/src/opt/tool.rs
@@ -565,6 +565,10 @@ pub enum HimmelblauUnixOpt {
 
 #[derive(Debug, clap::Parser)]
 #[clap(about = "Himmelblau Management Utility")]
+#[cfg_attr(
+    feature = "donation-messages",
+    clap(after_help = "Support Himmelblau: Financial support helps keep cloud identity for Linux open.\nLearn more: https://himmelblau-idm.org/donations/")
+)]
 pub struct HimmelblauUnixParser {
     #[clap(subcommand)]
     pub commands: HimmelblauUnixOpt,

--- a/src/daemon/scripts/postinst
+++ b/src/daemon/scripts/postinst
@@ -154,3 +154,6 @@ elif command -v systemctl >/dev/null 2>&1; then
     # Globally enable user timer for compliance checks (does not start existing sessions)
     systemctl --global enable himmelblau-compliance-check.timer 2>/dev/null || true
 fi
+
+echo "Support Himmelblau: Financial support helps keep cloud identity for Linux open."
+echo "Learn more: https://himmelblau-idm.org/donations/"


### PR DESCRIPTION
Add configurable donation prompts to aad-tool help, packaging output, and generated documentation. This keeps the support message visible while allowing no-default-features builds to omit it.

## Summary

Fixes #

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
