### PR TITLE
fix(auth): skip Intune for OIDC

### DIFF
--- a/src/daemon/src/daemon.rs
+++ b/src/daemon/src/daemon.rs
@@ -807,7 +807,7 @@ async fn handle_client(
                                                     }
 
                                                     // Apply Intune policies
-                                                    if cfg.get_apply_policy() {
+                                                    if !is_oidc_auth && cfg.get_apply_policy() {
                                                         spawn_intune_policy_application_if_due(
                                                             cachelayer.clone(),
                                                             cfg.clone(),
@@ -1070,8 +1070,8 @@ async fn handle_client(
                 async {
                     trace!("compliance check requested");
 
-                    if !cfg.get_apply_policy() {
-                        warn!("compliance check: apply_policy is disabled in config");
+                    if !cfg.get_apply_policy() || cfg.get_oidc_issuer_url().is_some() {
+                        warn!("compliance check: unavailable for current configuration");
                         return ClientResponse::Error;
                     }
 


### PR DESCRIPTION
Avoid requesting Intune policy tokens when the client is authenticating via OIDC. This keeps Entra ID service token requests on the non-OIDC authentication path.

## Summary

Fixes #

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
