### PR TITLE
fix(profile): preserve desktop session selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,7 @@ dependencies = [
  "uuid",
  "uzers",
  "walkdir",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7793,6 +7793,10 @@ rec {
             packageId = "sketching";
           }
           {
+            name = "tempfile";
+            packageId = "tempfile";
+          }
+          {
             name = "tokio";
             packageId = "tokio";
             features = [ "rt" "macros" "sync" "time" "net" "io-util" "signal" "rt-multi-thread" "tracing" ];
@@ -7823,11 +7827,9 @@ rec {
             name = "walkdir";
             packageId = "walkdir";
           }
-        ];
-        devDependencies = [
           {
-            name = "tempfile";
-            packageId = "tempfile";
+            name = "zbus";
+            packageId = "zbus";
           }
         ];
         features = {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ reqwest = { version = "^0.13.1", features = ["json"] }
 anyhow = "^1.0.102"
 tokio = { version = "^1.52.2", features = ["rt", "macros", "sync", "time", "net", "io-util", "signal", "rt-multi-thread"] }
 tokio-util = { version = "^0.7.18", features = ["codec"] }
+zbus = "5.14"
 async-trait = "^0.1.89"
 himmelblau_policies = { path = "src/policies" }
 pem = "^3.0.6"

--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -51,9 +51,8 @@ libhimmelblau.workspace = true
 url.workspace = true
 console-subscriber = { workspace = true, optional = true }
 libkrimes = { workspace = true }
-
-[dev-dependencies]
 tempfile = "3.27.0"
+zbus = { workspace = true }
 
 [package.metadata.deb]
 name = "himmelblau"

--- a/src/daemon/src/tasks_daemon.rs
+++ b/src/daemon/src/tasks_daemon.rs
@@ -22,7 +22,7 @@
 
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{symlink, OpenOptionsExt};
+use std::os::unix::fs::{symlink, OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::process::ExitCode;
 use std::str;
@@ -47,17 +47,38 @@ use sketching::tracing_forest::{self};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::process::Command;
+use tempfile::NamedTempFile;
 use tokio::net::UnixStream;
 use tokio::sync::broadcast;
 use tokio::time;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 use tracing::span;
 use walkdir::WalkDir;
+use zbus::zvariant::OwnedObjectPath;
+use zbus::{proxy, Connection};
 
 #[cfg(all(target_family = "unix", feature = "selinux"))]
 use himmelblau_unix_common::selinux_util;
 
 struct TaskCodec;
+
+#[proxy(
+    interface = "org.freedesktop.Accounts",
+    default_service = "org.freedesktop.Accounts",
+    default_path = "/org/freedesktop/Accounts"
+)]
+trait AccountsService {
+    fn find_user_by_name(&self, name: &str) -> zbus::Result<OwnedObjectPath>;
+    fn cache_user(&self, name: &str) -> zbus::Result<OwnedObjectPath>;
+}
+
+#[proxy(
+    interface = "org.freedesktop.Accounts.User",
+    default_service = "org.freedesktop.Accounts"
+)]
+trait AccountsServiceUser {
+    fn set_icon_file(&self, filename: &str) -> zbus::Result<()>;
+}
 
 impl Decoder for TaskCodec {
     type Error = io::Error;
@@ -436,6 +457,35 @@ fn setup_subordinate_ids(username: &str, start: u32, count: u32) -> Result<(), S
     Ok(())
 }
 
