### PR TITLE
fix(o365): avoid busy test script exec

### DIFF
--- a/src/o365/tests/url_handler.rs
+++ b/src/o365/tests/url_handler.rs
@@ -77,7 +77,8 @@ impl Harness {
         let log = self.dir.join("calls.log");
         let _ = fs::remove_file(&log);
 
-        let out = Command::new(self.dir.join("o365-url-handler"))
+        let out = Command::new("bash")
+            .arg(self.dir.join("o365-url-handler"))
             .args(args)
             // The stubs shadow anything of the same name on the real PATH.
             .env(


### PR DESCRIPTION
Invoke the generated o365-url-handler script
through bash in the test harness. This avoids the
CI race where the temp script can still be busy
when executed directly.

## Summary

Fixes #

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
