### PR TITLE
apparmor: allow runc container networking

### DIFF
--- a/platform/arch/PKGBUILD
+++ b/platform/arch/PKGBUILD
@@ -214,6 +214,8 @@ package() {
     "$pkgdir/etc/apparmor.d/himmelblau-orchestrator-container"
   install -Dm644 platform/debian/apparmor.crun.local \
     "$pkgdir/etc/apparmor.d/local/crun"
+  install -Dm644 platform/debian/apparmor.runc.local \
+    "$pkgdir/etc/apparmor.d/local/runc"
   install -Dm644 platform/debian/apparmor.cupsd.local \
     "$pkgdir/etc/apparmor.d/local/usr.sbin.cupsd"
   install -Dm644 platform/debian/apparmor.unix-chkpwd.local \

--- a/platform/debian/apparmor.runc.local
+++ b/platform/debian/apparmor.runc.local
@@ -1,0 +1,11 @@
+# File: /etc/apparmor.d/local/runc
+#
+# Chromium inside the himmelblaud-orchestrator browser container creates
+# IPv4/IPv6 datagram sockets for DNS/network probing while the process is
+# still mediated by Ubuntu's runc profile.
+
+network inet stream,
+network inet6 stream,
+network inet dgram,
+network inet6 dgram,
+network netlink raw,

--- a/src/apparmor/Cargo.toml
+++ b/src/apparmor/Cargo.toml
@@ -15,6 +15,7 @@ depends = ["apparmor"]
 assets = [
   ["../../platform/debian/apparmor.himmelblau-orchestrator-container", "etc/apparmor.d/himmelblau-orchestrator-container", "644"],
   ["../../platform/debian/apparmor.crun.local", "etc/apparmor.d/local/crun", "644"],
+  ["../../platform/debian/apparmor.runc.local", "etc/apparmor.d/local/runc", "644"],
   ["../../platform/debian/apparmor.cupsd.local", "etc/apparmor.d/local/usr.sbin.cupsd", "644"],
   ["../../platform/debian/apparmor.unix-chkpwd.local", "etc/apparmor.d/local/unix-chkpwd", "644"],
   ["../../platform/debian/apparmor.fusermount3.local", "etc/apparmor.d/local/fusermount3", "644"],
@@ -26,6 +27,7 @@ name = "himmelblau-apparmor"
 assets = [
   { source = "../../platform/debian/apparmor.himmelblau-orchestrator-container", dest = "/etc/apparmor.d/himmelblau-orchestrator-container", mode = "644" },
   { source = "../../platform/debian/apparmor.crun.local", dest = "/etc/apparmor.d/local/crun", mode = "644" },
+  { source = "../../platform/debian/apparmor.runc.local", dest = "/etc/apparmor.d/local/runc", mode = "644" },
   { source = "../../platform/debian/apparmor.cupsd.local", dest = "/etc/apparmor.d/local/usr.sbin.cupsd", mode = "644" },
   { source = "../../platform/debian/apparmor.unix-chkpwd.local", dest = "/etc/apparmor.d/local/unix-chkpwd", mode = "644" },
   { source = "../../platform/debian/apparmor.fusermount3.local", dest = "/etc/apparmor.d/local/fusermount3", mode = "644" },

--- a/src/apparmor/scripts/postinst
+++ b/src/apparmor/scripts/postinst
@@ -20,6 +20,7 @@ reload_apparmor_profile() {
 
 reload_apparmor_profile /etc/apparmor.d/himmelblau-orchestrator-container himmelblau-orchestrator-container
 reload_apparmor_profile /etc/apparmor.d/crun crun
+reload_apparmor_profile /etc/apparmor.d/runc runc
 reload_apparmor_profile /etc/apparmor.d/usr.sbin.cupsd cupsd
 reload_apparmor_profile /etc/apparmor.d/unix-chkpwd unix-chkpwd
 reload_apparmor_profile /etc/apparmor.d/fusermount3 fusermount3


### PR DESCRIPTION
## Summary
- ship a local runc AppArmor snippet with the same network allowances as the existing crun snippet
- reload the runc profile during apparmor package setup when present

## Validation
- sh -n src/apparmor/scripts/postinst src/orchestrator/scripts/postinst src/orchestrator/scripts/prerm src/orchestrator/scripts/postrm

Fixes #1401
