### PR TITLE
Skip Hello TOTP for local password-only sessions

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -1826,6 +1826,7 @@ impl IdProvider for HimmelblauProvider {
                 .iter()
                 .any(|s| !s.is_empty() && service.contains(s));
         let hello_totp_enabled = check_hello_totp_enabled!(self);
+        let console_password_only = self.config.lock().await.get_allow_console_password_only();
         let allow_remote_hello = self.config.lock().await.get_allow_remote_hello();
         // Skip Hello authentication if it is disabled by config
         let hello_enabled = self.config.lock().await.get_enable_hello();
@@ -1861,7 +1862,6 @@ impl IdProvider for HimmelblauProvider {
             // For local terminal authentication (GDM, etc.), don't force MFA
             // to allow natural passwordless flow without prematurely triggering
             // MFA notifications.
-            let console_password_only = self.config.lock().await.get_allow_console_password_only();
             debug!(
                 "Service '{}' remote_service={} console_password_only={}",
                 service, is_remote_service, console_password_only
@@ -2161,6 +2161,20 @@ impl IdProvider for HimmelblauProvider {
                 AuthCacheAction::None,
             ));
         }
+
+        let remote_services = self
+            .config
+            .lock()
+            .await
+            .get_password_only_remote_services_deny_list();
+        let is_remote_service = service.starts_with("remote:")
+            || remote_services
+                .iter()
+                .any(|s| !s.is_empty() && service.contains(s));
+        let hello_totp_enabled = check_hello_totp_enabled!(self);
+        let console_password_only = self.config.lock().await.get_allow_console_password_only();
+        let require_hello_totp =
+            hello_totp_enabled && (is_remote_service || !console_password_only);
 
         macro_rules! intune_enroll {
             ($token:ident) => {
@@ -2664,7 +2678,7 @@ impl IdProvider for HimmelblauProvider {
             }};
         }
         macro_rules! sspr_demand_hello_fallback {
-            ($cred:ident) => {{
+            ($cred:ident, $require_hello_totp:expr) => {{
                 // Hello authentication already succeeded,
                 // but SSPR demand was sent. Proceed and permit
                 // this authentication so the user has the opportunity
@@ -2673,7 +2687,7 @@ impl IdProvider for HimmelblauProvider {
                     "AADSTS{} (SSPR required) encountered; permitting auth via local Hello Pin",
                     PASSWORD_RESET_REGISTRATION_REQUIRED
                 );
-                if check_hello_totp_enabled!(self) {
+                if $require_hello_totp {
                     if !check_hello_totp_setup!(self, account_id, keystore) {
                         return impl_setup_hello_totp!(
                             self,
@@ -2710,7 +2724,7 @@ impl IdProvider for HimmelblauProvider {
             }};
         }
         macro_rules! auth_and_validate_hello_key {
-            ($hello_key:ident, $keytype:ident, $cred:ident) => {{
+            ($hello_key:ident, $keytype:ident, $cred:ident, $require_hello_totp:expr) => {{
                 // CRITICAL: Validate that we can load the key, otherwise the offline
                 // fallback will allow the user to authenticate with a bad PIN here.
                 // `acquire_token_by_hello_for_business_key` CAN (and probably will)
@@ -2779,7 +2793,7 @@ impl IdProvider for HimmelblauProvider {
                             let mut state = self.state.lock().await;
                             *state =
                                 CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
-                            if check_hello_totp_enabled!(self) {
+                            if $require_hello_totp {
                                 if !check_hello_totp_setup!(self, account_id, keystore) {
                                     return impl_setup_hello_totp!(
                                         self,
@@ -2810,7 +2824,7 @@ impl IdProvider for HimmelblauProvider {
                             }
                         }
                         Err(ref e) if is_sspr_required(e) => {
-                            sspr_demand_hello_fallback!($cred)
+                            sspr_demand_hello_fallback!($cred, $require_hello_totp)
                         }
                         Err(MsalError::AcquireTokenFailed(e)) => {
                             if e.error_codes.contains(&CONSENT_REQUIRED) {
@@ -3065,7 +3079,7 @@ impl IdProvider for HimmelblauProvider {
                                     let mut state = self.state.lock().await;
                                     *state =
                                         CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
-                                    if check_hello_totp_enabled!(self) {
+                                    if $require_hello_totp {
                                         if !check_hello_totp_setup!(self, account_id, keystore) {
                                             return impl_setup_hello_totp!(
                                                 self,
@@ -3096,7 +3110,7 @@ impl IdProvider for HimmelblauProvider {
                                     }
                                 }
                                 Err(ref e) if is_sspr_required(e) => {
-                                    sspr_demand_hello_fallback!($cred)
+                                    sspr_demand_hello_fallback!($cred, $require_hello_totp)
                                 }
                                 Err(MsalError::AcquireTokenFailed(e)) => {
                                     if e.error_codes.contains(&CONSENT_REQUIRED) {
@@ -3201,7 +3215,7 @@ impl IdProvider for HimmelblauProvider {
                                 let mut state = self.state.lock().await;
                                 *state =
                                     CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
-                                if check_hello_totp_enabled!(self) {
+                                if $require_hello_totp {
                                     if !check_hello_totp_setup!(self, account_id, keystore) {
                                         return impl_setup_hello_totp!(
                                             self,
@@ -3232,7 +3246,7 @@ impl IdProvider for HimmelblauProvider {
                                 }
                             }
                             Err(ref e) if is_sspr_required(e) => {
-                                sspr_demand_hello_fallback!($cred)
+                                sspr_demand_hello_fallback!($cred, $require_hello_totp)
                             }
                             Err(e) => {
                                 error!("Failed to exchange refresh token for access token: {:?}", e);
@@ -3318,7 +3332,7 @@ impl IdProvider for HimmelblauProvider {
 
                 match self.token_validate(account_id, &token, None).await {
                     Ok(AuthResult::Success { token }) => {
-                        if check_hello_totp_enabled!(self) {
+                        if $require_hello_totp {
                             if !check_hello_totp_setup!(self, account_id, keystore) {
                                 return impl_setup_hello_totp!(
                                     self,
@@ -3650,7 +3664,7 @@ impl IdProvider for HimmelblauProvider {
                         IdpError::Tpm
                     })?;
 
-                auth_and_validate_hello_key!(hello_key, keytype, pin)
+                auth_and_validate_hello_key!(hello_key, keytype, pin, require_hello_totp)
             }
             (_, PamAuthRequest::Pin { cred }) => {
                 let (hello_key, keytype) =
@@ -3659,7 +3673,7 @@ impl IdProvider for HimmelblauProvider {
                             error!("Online authentication failed. Hello key missing.");
                         })?;
 
-                auth_and_validate_hello_key!(hello_key, keytype, cred)
+                auth_and_validate_hello_key!(hello_key, keytype, cred, require_hello_totp)
             }
             // Sign-in frequency optimization: Password-first flow for console logins.
             // This handler validates password via ROPC, then checks PRT for sign-in

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -2939,6 +2939,7 @@ impl IdProvider for OidcProvider {
                 .iter()
                 .any(|s| !s.is_empty() && service.contains(s));
         let hello_totp_enabled = check_hello_totp_enabled!(self);
+        let console_password_only = self.config.lock().await.get_allow_console_password_only();
         let allow_remote_hello = self.config.lock().await.get_allow_remote_hello();
         // Skip Hello authentication if it is disabled by config
         let hello_enabled = self.config.lock().await.get_enable_hello();
@@ -2957,7 +2958,6 @@ impl IdProvider for OidcProvider {
             // is enabled by config, this is not a remote service, and the provider
             // advertises the `password` grant. Behaves like the Entra password-only
             // flow: a successful password can still lead to Hello PIN setup.
-            let console_password_only = self.config.lock().await.get_allow_console_password_only();
             if console_password_only
                 && !is_remote_service
                 && self.client.password_grant_supported().await
@@ -2992,7 +2992,7 @@ impl IdProvider for OidcProvider {
         &self,
         account_id: &str,
         old_token: &UserToken,
-        _service: &str,
+        service: &str,
         no_hello_pin: bool,
         cred_handler: &mut AuthCredHandler,
         pam_next_req: PamAuthRequest,
@@ -3013,8 +3013,22 @@ impl IdProvider for OidcProvider {
             ));
         }
 
+        let remote_services = self
+            .config
+            .lock()
+            .await
+            .get_password_only_remote_services_deny_list();
+        let is_remote_service = service.starts_with("remote:")
+            || remote_services
+                .iter()
+                .any(|s| !s.is_empty() && service.contains(s));
+        let hello_totp_enabled = check_hello_totp_enabled!(self);
+        let console_password_only = self.config.lock().await.get_allow_console_password_only();
+        let require_hello_totp =
+            hello_totp_enabled && (is_remote_service || !console_password_only);
+
         macro_rules! auth_and_validate_hello_key {
-            ($hello_key:ident, $keytype:ident, $cred:ident) => {{
+            ($hello_key:ident, $keytype:ident, $cred:ident, $require_hello_totp:expr) => {{
                 // CRITICAL: Validate that we can load the key, otherwise the offline
                 // fallback will allow the user to authenticate with a bad PIN here.
                 let pin = match PinValue::new(&$cred) {
@@ -3122,7 +3136,7 @@ impl IdProvider for OidcProvider {
                             let mut state = self.state.lock().await;
                             *state =
                                 CacheState::OfflineNextCheck(SystemTime::now() + OFFLINE_NEXT_CHECK);
-                            if check_hello_totp_enabled!(self) {
+                            if $require_hello_totp {
                                 if !check_hello_totp_setup!(self, account_id, keystore) {
                                     return impl_setup_hello_totp!(
                                         self,
@@ -3247,7 +3261,7 @@ impl IdProvider for OidcProvider {
 
                 match self.token_validate(account_id, &token).await {
                     Ok(AuthResult::Success { token }) => {
-                        if check_hello_totp_enabled!(self) {
+                        if $require_hello_totp {
                             if !check_hello_totp_setup!(self, account_id, keystore) {
                                 return impl_setup_hello_totp!(
                                     self,
@@ -3316,7 +3330,7 @@ impl IdProvider for OidcProvider {
                         IdpError::Tpm
                     })?;
 
-                auth_and_validate_hello_key!(hello_key, keytype, cred)
+                auth_and_validate_hello_key!(hello_key, keytype, cred, require_hello_totp)
             }
             (AuthCredHandler::PasswordFirst { .. }, PamAuthRequest::Password { cred }) => {
                 // Wrap the wire-delivered credential so this copy (and the clone
@@ -3371,7 +3385,7 @@ impl IdProvider for OidcProvider {
                             error!("Online authentication failed. Hello key missing.");
                         })?;
 
-                auth_and_validate_hello_key!(hello_key, keytype, cred)
+                auth_and_validate_hello_key!(hello_key, keytype, cred, require_hello_totp)
             }
             (
                 AuthCredHandler::MFA {


### PR DESCRIPTION
## Summary
- Skip Hello TOTP setup/prompt after successful Hello PIN auth when the session is local and `allow_console_password_only` is enabled.
- Preserve existing Hello TOTP behavior for remote sessions and for local sessions where console password-only auth is disabled.

Fixes #1413.

## Testing
- `git diff --check`
- Not run: `cargo fmt --check` / Rust checks because `cargo` is not installed in this environment.