### PR TITLE
fix(rpm): restore rpmsaved config

### DIFF
--- a/src/daemon/Cargo.toml
+++ b/src/daemon/Cargo.toml
@@ -200,6 +200,7 @@ assets = [
   { source = "target/release/locale/vi/LC_MESSAGES/himmelblau.mo", dest = "/usr/share/locale/vi/LC_MESSAGES/", mode = "644" },
 ]
 post_install_script = "scripts/postinst"
+post_trans_script = "scripts/posttrans"
 pre_uninstall_script = "scripts/prerm"
 post_uninstall_script = "scripts/postrm"
 

--- a/src/daemon/scripts/posttrans
+++ b/src/daemon/scripts/posttrans
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+config_file="/etc/himmelblau/himmelblau.conf"
+saved_config="${config_file}.rpmsave"
+
+# RPM creates .rpmsave after %post when an owned config is removed during an
+# upgrade, so recover the previous local configuration at transaction end.
+if [ -f "$saved_config" ] && [ ! -e "$config_file" ] && [ ! -L "$config_file" ]; then
+    echo "Restoring Himmelblau configuration from $saved_config"
+    if ! mv -- "$saved_config" "$config_file"; then
+        echo "Failed to restore Himmelblau configuration from $saved_config" >&2
+        exit 1
+    fi
+
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl try-restart himmelblaud.service himmelblaud-tasks.service 2>/dev/null || true
+    fi
+fi


### PR DESCRIPTION
Restore the existing Himmelblau configuration from .rpmsave at the end of RPM upgrade transactions. This prevents package layout changes from leaving upgraded systems without their user-configured himmelblau.conf.

## Summary

Fixes #

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
