### PR TITLE
Fix local group membership parsing

### DIFF
--- a/src/daemon/src/tasks_daemon.rs
+++ b/src/daemon/src/tasks_daemon.rs
@@ -285,6 +285,10 @@ fn add_user_to_group(account_id: &str, local_group: &str) {
     }
 }
 
+fn group_members_include(users: &str, account_id: &str) -> bool {
+    users.split(',').any(|user| user.trim() == account_id)
+}
+
 fn user_in_group(account_id: &str, local_group: &str) -> bool {
     let output = Command::new("getent")
         .arg("group")
@@ -295,7 +299,7 @@ fn user_in_group(account_id: &str, local_group: &str) -> bool {
         if out.status.success() {
             let stdout = String::from_utf8_lossy(&out.stdout);
             if let Some(users) = stdout.split(':').nth(3) {
-                return users.split(',').any(|u| u == account_id);
+                return group_members_include(users, account_id);
             }
         }
     }
@@ -1089,6 +1093,13 @@ mod tests {
                 username
             );
         }
+    }
+
+    #[test]
+    fn group_membership_matches_newline_terminated_last_member() {
+        let users = "alice,bob\n";
+
+        assert!(group_members_include(users, "bob"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- The `user_in_group` helper read the fourth field of `getent group` but compared raw comma-separated tokens to `account_id` without trimming, so trailing newlines caused sole/last members to be missed and `gpasswd -d` to be skipped.

### Description

- Replace the inline comparison with a dedicated `group_members_include(users: &str, account_id: &str)` helper that trims each token before comparing. 
- Update `user_in_group` to delegate to `group_members_include` to correctly detect membership for newline-terminated entries. 
- Preserve the existing `remove_user_from_group` flow so removals still run when membership is detected. 
- Add a regression test `group_membership_matches_newline_terminated_last_member` that asserts a newline-terminated last member is matched.

### Testing

- Ran `cargo fmt --all -- --check` which completed successfully. 
- Ran `git diff --check` which reported no issues. 
- Attempted `cargo test -p himmelblaud --bin himmelblaud_tasks group_membership_matches_newline_terminated_last_member` but the build failed due to a missing system dependency (`dbus-1` development package required by `libdbus-sys`), so the full crate tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7642ef06208326bbeee63c257ea00f)