### PR TITLE
fix(auth): set up offline Hello TOTP

### DIFF
--- a/src/common/src/idprovider/common.rs
+++ b/src/common/src/idprovider/common.rs
@@ -612,7 +612,7 @@ macro_rules! check_hello_totp_enabled {
 
 #[macro_export]
 macro_rules! impl_himmelblau_offline_auth_step {
-    ($cred_handler:expr, $pam_next_req:expr, $self:ident, $account_id:expr, $keystore:expr, $tpm:expr, $machine_key:expr, $token:expr, $load_cached_prt:ident) => {{
+    ($cred_handler:ident, $pam_next_req:expr, $self:ident, $account_id:ident, $keystore:ident, $tpm:ident, $machine_key:ident, $token:ident, $load_cached_prt:ident) => {{
         match (&$cred_handler, $pam_next_req) {
             (_, PamAuthRequest::Pin { cred }) => {
                 let (hello_key, _keytype) =
@@ -667,14 +667,30 @@ macro_rules! impl_himmelblau_offline_auth_step {
                                 .add($account_id, &RefreshCacheEntry::RefreshToken(refresh_token))
                                 .await;
                         }
-                        if check_hello_totp_setup!($self, $account_id, $keystore)
-                            && check_hello_totp_enabled!($self)
-                        {
-                            Ok(AuthResult::Next(AuthRequest::HelloTOTP {
-                                msg: tr(
-                                    "Please enter your Hello TOTP code from your Authenticator:",
-                                ) + " ",
-                            }))
+                        if check_hello_totp_enabled!($self) {
+                            if !check_hello_totp_setup!($self, $account_id, $keystore) {
+                                let (auth_result, _auth_cache_action) = impl_setup_hello_totp!(
+                                    $self,
+                                    $account_id,
+                                    $keystore,
+                                    $token,
+                                    cred,
+                                    $tpm,
+                                    $machine_key,
+                                    $cred_handler
+                                )?;
+                                Ok(auth_result)
+                            } else {
+                                *$cred_handler = AuthCredHandler::HelloTOTP {
+                                    cred,
+                                    pending_sealed_totp: None,
+                                };
+                                Ok(AuthResult::Next(AuthRequest::HelloTOTP {
+                                    msg: tr(
+                                        "Please enter your Hello TOTP code from your Authenticator:",
+                                    ) + " ",
+                                }))
+                            }
                         } else {
                             $self.bad_pin_counter.reset_bad_pin_count($account_id).await;
                             Ok(AuthResult::Success {


### PR DESCRIPTION
Run the Hello TOTP setup flow during offline PIN
authentication when the feature is enabled but no
setup exists. This keeps the auth flow from
bypassing enrollment and preserves the existing
TOTP prompt for configured accounts.

## Summary

Fixes #

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
