### PR TITLE
Restrict SYSTEMD_ACTIVATION_UNIT bypass to authenticated systemd-executor

### DIFF
--- a/src/common/src/client_sync.rs
+++ b/src/common/src/client_sync.rs
@@ -30,10 +30,20 @@ pub fn should_skip_daemon_call() -> bool {
 
     static SKIP: OnceLock<bool> = OnceLock::new();
     *SKIP.get_or_init(|| {
-        matches!(
+        // SYSTEMD_ACTIVATION_UNIT may be inherited from an untrusted caller.
+        // Only sd-executor, running directly under the system manager, may use
+        // it to suppress daemon calls during service credential resolution.
+        let is_root_system_child = unsafe { libc::geteuid() == 0 && libc::getppid() == 1 };
+        let is_systemd_executor = std::fs::read_link("/proc/self/exe")
+            .ok()
+            .and_then(|path| path.file_name().map(|name| name == "systemd-executor"))
+            .unwrap_or(false);
+        let is_himmelblau_unit = matches!(
             std::env::var_os("SYSTEMD_ACTIVATION_UNIT").as_deref(),
             Some(v) if v == "himmelblaud.service" || v == "himmelblaud-tasks.service"
-        )
+        );
+
+        is_root_system_child && is_systemd_executor && is_himmelblau_unit
     })
 }
 


### PR DESCRIPTION
### Motivation

- A previous change let `should_skip_daemon_call()` unconditionally trust the `SYSTEMD_ACTIVATION_UNIT` environment variable, allowing untrusted callers to force PAM/NSS hooks to skip daemon checks.
- The intent is to avoid deadlocks during legitimate `sd-executor` service startup while preventing an attacker-controlled environment from bypassing authentication and account checks.

### Description

- Tighten `should_skip_daemon_call()` in `src/common/src/client_sync.rs` to only return true when the process appears to be the trusted systemd executor by checking `geteuid() == 0`, parent PID is `1`, and `/proc/self/exe` basename equals `systemd-executor`, in addition to matching the Himmelblau unit names.
- Preserve the existing unit-name check for `himmelblaud.service` and `himmelblaud-tasks.service` and keep the `OnceLock` caching semantics.
- No changes were made to PAM/NSS call sites; they continue to call `should_skip_daemon_call()` as before.

### Testing

- Ran `cargo fmt --all -- --check`, which succeeded.
- Ran repository diff and formatting checks (`git diff HEAD^ --check`), which succeeded.
- Ran `cargo test -p himmelblau_unix_common --lib`, which failed to complete due to a missing system dependency (`dbus-1` development library required by `libdbus-sys`), so full test-suite execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76189523648326899f5f819436fac1)