### PR TITLE
ci: limit OBS credential exposure during package generation

### DIFF
--- a/.github/workflows/obs-update.yml
+++ b/.github/workflows/obs-update.yml
@@ -38,36 +38,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && env.OBS_STABLE_BRANCH || github.sha }}
 
-      - name: Configure osc credentials
-        env:
-          OBS_USER: ${{ secrets.OBS_USER }}
-          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${OBS_USER:-}" ]; then
-            echo "::error::OBS_USER secret is not configured"
-            exit 1
-          fi
-
-          if [ -z "${OBS_PASSWORD:-}" ]; then
-            echo "::error::OBS_PASSWORD secret is not configured"
-            exit 1
-          fi
-
-          umask 077
-          mkdir -p "$HOME/.config/osc"
-          cat > "$HOME/.config/osc/oscrc" << EOF
-          [general]
-          apiurl = ${OBS_API_URL}
-
-          [${OBS_API_URL}]
-          user=${OBS_USER}
-          pass=${OBS_PASSWORD}
-          credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
-          trusted_prj=${OBS_TARGET_PROJECT}
-          EOF
-
       - name: Install osc and OBS services
         run: |
           set -euo pipefail
@@ -113,7 +83,7 @@ jobs:
           CARGO_SERVICE_RPM_DIR=$(mktemp -d "${RUNNER_TEMP}/obs-service-cargo-rpm.XXXXXX")
           CARGO_SERVICE_EXTRACT_DIR=$(mktemp -d "${RUNNER_TEMP}/obs-service-cargo-extract.XXXXXX")
 
-          osc getbinaries \
+          osc -A "$OBS_API_URL" getbinaries \
             -d "$CARGO_SERVICE_RPM_DIR" \
             devel:languages:rust \
             obs-service-cargo \
@@ -170,7 +140,37 @@ jobs:
             rpm2cpio \
             zlib1g \
             zstd
-          osc api "/source/${OBS_TARGET_PROJECT}/${OBS_PACKAGE}" >/dev/null
+          osc -A "$OBS_API_URL" api "/source/${OBS_TARGET_PROJECT}/${OBS_PACKAGE}" >/dev/null
+
+      - name: Configure osc credentials
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${OBS_USER:-}" ]; then
+            echo "::error::OBS_USER secret is not configured"
+            exit 1
+          fi
+
+          if [ -z "${OBS_PASSWORD:-}" ]; then
+            echo "::error::OBS_PASSWORD secret is not configured"
+            exit 1
+          fi
+
+          umask 077
+          mkdir -p "$HOME/.config/osc"
+          cat > "$HOME/.config/osc/oscrc" << EOF
+          [general]
+          apiurl = ${OBS_API_URL}
+
+          [${OBS_API_URL}]
+          user=${OBS_USER}
+          pass=${OBS_PASSWORD}
+          credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+          trusted_prj=${OBS_TARGET_PROJECT}
+          EOF
 
       - name: Detect source version
         id: version
@@ -217,6 +217,9 @@ jobs:
           cd "$WORKDIR"
 
           osc co "${{ steps.branch.outputs.branch_project }}/${OBS_PACKAGE}"
+
+      - name: Remove osc credentials before generating sources
+        run: rm -f "$HOME/.config/osc/oscrc"
 
       - name: Update OBS package sources
         id: update
@@ -274,6 +277,32 @@ jobs:
           echo "$STATUS"
           osc diff || true
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Restore osc credentials for submission and cleanup
+        if: always()
+        env:
+          OBS_USER: ${{ secrets.OBS_USER }}
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${OBS_USER:-}" ] || [ -z "${OBS_PASSWORD:-}" ]; then
+            echo "::error::OBS credentials are not configured"
+            exit 1
+          fi
+
+          umask 077
+          mkdir -p "$HOME/.config/osc"
+          cat > "$HOME/.config/osc/oscrc" << EOF
+          [general]
+          apiurl = ${OBS_API_URL}
+
+          [${OBS_API_URL}]
+          user=${OBS_USER}
+          pass=${OBS_PASSWORD}
+          credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+          trusted_prj=${OBS_TARGET_PROJECT}
+          EOF
 
       - name: Commit and submit OBS changes
         if: steps.update.outputs.has_changes == 'true'


### PR DESCRIPTION
### Motivation
- Prevent OBS plaintext credentials from being present while untrusted, network-fetched tools or third‑party packages are installed and executed to reduce the risk of credential exfiltration or package tampering.
- Ensure the workflow only materializes OBS secrets when needed for authenticated operations (branch creation/checkout and final submission) and removes them during untrusted build steps.

### Description
- Reordered and refactored `.github/workflows/obs-update.yml` so all external tool installation and validation (apt installs, `rustup` install, `osc` binary checks, and unpacking `obs-service-cargo`) run before OBS credentials are written to disk, and use `osc -A "$OBS_API_URL"` for anonymous API calls where appropriate.
- Removed the initial early `Configure osc credentials` step and added a single `Configure osc credentials` step after tool installation to restrict the credential lifetime to authenticated operations only.
- Added `rm -f "$HOME/.config/osc/oscrc"` immediately after checking out the branched package to remove credentials before running source-generation services, and restored credentials in a short-lived `Restore osc credentials for submission and cleanup` step executed just prior to commit/submit and cleanup (using `if: always()` to ensure restoration for authenticated cleanup when required).
- Kept final cleanup to remove the credential file at job end so credentials are not left on disk.

### Testing
- Ran `git diff --check` to validate there are no local patch whitespace or index issues, which succeeded.
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/obs-update.yml")'` to confirm valid YAML, which reported `YAML OK`.
- Executed a Python verification that checks the ordering of steps and ensures no `secrets.OBS_*` references appear in the tool-install and source-generation sections, which reported `credential lifecycle ordering OK`.
- Inspected repository status with `git status --porcelain` to confirm the working tree is clean after applying the change, which succeeded; attempted to run the local `make_pr` helper failed because the environment is missing the `mcp` Python dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a760c46eec88326b59d1d73131e5999)