### PR TITLE
Backport to 2.x: 11 commits + 1 dependency update(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.29"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ac5b3c2c565a8561ef291106116270fc7bf545cbb72ca885a6d48f07103de0"
+checksum = "826695436e4c4d1bc3da1e8b39416e2c767c53d750571a279455f270b17a18f1"
 dependencies = [
  "base64 0.23.1",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -285,7 +285,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -314,13 +314,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -446,6 +446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +494,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -512,7 +518,7 @@ dependencies = [
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -540,7 +546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -631,9 +637,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "c-types"
@@ -668,16 +674,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -742,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -752,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -764,23 +770,23 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.6"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bf4965940c2382204c0ded6dd3dd48c0c4e872f1e76fb1bf94f45991a2cb6a"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1069,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1082,12 +1088,12 @@ dependencies = [
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1122,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1185,7 +1191,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1196,7 +1202,7 @@ checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1213,7 +1219,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1233,7 +1239,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1278,7 +1284,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1327,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1391,7 +1397,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1482,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flagset"
@@ -1560,20 +1566,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1586,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1596,15 +1592,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1613,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -1632,32 +1628,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1882,7 +1878,7 @@ version = "2.3.14"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "himmelblau_unix_common",
  "libc",
  "libhimmelblau",
@@ -1905,7 +1901,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "authenticator",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "compact_jwt",
  "configparser",
@@ -1945,7 +1941,7 @@ name = "himmelblaud"
 version = "2.3.14"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "clap",
  "console-subscriber",
@@ -2022,9 +2018,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -2502,7 +2498,7 @@ dependencies = [
  "md4",
  "openssl",
  "openssl-sys",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "serde",
  "sha-crypt",
@@ -2636,9 +2632,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -2661,11 +2657,11 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.27"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0c3990110cfb28f4e235ab0cb8e1d4796e74fa99c8f256c3fccd18994dc02b"
+checksum = "27ac5b3c2c565a8561ef291106116270fc7bf545cbb72ca885a6d48f07103de0"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "cbindgen",
  "chrono",
  "compact_jwt",
@@ -2723,7 +2719,7 @@ dependencies = [
  "md5",
  "num_enum",
  "pbkdf2",
- "rand 0.9.4",
+ "rand 0.9.5",
  "serde",
  "serde-binary",
  "sha1",
@@ -2843,18 +2839,12 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
-
-[[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "malloced"
@@ -2864,9 +2854,9 @@ checksum = "6dfebb2f9e0b39509c62eead6ec7ae0c0ed45bb61d12bbcf4e976c566c5400ec"
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -3092,7 +3082,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3144,7 +3134,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3195,7 +3185,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3320,7 +3310,7 @@ dependencies = [
  "opentelemetry 0.32.0",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -3486,11 +3476,11 @@ checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -3550,7 +3540,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3579,7 +3569,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3696,7 +3686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3746,7 +3736,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3810,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3867,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3879,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4117,9 +4107,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4228,9 +4218,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
 dependencies = [
  "cssparser",
  "ego-tree",
@@ -4302,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -4331,9 +4321,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4378,29 +4368,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4417,7 +4407,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4683,6 +4673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4699,7 +4700,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4754,13 +4755,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -4789,7 +4788,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4800,7 +4799,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4815,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4835,9 +4834,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4871,7 +4870,7 @@ checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4900,7 +4899,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4936,13 +4935,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5122,7 +5122,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5316,12 +5316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,9 +5329,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -5447,7 +5441,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5482,7 +5476,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5641,7 +5635,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5652,7 +5646,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5983,7 +5977,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5999,7 +5993,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6081,15 +6075,15 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.16.0"
+version = "5.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6122,14 +6116,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.16.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6137,13 +6131,22 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.2",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6163,7 +6166,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6183,7 +6186,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -6205,7 +6208,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6238,7 +6241,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6249,40 +6252,41 @@ checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zvariant"
-version = "5.12.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.2",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.12.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.4.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 3.0.3",
  "winnow 1.0.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aad-tool"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "serde_json",
  "zbus",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-fuzz"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "arbitrary",
  "himmelblau_unix_common",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "bindgen",
  "cc",
@@ -3033,7 +3033,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "himmelblau_unix_common",
  "lazy_static",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "o365"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "anyhow",
  "reqwest 0.12.24",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "2.3.14"
+version = "2.3.15"
 
 [[package]]
 name = "quinn"
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "2.3.14"
+version = "2.3.15"
 
 [[package]]
 name = "semver"
@@ -4605,11 +4605,11 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "2.3.14"
+version = "2.3.15"
 
 [[package]]
 name = "sso"
-version = "2.3.14"
+version = "2.3.15"
 dependencies = [
  "broker-client",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { version = "^1.50.0", features = ["rt", "macros", "sync", "time", "net"
 tokio-util = { version = "^0.7.18", features = ["codec"] }
 async-trait = "^0.1.89"
 himmelblau_policies = { path = "src/policies" }
-pem = "^3.0.6"
+pem = "^4.0.0"
 chrono = "^0.4.44"
 os-release = "^0.1.0"
 jsonwebtoken = "^9.2.0"
@@ -72,7 +72,7 @@ libkrimes = { version = "0.1.0", features = ["keyring"] }
 # Kanidm deps
 argon2 = { version = "0.5.2", features = ["alloc"] }
 base32 = "^0.5.0"
-base64 = "^0.22.0"
+base64 = "^0.23.1"
 base64urlsafedata = "0.5.5"
 hex = "^0.4.3"
 num_enum = "^0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ quinn-0-11-8 = { package = "quinn", path = "src/overrides/quinn/0.11.8" }
 serde_cbor-0-11-2 = { package = "serde_cbor", path = "src/serde_cbor" }
 
 [workspace.package]
-version = "2.3.14"
+version = "2.3.15"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ check-licenses: ## Validate dependant licenses comply with GPLv3
 	cargo deny --all-features check licenses
 
 vet: ## Interactive dependency review with AI analysis
-	cargo vet -V >/dev/null || (echo "cargo-vet required" && cargo install cargo-vet)
-	cargo vet regenerate imports
-	@python3 scripts/cargo_vet_review.py --ai-provider claude
+	/usr/bin/cargo vet -V >/dev/null || (echo "cargo-vet required" && cargo install cargo-vet)
+	/usr/bin/cargo vet regenerate imports
+	@python3 scripts/cargo_vet_review.py
 
 sbom: .packaging ## Generate a Software Bill of Materials
 	cargo sbom -V >/dev/null || (echo "cargo-sbom required" && cargo install cargo-sbom)

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Setup PAM
     auth        required      pam_deny.so
 
     # vim /etc/pam.d/common-account
-    account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+    account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
     account    sufficient    pam_unix.so
     account    required      pam_deny.so
 

--- a/man/man8/pam_himmelblau.8
+++ b/man/man8/pam_himmelblau.8
@@ -92,7 +92,7 @@ auth        required      pam_deny.so
 Configure \f[CR]/etc/pam.d/common\-account\f[R] in a similar manner.
 .IP
 .EX
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 .EE

--- a/man/pam_himmelblau.md
+++ b/man/pam_himmelblau.md
@@ -68,7 +68,7 @@ auth        required      pam_deny.so
 Configure `/etc/pam.d/common-account` in a similar manner.
 
 ```pam
-account    [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
+account    [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user
 account    sufficient    pam_unix.so
 account    required      pam_deny.so
 ```

--- a/platform/debian/pam-config
+++ b/platform/debian/pam-config
@@ -6,7 +6,7 @@ Auth:
 	[success=end default=ignore]    pam_himmelblau.so ignore_unknown_user
 Account-Type: Primary
 Account:
-	[success=end auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
+	[success=ok auth_err=die default=ignore]    pam_himmelblau.so ignore_unknown_user
 Password-Type: Primary
 Password:
 	[success=end ignore=ignore default=die]    pam_himmelblau.so ignore_unknown_user

--- a/platform/opensuse/pam-config
+++ b/platform/opensuse/pam-config
@@ -5,7 +5,7 @@ Auth: auth     sufficient    pam_himmelblau.so    ignore_unknown_user
 Auth-Priority: 800
 
 # Account stack
-Account: account        [success=end auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
+Account: account        [success=ok auth_err=die default=ignore]      pam_himmelblau.so    ignore_unknown_user
 Account-Priority: 300
 
 # Password stack

--- a/scripts/authselect_README
+++ b/scripts/authselect_README
@@ -15,7 +15,7 @@ PAM (both system-auth and password-auth):
 - Adds at the top of each stack:
     `auth     sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:
-    `account  [success=end auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
+    `account  [success=ok auth_err=die default=ignore] pam_himmelblau.so ignore_unknown_user`
 - Adds:
     `password sufficient   pam_himmelblau.so ignore_unknown_user`
 - Adds:

--- a/scripts/cargo_vet_review.py
+++ b/scripts/cargo_vet_review.py
@@ -4,13 +4,13 @@ Cargo Vet Review Assistant
 
 Automates the cargo vet workflow by:
 1. Parsing `cargo vet` output to identify unvetted dependencies
-2. Fetching diffs from diff.rs or using local mode
+2. Fetching published crate sources and generating local diffs
 3. Analyzing changes for security concerns (pattern matching + AI)
 4. Providing educated suggestions about safety
 5. Facilitating the certification process
 
 Usage:
-  python scripts/cargo_vet_review.py [--ai-provider gemini|claude] [--no-ai]
+  python scripts/cargo_vet_review.py [--ai-provider codex|gemini|claude] [--no-ai]
 """
 
 import argparse
@@ -20,14 +20,16 @@ import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import urllib.request
-import urllib.error
 from dataclasses import dataclass, field
 from enum import Enum
-from html.parser import HTMLParser
 from pathlib import Path
 from typing import Optional
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class RiskLevel(Enum):
@@ -61,34 +63,16 @@ class DiffAnalysis:
     recommendation: str = ""
     risk_score: RiskLevel = RiskLevel.LOW
     trust_suggestion: Optional[str] = None
-    claude_analysis: Optional[str] = None  # AI-powered analysis
+    ai_analysis: Optional[str] = None  # AI-powered analysis
 
 
-class DiffRsParser(HTMLParser):
-    """Parse diff.rs HTML to extract the actual diff content."""
-    def __init__(self):
-        super().__init__()
-        self.in_code = False
-        self.in_pre = False
-        self.diff_content = []
-        self.current_file = ""
-
-    def handle_starttag(self, tag, attrs):
-        attrs_dict = dict(attrs)
-        if tag == "pre":
-            self.in_pre = True
-        elif tag == "code" and self.in_pre:
-            self.in_code = True
-
-    def handle_endtag(self, tag):
-        if tag == "code":
-            self.in_code = False
-        elif tag == "pre":
-            self.in_pre = False
-
-    def handle_data(self, data):
-        if self.in_code:
-            self.diff_content.append(data)
+@dataclass
+class FetchedDiff:
+    """A locally generated crate diff and the source paths used to create it."""
+    diff: str
+    old_source: Optional[Path]
+    new_source: Path
+    cache_hit: bool
 
 
 class SecurityAnalyzer:
@@ -391,13 +375,12 @@ class SecurityAnalyzer:
         if build_findings:
             recommendations.append("Build script changes detected - verify no malicious build-time behavior.")
 
-        # Add diff URL for easy review
+        # Point reviewers at the local diff/source flow used by this script.
         if analysis.old_version:
-            diff_url = f"https://diff.rs/{analysis.crate_name}/{analysis.old_version}/{analysis.new_version}"
-            recommendations.append(f"Review diff: {diff_url}")
+            recommendations.append("Review the locally generated crate package diff before certifying.")
         else:
             crate_url = f"https://crates.io/crates/{analysis.crate_name}/{analysis.new_version}"
-            recommendations.append(f"Review crate: {crate_url}")
+            recommendations.append(f"Review the published crate package and metadata: {crate_url}")
 
         return "\n".join(f"  - {r}" for r in recommendations)
 
@@ -490,180 +473,236 @@ class CargoVetParser:
 
 
 class DiffFetcher:
-    """Fetch diffs from diff.rs or locally via cargo vet."""
+    """Fetch published crate sources and generate local diffs."""
 
-    def fetch_from_diff_rs(self, crate: str, old_ver: str, new_ver: str, verbose: bool = False) -> Optional[str]:
-        """Fetch diff from diff.rs website."""
-        url = f"https://diff.rs/{crate}/{old_ver}/{new_ver}/"
+    def __init__(self, source_cache_dir: Optional[str] = None):
+        if source_cache_dir:
+            base_cache = Path(source_cache_dir).expanduser()
+        else:
+            xdg_cache = os.environ.get("XDG_CACHE_HOME")
+            base_cache = Path(xdg_cache).expanduser() if xdg_cache else Path.home() / ".cache"
+            base_cache = base_cache / "cargo-vet-review"
 
+        self.source_cache_dir = base_cache
+        self.extracted_dir = self.source_cache_dir / "src"
+        self.crate_archive_dir = self.source_cache_dir / "crates"
+
+    def fetch(self, crate: str, old_ver: Optional[str], new_ver: str, verbose: bool = False) -> Optional[FetchedDiff]:
+        """Fetch published crate sources and generate a unified local diff."""
         try:
-            if verbose:
-                print(f"    Debug: Fetching from {url}")
+            new_source, new_cache_hit = self._ensure_source(crate, new_ver, verbose)
+            old_source = None
+            cache_hit = new_cache_hit
 
-            req = urllib.request.Request(url, headers={
-                'User-Agent': 'cargo-vet-review/1.0 (security audit tool)',
-                'Accept': 'text/html',
-            })
-            with urllib.request.urlopen(req, timeout=60) as response:
-                html = response.read().decode('utf-8')
-
-            if verbose:
-                print(f"    Debug: Got {len(html)} bytes of HTML")
-
-            # Parse HTML to extract diff
-            parser = DiffRsParser()
-            parser.feed(html)
-
-            if verbose:
-                print(f"    Debug: Parsed {len(parser.diff_content)} content blocks")
-
-            if parser.diff_content:
-                return '\n'.join(parser.diff_content)
-
-            # If parsing failed, return None to fall back to local mode
-            if verbose:
-                print("    Debug: No content extracted from HTML")
-            return None
-
-        except (urllib.error.URLError, urllib.error.HTTPError) as e:
-            print(f"    Warning: Could not fetch from diff.rs: {e}")
-            return None
-        except Exception as e:
-            print(f"    Warning: Error fetching from diff.rs: {e}")
-            return None
-
-    def fetch_local(self, crate: str, old_ver: Optional[str], new_ver: str, verbose: bool = False) -> Optional[str]:
-        """Fetch diff using cargo vet's local mode."""
-        timeout = 60
-        cmd: list[str] = []
-        try:
             if old_ver:
-                cmd = ["cargo", "vet", "diff", crate, old_ver, new_ver, "--mode=local"]
-                timeout = 60  # Diffs are usually fast
+                old_source, old_cache_hit = self._ensure_source(crate, old_ver, verbose)
+                cache_hit = new_cache_hit and old_cache_hit
+                diff = self._git_diff_no_index(old_source, new_source, old_source, new_source, verbose)
             else:
-                cmd = ["cargo", "vet", "inspect", crate, new_ver, "--mode=local"]
-                timeout = 180  # Full crate downloads can be slow
+                with tempfile.TemporaryDirectory(prefix="cargo-vet-review-empty-") as empty_dir:
+                    empty_source = Path(empty_dir)
+                    diff = self._git_diff_no_index(empty_source, new_source, empty_source, new_source, verbose)
 
-            if verbose:
-                print(f"    Debug: Running command: {' '.join(cmd)}")
-
-            # For inspect (new crate), first check if the cache already exists
-            if not old_ver:
-                cache_dir = Path.home() / ".cache" / "cargo-vet" / "src" / f"{crate}-{new_ver}"
-                if cache_dir.exists():
-                    if verbose:
-                        print(f"    Debug: Cache already exists at {cache_dir}")
-                    return self._generate_inspect_diff(cache_dir, crate, new_ver, verbose)
-
-            # cargo vet inspect/diff --mode=local prompts "(press ENTER to inspect locally)"
-            # and then opens an interactive shell. We need to:
-            # 1. Send ENTER to proceed past the prompt
-            # 2. Immediately send 'exit' to close the nested shell
-            # 3. Read the source files directly from the cache
-            result = subprocess.run(
-                cmd,
-                input="\nexit\n",  # ENTER to proceed, then exit the shell
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=timeout,
+            return FetchedDiff(
+                diff=diff,
+                old_source=old_source,
+                new_source=new_source,
+                cache_hit=cache_hit,
             )
-
+        except Exception as e:
+            print(f"    Warning: Could not generate local crate diff: {e}")
             if verbose:
-                print(f"    Debug: Command returned {result.returncode}")
-                if result.stderr:
-                    print(f"    Debug: stderr: {result.stderr[:200]}")
+                import traceback
+                traceback.print_exc()
+            return None
 
-            # For 'inspect' command, the source is downloaded to ~/.cache/cargo-vet/src/{crate}-{version}/
-            # We need to generate a diff-like output from the source files
-            if not old_ver:
-                cache_dir = Path.home() / ".cache" / "cargo-vet" / "src" / f"{crate}-{new_ver}"
-                if cache_dir.exists():
-                    if verbose:
-                        print(f"    Debug: Reading source from {cache_dir}")
-                    return self._generate_inspect_diff(cache_dir, crate, new_ver, verbose)
-                else:
-                    if verbose:
-                        print(f"    Debug: Cache dir not found: {cache_dir}")
-                    # Fall back to stdout if available
-                    if result.stdout:
-                        return result.stdout
+    def _ensure_source(self, crate: str, version: str, verbose: bool = False) -> tuple[Path, bool]:
+        """Return an extracted source directory for a published crate version."""
+        managed_source = self.extracted_dir / f"{crate}-{version}"
+        if managed_source.exists():
+            if verbose:
+                print(f"    Debug: Using cached extracted source {managed_source}")
+            return managed_source, True
 
-            if result.returncode == 0:
-                return result.stdout
+        cargo_source = self._find_cargo_registry_source(crate, version)
+        if cargo_source:
+            if verbose:
+                print(f"    Debug: Using Cargo registry source {cargo_source}")
+            return cargo_source, True
+
+        archive = self._find_cargo_registry_archive(crate, version)
+        cache_hit = True
+        if archive:
+            if verbose:
+                print(f"    Debug: Using Cargo registry archive {archive}")
+        else:
+            archive = self.crate_archive_dir / f"{crate}-{version}.crate"
+            if archive.exists():
+                if verbose:
+                    print(f"    Debug: Using cached downloaded archive {archive}")
             else:
-                # cargo vet diff sometimes returns non-zero but still produces output
-                if result.stdout:
-                    return result.stdout
-                print(f"    Warning: cargo vet command failed: {result.stderr}")
-                return None
+                archive = self._download_crate(crate, version, verbose)
+                cache_hit = False
 
-        except subprocess.TimeoutExpired:
-            print(f"    Warning: cargo vet command timed out ({timeout}s)")
+        self._extract_crate_archive(archive, managed_source, crate, version, verbose)
+        return managed_source, cache_hit
+
+    def _cargo_home(self) -> Path:
+        return Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo")).expanduser()
+
+    def _find_cargo_registry_source(self, crate: str, version: str) -> Optional[Path]:
+        registry_src = self._cargo_home() / "registry" / "src"
+        if not registry_src.exists():
             return None
-        except FileNotFoundError:
-            print("    Error: cargo-vet not found. Install with: cargo install cargo-vet")
+
+        crate_dir = f"{crate}-{version}"
+        for registry_root in registry_src.iterdir():
+            candidate = registry_root / crate_dir
+            if candidate.is_dir():
+                return candidate
+        return None
+
+    def _find_cargo_registry_archive(self, crate: str, version: str) -> Optional[Path]:
+        registry_cache = self._cargo_home() / "registry" / "cache"
+        if not registry_cache.exists():
             return None
 
-    def _generate_inspect_diff(self, cache_dir: Path, crate: str, version: str, verbose: bool = False) -> str:
-        """Generate a unified diff-like output for a full crate inspection.
+        archive_name = f"{crate}-{version}.crate"
+        for registry_root in registry_cache.iterdir():
+            candidate = registry_root / archive_name
+            if candidate.is_file():
+                return candidate
+        return None
 
-        This creates output similar to what 'git diff' would show, treating all
-        files as new additions. This allows the security analyzer to process
-        the crate source using the same logic as version diffs.
-        """
-        diff_lines = []
+    def _download_crate(self, crate: str, version: str, verbose: bool = False) -> Path:
+        self.crate_archive_dir.mkdir(parents=True, exist_ok=True)
+        archive = self.crate_archive_dir / f"{crate}-{version}.crate"
+        url = f"https://crates.io/api/v1/crates/{crate}/{version}/download"
+        if verbose:
+            print(f"    Debug: Downloading {url}")
 
-        # Find all source files (prioritize important files)
-        important_files = ['Cargo.toml', 'build.rs', 'src/lib.rs', 'src/main.rs']
-        all_files = []
+        req = urllib.request.Request(url, headers={
+            "User-Agent": "cargo-vet-review/1.0 (security audit tool)",
+        })
+        with urllib.request.urlopen(req, timeout=120) as response:
+            data = response.read()
+        archive.write_bytes(data)
+        return archive
 
-        for pattern in ['**/*.rs', '**/*.toml', '**/build.rs']:
-            all_files.extend(cache_dir.glob(pattern))
+    def _extract_crate_archive(
+        self,
+        archive: Path,
+        destination: Path,
+        crate: str,
+        version: str,
+        verbose: bool = False,
+    ) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="cargo-vet-review-extract-") as tmp:
+            tmp_path = Path(tmp)
+            root_name = f"{crate}-{version}"
 
-        # Remove duplicates and sort (important files first)
-        seen = set()
-        sorted_files = []
+            with tarfile.open(archive, "r:gz") as tar:
+                self._safe_extract(tar, tmp_path)
 
-        for important in important_files:
-            full_path = cache_dir / important
-            if full_path.exists() and full_path not in seen:
-                sorted_files.append(full_path)
-                seen.add(full_path)
+            extracted_root = tmp_path / root_name
+            if not extracted_root.is_dir():
+                entries = [p for p in tmp_path.iterdir() if p.is_dir()]
+                if len(entries) == 1:
+                    extracted_root = entries[0]
+                else:
+                    raise RuntimeError(f"archive {archive} did not contain expected root {root_name}")
 
-        for f in sorted(all_files):
-            if f not in seen and f.is_file():
-                sorted_files.append(f)
-                seen.add(f)
+            if destination.exists():
+                shutil.rmtree(destination)
+            shutil.move(str(extracted_root), str(destination))
 
         if verbose:
-            print(f"    Debug: Found {len(sorted_files)} source files")
+            print(f"    Debug: Extracted {archive} to {destination}")
 
-        for file_path in sorted_files:
+    def _safe_extract(self, tar: tarfile.TarFile, destination: Path) -> None:
+        destination = destination.resolve()
+        for member in tar.getmembers():
+            member_path = destination / member.name
             try:
-                rel_path = file_path.relative_to(cache_dir)
-                content = file_path.read_text(encoding='utf-8', errors='replace')
-                lines = content.split('\n')
+                member_path.resolve().relative_to(destination)
+            except ValueError as e:
+                raise RuntimeError(f"unsafe path in crate archive: {member.name}") from e
+        try:
+            tar.extractall(destination, filter="data")
+        except TypeError:
+            tar.extractall(destination)
 
-                # Generate unified diff header (treating as new file)
-                diff_lines.append(f"diff --git a/{rel_path} b/{rel_path}")
-                diff_lines.append(f"new file mode 100644")
-                diff_lines.append(f"--- /dev/null")
-                diff_lines.append(f"+++ b/{rel_path}")
-                diff_lines.append(f"@@ -0,0 +1,{len(lines)} @@")
+    def _git_diff_no_index(
+        self,
+        old_source: Path,
+        new_source: Path,
+        old_display_root: Path,
+        new_display_root: Path,
+        verbose: bool = False,
+    ) -> str:
+        cmd = [
+            "git",
+            "diff",
+            "--no-index",
+            "--no-ext-diff",
+            "--",
+            str(old_source),
+            str(new_source),
+        ]
+        if verbose:
+            print(f"    Debug: Running command: {' '.join(cmd)}")
 
-                # Add all lines as additions
-                for line in lines:
-                    diff_lines.append(f"+{line}")
-                diff_lines.append("")  # Empty line between files
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+        )
 
-            except Exception as e:
-                if verbose:
-                    print(f"    Debug: Could not read {file_path}: {e}")
+        if result.returncode not in (0, 1):
+            raise RuntimeError(result.stderr.strip() or f"git diff failed with code {result.returncode}")
+
+        return self._normalize_diff_paths(result.stdout, old_display_root, new_display_root)
+
+    def _normalize_diff_paths(self, diff: str, old_root: Path, new_root: Path) -> str:
+        old_root_str = str(old_root)
+        new_root_str = str(new_root)
+        normalized = []
+
+        for line in diff.splitlines():
+            if line.startswith("diff --git "):
+                match = re.match(r"diff --git a/(.+) b/(.+)$", line)
+                if match:
+                    old_rel = self._relative_diff_path(match.group(1), old_root_str, new_root_str)
+                    new_rel = self._relative_diff_path(match.group(2), new_root_str, old_root_str)
+                    normalized.append(f"diff --git a/{old_rel} b/{new_rel}")
+                    continue
+            elif line.startswith("--- a/"):
+                normalized.append(f"--- a/{self._relative_diff_path(line[6:], old_root_str, new_root_str)}")
+                continue
+            elif line.startswith("+++ b/"):
+                normalized.append(f"+++ b/{self._relative_diff_path(line[6:], new_root_str, old_root_str)}")
                 continue
 
-        return '\n'.join(diff_lines)
+            normalized.append(line)
+
+        return "\n".join(normalized)
+
+    def _relative_diff_path(self, path: str, *roots: str) -> str:
+        for root in roots:
+            candidates = {root.rstrip("/"), root.lstrip("/").rstrip("/")}
+            for candidate in candidates:
+                if not candidate:
+                    continue
+                if path == candidate:
+                    return Path(path).name
+                root_prefix = candidate + "/"
+                if path.startswith(root_prefix):
+                    return path[len(root_prefix):]
+        return path
 
 
 class AIAnalyzer:
@@ -854,6 +893,31 @@ Keep your response focused and actionable.
                 if result.returncode == 0 and result.stdout and len(result.stdout.strip()) > 10:
                     return result.stdout.strip()
 
+            elif self.provider == 'codex':
+                with tempfile.NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as output:
+                    output_file = output.name
+
+                try:
+                    result = subprocess.run(
+                        [
+                            self.cli_path,
+                            "exec",
+                            "--cd", str(PROJECT_ROOT),
+                            "--sandbox", "read-only",
+                            "--dangerously-bypass-approvals-and-sandbox",
+                            "--output-last-message", output_file,
+                            "-",
+                        ],
+                        input=prompt, capture_output=True, text=True, timeout=180,
+                    )
+                    if result.returncode == 0:
+                        with open(output_file, "r", encoding="utf-8") as f:
+                            output_text = f.read().strip()
+                        if len(output_text) > 10:
+                            return output_text
+                finally:
+                    if os.path.exists(output_file):
+                        os.unlink(output_file)
 
             # If all methods failed, print debug info
             print(f"    Warning: All {self.provider} invocation methods failed")
@@ -890,30 +954,6 @@ def print_color(text: str, color: str):
         'bold': '\033[1m',
     }
     print(f"{colors.get(color, '')}{text}{colors['reset']}")
-
-
-def generate_diff_url(crate_name: str, old_version: Optional[str], new_version: str) -> str:
-    """Generate a diff.rs URL for reviewing changes.
-
-    Note: File-specific URLs don't work reliably because browsers decode %2F
-    in the URL bar, which breaks diff.rs links. So we only generate base URLs.
-
-    For full crate reviews (no old_version), we use the same version twice
-    which shows the entire crate as "new" code on diff.rs.
-
-    Args:
-        crate_name: Name of the crate
-        old_version: Previous version (None for full crate review)
-        new_version: New version being reviewed
-
-    Returns:
-        URL to diff.rs for reviewing
-    """
-    if old_version:
-        return f"https://diff.rs/{crate_name}/{old_version}/{new_version}"
-    else:
-        # For full crate review, use same version twice to show all code as "new"
-        return f"https://diff.rs/{crate_name}/{new_version}/{new_version}"
 
 
 def print_finding(finding: SecurityFinding):
@@ -986,8 +1026,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s                    # Interactive review with Gemini AI analysis
+  %(prog)s                    # Interactive review with Codex AI analysis
   %(prog)s --ai-provider claude # Use Claude AI instead
+  %(prog)s --ai-provider gemini # Use Gemini AI instead
   %(prog)s --no-ai            # Review without AI (pattern matching only)
   %(prog)s --skip-large 5000  # Skip diffs larger than 5000 lines
   %(prog)s --dry-run          # Analyze without certifying
@@ -1019,20 +1060,26 @@ Examples:
     parser.add_argument(
         "--ai-provider",
         type=str,
-        default="gemini",
-        choices=["gemini", "claude"],
-        help="The AI provider to use for analysis (default: gemini)",
+        default="codex",
+        choices=["codex", "gemini", "claude"],
+        help="The AI provider to use for analysis (default: codex)",
     )
     parser.add_argument(
         "--ai-provider-path",
         type=str,
         default=None,
-        help="Path to the AI provider's CLI binary (e.g., /path/to/gemini)",
+        help="Path to the AI provider's CLI binary (e.g., /path/to/codex)",
     )
     parser.add_argument(
         "--no-ai",
         action="store_true",
         help="Disable AI analysis (use pattern matching only)",
+    )
+    parser.add_argument(
+        "--source-cache-dir",
+        type=str,
+        default=None,
+        help="Directory for downloaded/extracted crate sources (default: XDG cache)",
     )
     parser.add_argument(
         "--verbose", "-v",
@@ -1085,7 +1132,7 @@ Examples:
     ai_analyzer = None
     if not args.no_ai:
         ai_analyzer = AIAnalyzer(provider=args.ai_provider, path=args.ai_provider_path)
-    fetcher = DiffFetcher()
+    fetcher = DiffFetcher(source_cache_dir=args.source_cache_dir)
     analyses = []
 
     # Check AI availability
@@ -1114,10 +1161,6 @@ Examples:
         print(f"    Size: {item.audit_size}")
         print(f"    Type: {review_type}")
 
-        # Show diff URL prominently
-        diff_url = generate_diff_url(item.crate_name, item.old_version, item.new_version)
-        print_color(f"    Review: {diff_url}", "cyan")
-
         if item.trust_note:
             print_color(f"    Trust suggestion: cargo vet trust {item.crate_name} {item.trust_note}", "cyan")
         print()
@@ -1131,15 +1174,17 @@ Examples:
             print(f"    Consider: cargo vet trust {item.crate_name} {item.trust_note or item.publisher}")
             continue
 
-        # Fetch diff using cargo vet (gets ALL files, unlike diff.rs which only shows one)
-        print("    Fetching source changes...")
-        diff_content = fetcher.fetch_local(
+        print("    Fetching published crate sources and generating local diff...")
+        fetched_diff = fetcher.fetch(
             item.crate_name, item.old_version, item.new_version, verbose=args.verbose
         )
 
-        if not diff_content:
+        if not fetched_diff or not fetched_diff.diff:
             print_color("    Could not fetch source content", "red")
             continue
+
+        diff_content = fetched_diff.diff
+        print_color(f"    Source: {fetched_diff.new_source}", "cyan")
 
         # Pattern-based analysis
         print("    Running pattern-based security analysis...")
@@ -1171,7 +1216,7 @@ Examples:
                 is_full_crate=is_full_crate,
                 verbose=args.verbose,
             )
-            analysis.claude_analysis = ai_result
+            analysis.ai_analysis = ai_result
 
         analyses.append(analysis)
 
@@ -1203,14 +1248,14 @@ Examples:
             print_color("    No pattern-based concerns found in added code.", "green")
 
         # AI analysis output
-        if analysis.claude_analysis:
+        if analysis.ai_analysis:
             print()
             print_color("-" * 50, "magenta")
             print_color("AI ANALYSIS", "bold")
             print_color("-" * 50, "magenta")
             print()
             # Indent the response
-            for line in analysis.claude_analysis.split('\n'):
+            for line in analysis.ai_analysis.split('\n'):
                 print(f"    {line}")
             print()
 
@@ -1228,12 +1273,12 @@ Examples:
             print("      [c] Certify this crate")
             print("      [v] View full diff in pager (less)")
             print("      [d] View diff inline (first 200 lines)")
-            print("      [u] Show diff.rs URL")
+            print("      [p] Show local source paths")
             if item.trust_note:
                 print(f"      [t] Trust publisher '{item.trust_note}'")
             if use_ai:
                 print("      [a] Re-run AI analysis")
-            if analysis.claude_analysis:
+            if analysis.ai_analysis:
                 print("      [r] Re-display AI analysis")
             print("      [s] Skip to next crate")
             print("      [q] Quit")
@@ -1275,13 +1320,12 @@ Examples:
                     if len(diff_content.split('\n')) > 200:
                         print_color(f"\n    ... [{len(diff_content.split(chr(10))) - 200} more lines, use 'v' to view all]", "yellow")
                     print()
-                elif choice == 'u':
-                    # Show URL for manual access
-                    if item.old_version:
-                        url = f"https://diff.rs/{item.crate_name}/{item.old_version}/{item.new_version}/"
-                    else:
-                        url = f"https://crates.io/crates/{item.crate_name}/{item.new_version}"
-                    print(f"\n    URL: {url}\n")
+                elif choice == 'p':
+                    print()
+                    if fetched_diff.old_source:
+                        print(f"    Old source: {fetched_diff.old_source}")
+                    print(f"    New source: {fetched_diff.new_source}")
+                    print()
                 elif choice == 't' and item.trust_note:
                     subprocess.run(["cargo", "vet", "trust", item.crate_name, item.trust_note])
                     break
@@ -1297,7 +1341,7 @@ Examples:
                         verbose=True,  # Always verbose on re-run for debugging
                     )
                     if ai_result:
-                        analysis.claude_analysis = ai_result
+                        analysis.ai_analysis = ai_result
                         print()
                         print_color("-" * 50, "magenta")
                         print_color("AI ANALYSIS (refreshed)", "bold")
@@ -1308,13 +1352,13 @@ Examples:
                         print()
                     else:
                         print_color("    AI analysis failed", "red")
-                elif choice == 'r' and analysis.claude_analysis:
+                elif choice == 'r' and analysis.ai_analysis:
                     print()
                     print_color("-" * 50, "magenta")
                     print_color("AI ANALYSIS", "bold")
                     print_color("-" * 50, "magenta")
                     print()
-                    for line in analysis.claude_analysis.split('\n'):
+                    for line in analysis.ai_analysis.split('\n'):
                         print(f"    {line}")
                     print()
                 elif choice == 's':
@@ -1346,7 +1390,8 @@ Examples:
                     for f in a.findings
                 ],
                 "recommendation": a.recommendation,
-                "claude_analysis": a.claude_analysis,
+                "ai_analysis": a.ai_analysis,
+                "claude_analysis": a.ai_analysis,
             })
         print(json.dumps(output, indent=2))
 
@@ -1360,7 +1405,7 @@ Examples:
     print(f"  Skipped: {len(items) - len(analyses)} crates (too large or fetch failed)")
 
     if use_ai:
-        ai_analyzed = sum(1 for a in analyses if a.claude_analysis)
+        ai_analyzed = sum(1 for a in analyses if a.ai_analysis)
         print(f"  AI-analyzed: {ai_analyzed} crates")
 
     # Count full crate reviews vs diffs

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1552,7 +1552,13 @@ async fn main() -> ExitCode {
             };
 
             // Map the name
-            let account_id = cfg.map_name_to_upn(&account_id);
+            let account_id = match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => {
+                    error!("'{}' is not a valid directory user", account_id);
+                    return ExitCode::FAILURE;
+                }
+            };
 
             let opts = Options::default();
             let msg_printer = Arc::new(SimpleMessagePrinter::default());

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -310,7 +310,7 @@ fn configure_pam(
     for account_file in &account_files {
         insert_module_line(
             account_file,
-            "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
+            "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user",
             None,
             Some(&|l: &str| {
                 (l.contains("pam_unix.so") && l.contains("account"))
@@ -2259,7 +2259,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const ACCOUNT_LINE: &str =
-        "account\t[success=end auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
+        "account\t[success=ok auth_err=die default=ignore]\tpam_himmelblau.so ignore_unknown_user";
 
     fn temp_pam_file(name: &str, content: &str) -> anyhow::Result<PathBuf> {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
@@ -2336,7 +2336,7 @@ mod tests {
     #[test]
     fn skips_already_correct_account_line() -> anyhow::Result<()> {
         let existing = concat!(
-            "account   [success=end auth_err=die default=ignore]   ",
+            "account   [success=ok auth_err=die default=ignore]   ",
             "pam_himmelblau.so   ignore_unknown_user\n",
             "account required pam_unix.so\n"
         );
@@ -2353,6 +2353,34 @@ mod tests {
 
         let content = read_to_string(&path)?;
         assert_eq!(content, existing);
+        remove_temp_file(&path)
+    }
+
+    #[test]
+    fn replaces_success_end_account_line() -> anyhow::Result<()> {
+        let path = temp_pam_file(
+            "success-end",
+            concat!(
+                "account [success=end auth_err=die default=ignore] ",
+                "pam_himmelblau.so ignore_unknown_user\n",
+                "account required pam_unix.so\n"
+            ),
+        )?;
+
+        insert_module_line(
+            path.to_str().unwrap_or_default(),
+            ACCOUNT_LINE,
+            None,
+            None,
+            true,
+            false,
+        )?;
+
+        let content = read_to_string(&path)?;
+        assert_eq!(
+            content,
+            format!("{}\naccount required pam_unix.so\n", ACCOUNT_LINE)
+        );
         remove_temp_file(&path)
     }
 

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -33,7 +33,8 @@ use crate::constants::{
     DEFAULT_JOIN_TYPE, DEFAULT_ODC_PROVIDER, DEFAULT_OFFLINE_BREAKGLASS_TTL,
     DEFAULT_POLICIES_DB_DIR, DEFAULT_SELINUX, DEFAULT_SFA_FALLBACK_ENABLED, DEFAULT_SHELL,
     DEFAULT_SOCK_PATH, DEFAULT_TASK_SOCK_PATH, DEFAULT_TPM_TCTI_NAME, DEFAULT_USER_MAP_FILE,
-    DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE, SERVER_CONFIG_PATH,
+    DEFAULT_USE_ETC_SKEL, MAPPED_NAME_CACHE, NSS_IGNORE_EXACT, NSS_IGNORE_PREFIX,
+    SERVER_CONFIG_PATH,
 };
 use crate::mapping::{MappedNameCache, Mode};
 use crate::unix_config::{HomeAttr, HsmType};
@@ -820,17 +821,26 @@ impl HimmelblauConfig {
         self.config.get("global", "name_mapping_script")
     }
 
-    /// This function attempts to convert a username to a valid UPN. On failure it
-    /// will leave the name as-is, and respond with the original input. Himmelblau
-    /// will reject the authentication attempt if the username isn't a valid UPN.
-    pub fn map_name_to_upn(&self, account_id: &str) -> String {
+    /// Convert a login name to a UPN, or `None` if it cannot be a directory user
+    /// (empty, or a known local-only name). Callers treat `None` as user-unknown
+    /// and must not look it up against Entra. See himmelblau-idm/himmelblau#1392.
+    pub fn map_name_to_upn(&self, account_id: &str) -> Option<String> {
+        self.map_name_to_upn_impl(account_id, "/etc/passwd")
+    }
+
+    /// Inner impl with an injectable passwd path for hermetic unit tests.
+    fn map_name_to_upn_impl(&self, account_id: &str, passwd_path: &str) -> Option<String> {
         let name_mapping_script = self.get_name_mapping_script();
         let cn_name_mapping = self.get_cn_name_mapping();
         let domains = self.get_configured_domains();
 
+        if account_id.trim().is_empty() {
+            return None;
+        }
+
         // Make sure this account_id isn't a local user
         let mut contents = vec![];
-        if let Ok(mut file) = File::open("/etc/passwd") {
+        if let Ok(mut file) = File::open(passwd_path) {
             let _ = file.read_to_end(&mut contents);
         }
         let local_users = parse_etc_passwd(contents.as_slice()).unwrap_or_default();
@@ -840,11 +850,19 @@ impl HimmelblauConfig {
             .collect::<Vec<String>>()
             .contains(&account_id.to_string())
         {
-            return account_id.to_string();
+            return Some(account_id.to_string());
         }
 
-        // The name mapping script is expected to convert the input name to a UPN
-        // if a name is supplied, or to a name if the UPN is supplied.
+        // Local-only names probed by systemd/GDM at boot; never directory users.
+        if NSS_IGNORE_EXACT.contains(&account_id)
+            || NSS_IGNORE_PREFIX
+                .iter()
+                .any(|prefix| account_id.starts_with(prefix))
+        {
+            return None;
+        }
+
+        // Empty script output signals "not a directory user" -> None.
         if !account_id.contains('@') {
             if let Some(name_mapping_script) = &name_mapping_script {
                 let name_cache = MappedNameCache::new(MAPPED_NAME_CACHE, &Mode::ReadWrite).ok();
@@ -855,11 +873,14 @@ impl HimmelblauConfig {
                     Ok(output) => {
                         if output.status.success() {
                             let upn = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                            if upn.is_empty() {
+                                return None;
+                            }
                             if let Some(name_cache) = &name_cache {
                                 // Failing to insert a name map is not a critical failure.
                                 let _ = name_cache.insert_mapping(&upn, account_id);
                             }
-                            return upn;
+                            return Some(upn);
                         } else {
                             error!("Script execution failed with error: {:?}", output.status);
                         }
@@ -881,9 +902,9 @@ impl HimmelblauConfig {
             }
         }
         if cn_name_mapping && !account_id.contains('@') && !domains.is_empty() {
-            return format!("{}@{}", account_id, domains[0]);
+            return Some(format!("{}@{}", account_id, domains[0]));
         }
-        account_id.to_string()
+        Some(account_id.to_string())
     }
 
     /// This function maps a UPN to a mapped name. If a mapping script is
@@ -973,6 +994,13 @@ mod tests {
     fn create_temp_config(contents: &str) -> String {
         let file_path = format!("/tmp/himmelblau_test_config_{}.ini", uuid::Uuid::new_v4());
         fs::write(&file_path, contents).expect("Failed to write temporary config file");
+        file_path
+    }
+
+    // Throwaway passwd file so map_name_to_upn_impl can be tested hermetically.
+    fn create_temp_passwd(contents: &str) -> String {
+        let file_path = format!("/tmp/himmelblau_test_passwd_{}", uuid::Uuid::new_v4());
+        fs::write(&file_path, contents).expect("Failed to write temporary passwd file");
         file_path
     }
 
@@ -1744,74 +1772,153 @@ mod tests {
         assert_eq!(config_missing.get_name_mapping_script(), None);
     }
 
+    const PASSWD_MINIMAL: &str = "root:x:0:0:root:/root:/bin/bash\n";
+
     #[test]
     fn test_map_name_to_upn_script_execution_success() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
         name_mapping_script = ../../scripts/test_script_echo.sh
         domains = example.com
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-        let expected_output = "user";
-
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
         assert_eq!(
-            config.map_name_to_upn(account_id),
-            expected_output.to_string()
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user".to_string())
         );
     }
 
     #[test]
     fn test_map_name_to_upn_local_user() {
-        // Simulate a local user in /etc/passwd
-        let account_id = "localuser";
-
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
-        "#;
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(&format!(
+            "{}localuser:x:1000:1000::/home/localuser:/bin/bash\n",
+            PASSWD_MINIMAL
+        ));
+        assert_eq!(
+            config.map_name_to_upn_impl("localuser", &passwd),
+            Some("localuser".to_string())
+        );
+    }
 
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        // Simulating presence of local user
-        assert_eq!(config.map_name_to_upn(account_id), account_id.to_string());
+    #[test]
+    fn test_map_name_to_upn_local_user_wins_over_ignore_list() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(&format!(
+            "{}systemd-coredump:x:999:999::/run/systemd:/usr/sbin/nologin\n",
+            PASSWD_MINIMAL
+        ));
+        assert_eq!(
+            config.map_name_to_upn_impl("systemd-coredump", &passwd),
+            Some("systemd-coredump".to_string())
+        );
     }
 
     #[test]
     fn test_map_name_to_upn_add_domain() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
         cn_to_upn_mapping = true
         domains = example.com
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-        let expected_output = "user@example.com";
-
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
         assert_eq!(
-            config.map_name_to_upn(account_id),
-            expected_output.to_string()
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_map_name_to_upn_empty_is_none() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(config.map_name_to_upn_impl("", &passwd), None);
+        assert_eq!(config.map_name_to_upn_impl("   ", &passwd), None);
+    }
+
+    #[test]
+    fn test_map_name_to_upn_ignored_names_are_none() {
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        for name in [
+            "gdm",
+            "sssd",
+            "systemd-coredump",
+            "gnome-initial-setup",
+            "gdm-greeter",
+            "gdm-greeter-2",
+            "gdm-greeter-9",
+            "pam_unix_non_existent",
+            "pam_unix_non_existent:",
+        ] {
+            assert_eq!(
+                config.map_name_to_upn_impl(name, &passwd),
+                None,
+                "{name} should be None"
+            );
+        }
+    }
+
+    #[test]
+    fn test_map_name_to_upn_prefix_does_not_overmatch() {
+        // A real user whose name merely starts with "gdm" must NOT be ignored.
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
+        [global]
+        domains = example.com
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(
+            config.map_name_to_upn_impl("gdmitrij.popov", &passwd),
+            Some("gdmitrij.popov@example.com".to_string())
         );
     }
 
     #[test]
     fn test_map_name_to_upn_no_mapping() {
-        let config_data = r#"
+        let config = HimmelblauConfig::new(Some(&create_temp_config(
+            r#"
         [global]
-        "#;
-
-        let temp_file = create_temp_config(config_data);
-        let config = HimmelblauConfig::new(Some(&temp_file)).unwrap();
-
-        let account_id = "user";
-
-        assert_eq!(config.map_name_to_upn(account_id), account_id.to_string());
+        "#,
+        )))
+        .unwrap();
+        let passwd = create_temp_passwd(PASSWD_MINIMAL);
+        assert_eq!(
+            config.map_name_to_upn_impl("user", &passwd),
+            Some("user".to_string())
+        );
     }
 
     #[test]

--- a/src/common/src/constants.rs
+++ b/src/common/src/constants.rs
@@ -51,6 +51,10 @@ pub const DEFAULT_ID_ATTR_MAP: IdAttr = IdAttr::Name;
 pub const BROKER_APP_ID: &str = "29d9ed98-a469-4536-ade2-f981bc1d605e";
 pub const BROKER_CLIENT_IDENT: &str = "38aa3b87-a06d-4817-b275-7a316988d93b";
 pub const CN_NAME_MAPPING: bool = true;
+// Local-only names that must never be mapped to a UPN / looked up in Entra.
+// See himmelblau-idm/himmelblau#1392.
+pub const NSS_IGNORE_EXACT: &[&str] = &["gdm", "sssd", "systemd-coredump", "gnome-initial-setup"];
+pub const NSS_IGNORE_PREFIX: &[&str] = &["gdm-greeter", "pam_unix_non_existent"]; // variable suffix
 pub const DEFAULT_HELLO_PIN_MIN_LEN: usize = 6;
 pub const DEFAULT_HELLO_PIN_RETRY_COUNT: u32 = 3;
 pub const DEFAULT_KERBEROS_CONF_DIR: &str = "/etc/krb5.conf.d/";

--- a/src/nss/src/implementation.rs
+++ b/src/nss/src/implementation.rs
@@ -216,7 +216,10 @@ impl PasswdHooks for HimmelblauPasswd {
             (name.to_lowercase(), Some(local))
         } else {
             // No mapping - use standard cn_name_mapping
-            (cfg.map_name_to_upn(&name), None)
+            match cfg.map_name_to_upn(&name) {
+                Some(upn) => (upn, None),
+                None => return Response::NotFound,
+            }
         };
 
         let req = ClientRequest::NssAccountByName(upn.clone());
@@ -368,7 +371,10 @@ impl GroupHooks for HimmelblauGroup {
         if is_local_group(&cfg.map_upn_to_name(&name)) {
             return Response::NotFound;
         }
-        let upn = cfg.map_name_to_upn(&name);
+        let upn = match cfg.map_name_to_upn(&name) {
+            Some(upn) => upn,
+            None => return Response::NotFound,
+        };
         let mut daemon_client = match DaemonClientBlocking::new(cfg.get_socket_path().as_str()) {
             Ok(dc) => dc,
             Err(_) => {
@@ -611,7 +617,10 @@ impl ShadowHooks for HimmelblauShadow {
             (name.to_lowercase(), Some(local))
         } else {
             // No mapping - use standard cn_name_mapping
-            (cfg.map_name_to_upn(&name), None)
+            match cfg.map_name_to_upn(&name) {
+                Some(upn) => (upn, None),
+                None => return Response::NotFound,
+            }
         };
 
         let req = ClientRequest::NssAccountByName(upn.clone());

--- a/src/pam/Cargo.toml
+++ b/src/pam/Cargo.toml
@@ -81,7 +81,7 @@ fix_pam_config_account_line() {
     # Make explicit himmelblau account denials terminal while preserving
     # PAM_IGNORE fall-through for local users.
     sed -i -E \
-        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=end auth_err=die default=ignore]\3#' \
+        's#^([[:space:]]*account[[:space:]]+)(required|sufficient)([[:space:]]+pam_himmelblau\.so([[:space:]]+|$).*ignore_unknown_user)#\1[success=ok auth_err=die default=ignore]\3#' \
         "$plain" || return 1
 
     return 0

--- a/src/pam/src/pam/mod.rs
+++ b/src/pam/src/pam/mod.rs
@@ -184,7 +184,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
         let req = ClientRequest::PamAccountAllowed(account_id);
         // PamResultCode::PAM_IGNORE
@@ -267,7 +270,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         let authtok = match pamh.get_authtok() {
@@ -332,7 +338,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         // Local user (no UPN): not a Himmelblau/Entra account. Return PAM_IGNORE
@@ -755,7 +764,10 @@ impl PamHooks for PamKanidm {
         let user_map = UserMap::new(&cfg.get_user_map_file());
         let account_id = match user_map.get_upn_from_local(&account_id) {
             Some(account_id) => account_id,
-            None => cfg.map_name_to_upn(&account_id),
+            None => match cfg.map_name_to_upn(&account_id) {
+                Some(upn) => upn,
+                None => return PamResultCode::PAM_IGNORE,
+            },
         };
 
         let req = ClientRequest::PamAccountBeginSession(account_id);

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -299,6 +299,46 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.2.0"
 
+[[audits.futures-channel]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-executor]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-macro]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-task]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
+[[audits.futures-util]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.33 -> 0.3.34"
+
 [[audits.gethostname]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -488,6 +528,11 @@ delta = "0.12.2 -> 0.13.0-rc.1"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "3.0.6"
+
+[[audits.pem]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.0.6 -> 4.0.0"
 
 [[audits.picky-asn1-x509]]
 who = "David Mulder <dmulder@samba.org>"
@@ -759,10 +804,20 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "5.13.2"
 
+[[audits.zbus_macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.18.0 -> 5.19.0"
+
 [[audits.zbus_names]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "4.3.1"
+
+[[audits.zcheapstr]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
 
 [[audits.zeroize]]
 who = "David Mulder <dmulder@samba.org>"
@@ -784,6 +839,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "5.9.2"
 
+[[audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.13.1 -> 5.14.0"
+
 [[audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -794,10 +854,20 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "5.9.2"
 
+[[audits.zvariant_derive]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.13.1 -> 5.14.0"
+
 [[audits.zvariant_utils]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "3.3.0"
+
+[[audits.zvariant_utils]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.5.0 -> 4.0.0"
 
 [[trusted.aho-corasick]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -274,10 +274,6 @@ criteria = "safe-to-deploy"
 version = "4.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.futf]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.futures-lite]]
 version = "2.6.0"
 criteria = "safe-to-deploy"
@@ -396,10 +392,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.libudev-sys]]
 version = "0.1.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.mac]]
-version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.malloced]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -44,8 +44,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.anyhow]]
-version = "1.0.103"
-when = "2026-06-25"
+version = "1.0.104"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -58,8 +58,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.async-trait]]
-version = "0.1.89"
-when = "2025-08-14"
+version = "0.1.92"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -86,8 +86,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.bytes]]
-version = "1.12.0"
-when = "2026-06-18"
+version = "1.12.1"
+when = "2026-07-08"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -100,29 +100,29 @@ user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
 [[publisher.clap]]
-version = "4.6.1"
-when = "2026-04-15"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_builder]]
-version = "4.6.0"
-when = "2026-03-12"
+version = "4.6.6"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_complete]]
-version = "4.6.6"
-when = "2026-06-30"
+version = "4.6.9"
+when = "2026-08-06"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.clap_derive]]
-version = "4.6.1"
-when = "2026-04-15"
+version = "4.6.4"
+when = "2026-07-21"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -416,8 +416,8 @@ user-login = "yaleman"
 user-name = "James Hodgkinson"
 
 [[publisher.libc]]
-version = "0.2.186"
-when = "2026-04-23"
+version = "0.2.189"
+when = "2026-07-21"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -429,8 +429,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.libhimmelblau]]
-version = "0.8.25"
-when = "2026-07-01"
+version = "0.8.31"
+when = "2026-08-13"
 user-id = 247655
 user-login = "dmulder"
 user-name = "David Mulder"
@@ -589,15 +589,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regex]]
-version = "1.12.4"
-when = "2026-06-09"
+version = "1.13.1"
+when = "2026-07-15"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.regex-automata]]
-version = "0.4.13"
-when = "2025-10-13"
+version = "0.4.18"
+when = "2026-08-04"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
@@ -631,8 +631,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.rustls]]
-version = "0.23.41"
-when = "2026-06-22"
+version = "0.23.42"
+when = "2026-07-13"
 user-id = 4556
 user-login = "djc"
 user-name = "Dirkjan Ochtman"
@@ -658,6 +658,13 @@ user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
+[[publisher.serde]]
+version = "1.0.229"
+when = "2026-07-18"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.serde_bytes]]
 version = "0.11.17"
 when = "2025-03-09"
@@ -673,22 +680,22 @@ user-login = "Firstyear"
 user-name = "Firstyear"
 
 [[publisher.serde_core]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_derive]]
-version = "1.0.228"
-when = "2025-09-27"
+version = "1.0.229"
+when = "2026-07-18"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_json]]
-version = "1.0.150"
-when = "2026-05-21"
+version = "1.0.151"
+when = "2026-07-20"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -756,6 +763,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.syn]]
+version = "3.0.3"
+when = "2026-07-22"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.target-lexicon]]
 version = "0.12.16"
 when = "2024-07-30"
@@ -806,8 +820,8 @@ user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.tokio-util]]
-version = "0.7.18"
-when = "2026-01-04"
+version = "0.7.19"
+when = "2026-07-21"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -1940,12 +1954,6 @@ criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
 
-[[audits.bytecode-alliance.audits.utf-8]]
-who = "Chris Fallin <chris@cfallin.org>"
-criteria = "safe-to-deploy"
-version = "0.7.6"
-notes = "Small library that uses `unsafe` only around `str::from_utf8_unchecked` after explicitly verifying UTF-8."
-
 [[audits.bytecode-alliance.audits.vcpkg]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -2763,6 +2771,16 @@ See https://crrev.com/c/6323349 for more audit notes.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.himmelblau.audits.base64]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.22.1 -> 0.23.0"
+
+[[audits.himmelblau.audits.base64]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.23.0 -> 0.23.1"
+
 [[audits.himmelblau.audits.bitfield]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -2792,6 +2810,21 @@ delta = "1.2.60 -> 1.2.61"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.2.61 -> 1.2.65"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.2.65 -> 1.4.0"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.4.1"
+
+[[audits.himmelblau.audits.cc]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.1 -> 1.4.2"
 
 [[audits.himmelblau.audits.cesu8]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2823,12 +2856,37 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.10 -> 0.9.11"
 
+[[audits.himmelblau.audits.dbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.11 -> 0.9.12"
+
 [[audits.himmelblau.audits.der]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.8.0-rc.10 -> 0.8.0"
 
+[[audits.himmelblau.audits.ego-tree]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.0"
+
+[[audits.himmelblau.audits.find-msvc-tools]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.9 -> 0.1.10"
+
 [[audits.himmelblau.audits.futures]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.himmelblau.audits.futures]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-channel]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -2836,9 +2894,19 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.himmelblau.audits.futures-channel]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
 [[audits.himmelblau.audits.futures-core]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-executor]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -2846,9 +2914,19 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.himmelblau.audits.futures-executor]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
 [[audits.himmelblau.audits.futures-io]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-macro]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -2856,9 +2934,19 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.himmelblau.audits.futures-macro]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
 
 [[audits.himmelblau.audits.futures-sink]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
+
+[[audits.himmelblau.audits.futures-task]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
@@ -2866,12 +2954,17 @@ delta = "0.3.31 -> 0.3.32"
 [[audits.himmelblau.audits.futures-task]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
-delta = "0.3.31 -> 0.3.32"
+delta = "0.3.32 -> 0.3.33"
 
 [[audits.himmelblau.audits.futures-util]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.31 -> 0.3.32"
+
+[[audits.himmelblau.audits.futures-util]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.32 -> 0.3.33"
 
 [[audits.himmelblau.audits.getrandom]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2892,6 +2985,11 @@ version = "0.4.2"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.36.1"
+
+[[audits.himmelblau.audits.html5ever]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.36.1 -> 0.39.0"
 
 [[audits.himmelblau.audits.id-arena]]
 who = "David Mulder <dmulder@samba.org>"
@@ -2918,10 +3016,25 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.16.4 -> 0.18.0"
 
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.18.1"
+
+[[audits.himmelblau.audits.lru]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.18.1 -> 0.18.2"
+
 [[audits.himmelblau.audits.markup5ever]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.36.1"
+
+[[audits.himmelblau.audits.markup5ever]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.36.1 -> 0.39.0"
 
 [[audits.himmelblau.audits.num-conv]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3028,6 +3141,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "1.13.1"
 
+[[audits.himmelblau.audits.rand]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"
+
 [[audits.himmelblau.audits.regex-syntax]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3053,6 +3171,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "2.1.1 -> 2.1.2"
 
+[[audits.himmelblau.audits.rustls]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.23.42 -> 0.23.43"
+
 [[audits.himmelblau.audits.rustls-native-certs]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3072,6 +3195,11 @@ version = "0.1.1"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "0.25.0"
+
+[[audits.himmelblau.audits.scraper]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.25.0 -> 0.27.0"
 
 [[audits.himmelblau.audits.sd-notify]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3093,6 +3221,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.26.0 -> 0.33.0"
 
+[[audits.himmelblau.audits.selectors]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.33.0 -> 0.38.0"
+
 [[audits.himmelblau.audits.semver]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3107,6 +3240,11 @@ delta = "0.4.0 -> 0.4.3"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.3.0 -> 2.0.1"
+
+[[audits.himmelblau.audits.spin]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.8 -> 0.9.9"
 
 [[audits.himmelblau.audits.string_cache]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3123,6 +3261,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 version = "3.3.0"
 
+[[audits.himmelblau.audits.tendril]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.5.1"
+
 [[audits.himmelblau.audits.time]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3132,6 +3275,11 @@ delta = "0.3.44 -> 0.3.47"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.47 -> 0.3.51"
+
+[[audits.himmelblau.audits.time]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.51 -> 0.3.55"
 
 [[audits.himmelblau.audits.time-core]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3147,6 +3295,11 @@ delta = "0.2.22 -> 0.2.27"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.27 -> 0.2.30"
+
+[[audits.himmelblau.audits.time-macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.30 -> 0.2.32"
 
 [[audits.himmelblau.audits.toml_parser]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3218,6 +3371,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "1.23.1 -> 1.23.4"
 
+[[audits.himmelblau.audits.uuid]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "1.23.4 -> 1.24.0"
+
 [[audits.himmelblau.audits.uzers]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3248,6 +3406,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.15.0 -> 5.16.0"
 
+[[audits.himmelblau.audits.zbus]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.16.0 -> 5.18.0"
+
 [[audits.himmelblau.audits.zbus_macros]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3263,10 +3426,20 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.15.0 -> 5.16.0"
 
+[[audits.himmelblau.audits.zbus_macros]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.16.0 -> 5.18.0"
+
 [[audits.himmelblau.audits.zbus_names]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "4.3.1 -> 4.3.2"
+
+[[audits.himmelblau.audits.zbus_names]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "4.3.2 -> 4.3.4"
 
 [[audits.himmelblau.audits.zeroize]]
 who = "David Mulder <dmulder@samba.org>"
@@ -3293,6 +3466,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.11.0 -> 5.12.0"
 
+[[audits.himmelblau.audits.zvariant]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.12.0 -> 5.13.1"
+
 [[audits.himmelblau.audits.zvariant_derive]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3308,6 +3486,11 @@ who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "5.11.0 -> 5.12.0"
 
+[[audits.himmelblau.audits.zvariant_derive]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "5.12.0 -> 5.13.1"
+
 [[audits.himmelblau.audits.zvariant_utils]]
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
@@ -3317,6 +3500,11 @@ delta = "3.3.0 -> 3.3.1"
 who = "David Mulder <dmulder@samba.org>"
 criteria = "safe-to-deploy"
 delta = "3.3.1 -> 3.4.0"
+
+[[audits.himmelblau.audits.zvariant_utils]]
+who = "David Mulder <dmulder@samba.org>"
+criteria = "safe-to-deploy"
+delta = "3.4.0 -> 3.5.0"
 
 [[audits.isrg.audits.base64]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
@@ -3802,6 +3990,13 @@ criteria = "safe-to-deploy"
 delta = "0.35.0 -> 0.36.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.cssparser]]
+who = "Nico Burns <nico@nicoburns.com>"
+criteria = "safe-to-deploy"
+delta = "0.36.0 -> 0.37.0"
+notes = "First-party code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.cssparser-macros]]
 who = "Emilio Cobos Álvarez <emilio@crisal.io>"
 criteria = "safe-to-deploy"
@@ -3816,6 +4011,13 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.6.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cssparser-macros]]
+who = "Nico Burns <nico@nicoburns.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.7.0"
+notes = "First party code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.deranged]]


### PR DESCRIPTION
## Summary
Backport commits to stable-2.x:

- 6ffead28: fix(resolver): release db lock before offline auth fallback to prevent deadlock
- ae154c20: fix(auth): retry failed password changes
- 81dfc576: use debian-gdm user in qr postinst
- ddb2b281: security: replace rsa with aws-lc shim
- f6b8fca2: feat: add additional selinux denies via helper script from Aurora (based on Fedora 44 Kionite)
- 10d9e717: make pin shorter than 6 count towards pin reset count
- 651eeb49: fix(vet): diff crates locally
- 8df8c959: cargo audit/cargo vet
- 43d965dc: Use ok for account stack success.
- 54cc71d8: pam: add no_info_prompt to fold info text into the password prompt
- 9c48cc6e: fix(o365): avoid busy test script exec

### Dependabot Updates Included
- deps(rust): bump the all-cargo-updates group across 1 directory with 23 updates (#1596)


## Test plan
- [ ] Build succeeds
- [ ] `make vet` passes
- [ ] Basic functionality tested

---
Generated with [Claude Code](https://claude.com/claude-code)