+async fn set_accountsservice_icon(account_id: &str, icon_path: &Path) -> zbus::Result<()> {
+    let connection = Connection::system().await?;
+    let accounts = AccountsServiceProxy::new(&connection).await?;
+    let user_path = match accounts.find_user_by_name(account_id).await {
+        Ok(path) => path,
+        Err(err) => {
+            debug!(
+                ?err,
+                account_id, "AccountsService FindUserByName failed; falling back to CacheUser"
+            );
+            accounts.cache_user(account_id).await?
+        }
+    };
+    let user = AccountsServiceUserProxy::builder(&connection)
+        .path(user_path)?
+        .build()
+        .await?;
+
+    user.set_icon_file(icon_path.to_string_lossy().as_ref())
+        .await
+}
+
+fn create_profile_photo_temp_file(icons_dir: &Path) -> io::Result<NamedTempFile> {
+    let file = NamedTempFile::new_in(icons_dir)?;
+    file.as_file()
+        .set_permissions(fs::Permissions::from_mode(0o600))?;
+    Ok(file)
+}
+
 fn store_tgt(tgt: &KerberosCredentials, uid: uid_t, gid: uid_t) -> Result<(), String> {
     // Usually default_ccache_name in /etc/krb5.conf contains a %{uid} substitution,
     // which will be '0' (root) for the tasks daemon because it runs as root. Force
@@ -662,18 +712,19 @@ async fn handle_tasks(stream: UnixStream, cfg: &HimmelblauConfig) {
             }
             Some(Ok(TaskRequest::LoadProfilePhoto(mut account_id, access_token))) => {
                 debug!("Received task -> LoadProfilePhoto(...)");
-                let icons_dir = "/var/lib/AccountsService/icons/";
-                let users_dir = "/var/lib/AccountsService/users/";
-                if !Path::new(icons_dir).exists() {
-                    info!("Profile photo directory '{}' doesn't exist.", icons_dir);
+                let icons_dir = Path::new("/var/lib/AccountsService/icons/");
+                if !icons_dir.exists() {
+                    info!(
+                        "Profile photo directory '{}' doesn't exist.",
+                        icons_dir.display()
+                    );
                 } else {
                     let upn = account_id.clone();
                     let domain = split_username(&upn).map(|(_, domain)| domain);
                     account_id = cfg.map_upn_to_name(&account_id);
 
-                    // Validate account_id to prevent path traversal and
-                    // cross-user aliasing. Reject rather than strip to avoid
-                    // collisions (e.g. "a/lice" and "alice" mapping to the same file).
+                    // Reject invalid account identifiers before resolving them through
+                    // AccountsService. Stripping characters could select a different user.
                     if account_id.is_empty()
                         || !account_id.chars().all(|c| {
                             c.is_ascii_alphanumeric() || matches!(c, '@' | '.' | '_' | '-')
@@ -684,61 +735,45 @@ async fn handle_tasks(stream: UnixStream, cfg: &HimmelblauConfig) {
                         );
                     // Set the profile picture
                     } else if let Some(domain) = domain {
-                        let filename = format!("{}{}", icons_dir, account_id);
-                        match OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .truncate(true)
-                            .custom_flags(libc::O_NOFOLLOW)
-                            .open(&filename)
-                        {
-                            Ok(file) => {
-                                let authority_host = cfg.get_authority_host(domain);
-                                let tenant_id = cfg.get_tenant_id(domain);
-                                let graph_url = cfg.get_graph_url(domain);
-                                let ip_versions = cfg.get_ip_versions();
-                                let request_timeout = cfg.get_request_timeout();
-                                if let Ok(graph) = Graph::new(
-                                    &cfg.get_odc_provider(domain),
-                                    domain,
-                                    Some(&authority_host),
-                                    tenant_id.as_deref(),
-                                    graph_url.as_deref(),
-                                    Duration::from_secs(request_timeout),
-                                    &ip_versions,
-                                )
+                        let result = async {
+                            let profile_photo = create_profile_photo_temp_file(icons_dir)
+                                .map_err(|e| format!("Failed creating profile photo: {:?}", e))?;
+                            let file = profile_photo
+                                .reopen()
+                                .map_err(|e| format!("Failed opening profile photo: {:?}", e))?;
+                            let authority_host = cfg.get_authority_host(domain);
+                            let tenant_id = cfg.get_tenant_id(domain);
+                            let graph_url = cfg.get_graph_url(domain);
+                            let ip_versions = cfg.get_ip_versions();
+                            let request_timeout = cfg.get_request_timeout();
+                            let graph = Graph::new(
+                                &cfg.get_odc_provider(domain),
+                                domain,
+                                Some(&authority_host),
+                                tenant_id.as_deref(),
+                                graph_url.as_deref(),
+                                Duration::from_secs(request_timeout),
+                                &ip_versions,
+                            )
+                            .await
+                            .map_err(|e| format!("Failed creating Graph client: {:?}", e))?;
+                            graph
+                                .fetch_user_profile_photo(&access_token, file)
                                 .await
-                                {
-                                    if let Err(e) =
-                                        graph.fetch_user_profile_photo(&access_token, file).await
-                                    {
-                                        error!("Failed fetching user profile photo: {:?}", e);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                error!("Failed creating file for user profile photo: {:?}", e)
-                            }
+                                .map_err(|e| format!("Failed fetching profile photo: {:?}", e))?;
+                            set_accountsservice_icon(&account_id, profile_photo.path())
+                                .await
+                                .map_err(|e| {
+                                    format!(
+                                        "Failed updating AccountsService profile photo: {:?}",
+                                        e
+                                    )
+                                })?;
+                            Ok::<(), String>(())
                         }
-                        let user_file = format!("{}{}", users_dir, account_id);
-                        match OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .truncate(true)
-                            .custom_flags(libc::O_NOFOLLOW)
-                            .open(&user_file)
-                        {
-                            Ok(mut file) => {
-                                let contents =
-                                    format!("[User]\nIcon={}\nSystemAccount=false\n", filename);
-
-                                if let Err(e) = file.write_all(contents.as_bytes()) {
-                                    error!("Failed writing to user profile settings: {:?}", e);
-                                }
-                            }
-                            Err(e) => {
-                                error!("Failed creating file for user profile settings: {:?}", e)
-                            }
+                        .await;
+                        if let Err(e) = result {
+                            error!("{}", e);
                         }
                     } else {
                         error!("Couldn't parse domain from name");
@@ -1102,6 +1137,22 @@ mod tests {
 
         let contents = fs::read_to_string(path).unwrap_or_default();
         assert_eq!(contents, "user@example.com:2100000000:65536\n");
+    }
+
+    #[test]
+    fn profile_photo_temp_file_is_private() {
+        let icons_dir = tempfile::tempdir().expect("failed to create temp icon directory");
+        let profile_photo = create_profile_photo_temp_file(icons_dir.path())
+            .expect("failed to create profile photo");
+
+        let mode = profile_photo
+            .as_file()
+            .metadata()
+            .expect("failed to read profile photo metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     #[test]

--- a/src/selinux/src/himmelblaud.te
+++ b/src/selinux/src/himmelblaud.te
@@ -746,6 +746,7 @@ ifdef(`files_read_usr_files',`
 	files_read_usr_files(himmelblaud_t)
 	files_read_usr_files(himmelblaud_tasks_t)
 ')
+ifdef(`dbus_system_bus_client',`dbus_system_bus_client(himmelblaud_tasks_t)')
 
 # himmelblaud_tasks needs to manage user home content
 ifdef(`userdom_manage_user_home_content',`userdom_manage_user_home_content(himmelblaud_tasks_t)')
@@ -1020,7 +1021,10 @@ optional {
 optional {
 	require {
 		type accountsd_t;
+		class dbus send_msg;
 	}
+	allow himmelblaud_tasks_t accountsd_t:dbus send_msg;
+	allow accountsd_t himmelblaud_tasks_t:dbus send_msg;
 	allow accountsd_t himmelblau_etc_t:dir { getattr open read search };
 	allow accountsd_t himmelblau_etc_t:file { getattr open read };
 	allow accountsd_t himmelblau_etc_t:lnk_file { getattr read };


### PR DESCRIPTION
## Summary

| Section | Detail |
|---|---|
| TL;DR | Profile-photo updates now use AccountsService, preserving the desktop selected in GDM. |
| Why | Truncating the user record removed `XSession=i3` and made GDM fall back to GNOME. |
| Risk | 4/10 because D-Bus and SELinux behavior spans several Linux distributions |
| Confidence | 9/10 because local validation and GitHub checks passed |

<details>
<summary>Test evidence</summary>

| Test | Before | After |
|---|---|---|
| Preserve desktop selection | The photo task truncated the user record, deleting `Session` and `XSession`. | `SetIconFile` updates the icon while AccountsService retains other fields. |
| Publish complete photos | The canonical icon was truncated before download completed. | AccountsService publishes a private temporary file only after download succeeds. |
| Daemon tests | - | Focused task tests: 8 passed |
| Format and metadata | - | Format, locked metadata, and diff checks passed |
| SELinux policy | - | Passed Rocky 8/9/10, Fedora 43/44, and Tumbleweed; SLE 16 needs SCC credentials |
| Clippy | - | Blocked by pre-existing unknown lint `clippy::manual_checked_ops` |

</details>

## What Changed

- Update icons through AccountsService D-Bus instead of rewriting user records.
- Download to a private temporary file before publishing.
- Permit tasks-daemon D-Bus messages with `accountsd_t` under SELinux.

## Testing

- **Distro(s) tested:** Rocky 8/9/10, Fedora 43/44, and Tumbleweed policy containers.
- **Steps performed:** Focused daemon tests, format/metadata checks, and SELinux policy harness.
- **Results observed:** 8 daemon tests and six policy targets passed; SLE 16 needs SCC credentials.

## Automated Checks

- [x] Focused daemon tests and SELinux policy checks passed.
- [ ] Full `make test` and package builds were not run.

## System Integration Impact

Adds an AccountsService D-Bus dependency and narrow SELinux messaging rules for `accountsd_t`.

## Checklist

- [ ] No disposable desktop VM was available for manual GDM testing.
- [ ] No public issue exists; the regression was reported internally.


