### PR TITLE
Create fake primary groups for missing RFC2307 gids

### DIFF
--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -5090,6 +5090,14 @@ impl HimmelblauProvider {
                                 );
                                 return Err(IdpError::BadRequest);
                             }
+                            if !groups.iter().any(|group| group.gidnumber == gid_number) {
+                                groups.push(GroupToken {
+                                    name: spn.clone(),
+                                    spn: spn.clone(),
+                                    uuid,
+                                    gidnumber: gid_number,
+                                });
+                            }
                             gid_number
                         } else {
                             // Otherwise add a fake primary group


### PR DESCRIPTION
## Summary

Fixes #1448

## What Changed

When an RFC2307 user has a `gidNumber`, Himmelblau now checks whether any fetched Entra group token has that GID. If no matching group exists, it creates the existing synthetic primary group token using the user's SPN and the configured `gidNumber`.

This preserves the existing behavior when the matching Entra group exists, and keeps the current fallback behavior for users without `gidNumber`.

## Testing

- **Distro(s) tested:** Not run; local environment does not include the Rust toolchain.
- **Steps performed:** Inspected the affected `user_token_from_unix_user_token` flow and attempted `cargo fmt --check`.
- **Results observed:** `cargo fmt --check` could not run because `cargo` is not installed in this environment.

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

`make test` and package build checks were not run because the local environment lacks the Rust toolchain (`cargo` not found). `make test-selinux` was not run; this change does not modify SELinux policy.

## System Integration Impact

NSS group resolution can now see a synthetic primary group for RFC2307 users whose `gidNumber` does not correspond to a fetched Entra group. No systemd, PAM, authselect, filesystem path, or credential handling changes.

## Checklist

- [ ] I manually tested this change on a test VM
- [x] PR scope is focused and linked to an issue/enhancement/discussion
