### PR TITLE
Prevent offline fallback during Hello password reauthentication

### DIFF
--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -563,6 +563,41 @@ mod tests {
         );
         assert_eq!(resolver.client.user_get_calls.load(Ordering::Acquire), 0);
     }
+
+    #[tokio::test]
+    async fn hello_password_reauth_cannot_fall_back_to_offline_auth() {
+        let resolver = setup_resolver().await;
+        resolver
+            .set_cache_userpassword(test_token().uuid, "cached-password")
+            .await
+            .expect("failed to seed cached password");
+        resolver.client.set_cache_state(CacheState::Offline);
+        let (_shutdown_tx, shutdown_rx) = broadcast::channel(1);
+        let mut auth_session = AuthSession::InProgress {
+            account_id: "testuser@example.com".to_string(),
+            service: "gdm-password".to_string(),
+            id: Id::Name("testuser@example.com".to_string()),
+            token: Some(Box::new(test_token())),
+            online_at_init: true,
+            cred_handler: AuthCredHandler::ReauthPassword {
+                reauth_hello_pin: "123456".to_string().into(),
+            },
+            shutdown_rx,
+            no_hello_pin: false,
+            force_reauth: false,
+        };
+
+        let result = resolver
+            .pam_account_authenticate_step(
+                &mut auth_session,
+                PamAuthRequest::Password {
+                    cred: "cached-password".to_string(),
+                },
+            )
+            .await;
+
+        assert!(result.is_err());
+    }
 }
 
 impl<I> Resolver<I>
@@ -1844,6 +1879,11 @@ where
                 // contained to the resolver so that it has generic offline-paths
                 // that are possible?
                 match (&cred_handler, &pam_next_req) {
+                    (AuthCredHandler::ReauthPassword { .. }, _) => {
+                        // Password-based Hello reauthentication must complete online so
+                        // that the provider can enforce the remaining MFA requirements.
+                        return Err(());
+                    }
                     (_, PamAuthRequest::Password { cred }) => {
                         match self.check_cache_userpassword(token.uuid, cred).await {
                             Ok(true) => Ok(AuthResult::Success {
@@ -1919,10 +1959,6 @@ where
                     (AuthCredHandler::PasswordFirst { .. }, _) => {
                         // AuthCredHandler::PasswordFirst with anything other than
                         // PamAuthRequest::Password is invalid.
-                        return Err(());
-                    }
-                    (AuthCredHandler::ReauthPassword { .. }, _) => {
-                        // AuthCredHandler::ReauthPassword is invalid for offline auth.
                         return Err(());
                     }
                 }


### PR DESCRIPTION
### Motivation

- Prevent an offline cached-password path from satisfying a `ReauthPassword` (Hello PIN) reauthentication and thereby bypassing the intended online password+MFA/FIDO flow when the resolver transitions to offline between prompt and response.

### Description

- In `src/common/src/resolver.rs` move the `AuthCredHandler::ReauthPassword` rejection ahead of the generic `PamAuthRequest::Password` offline branch so `ReauthPassword` cannot be handled by cached-password offline auth.
- Add a regression test `hello_password_reauth_cannot_fall_back_to_offline_auth` in `src/common/src/resolver.rs` that simulates an online Hello reauth session becoming offline and asserts the password step is rejected rather than using cached-password authentication.

### Testing

- Ran `cargo fmt --check` and it succeeded.
- Ran `git diff --check` and it succeeded.
- Attempted `cargo test -p himmelblau_unix_common hello_password_reauth_cannot_fall_back_to_offline_auth`, but the build/test run was blocked by a missing system dependency (`dbus-1` development package) required by `libdbus-sys`, so the CI test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a762e7f0a808326bf16d5aa5373aa98)