### PR TITLE
Block remote Hello PIN during offline authentication

### DIFF
--- a/src/common/src/idprovider/common.rs
+++ b/src/common/src/idprovider/common.rs
@@ -264,6 +264,14 @@ pub(crate) fn should_block_hello_pin_attempts(bad_pin_count: u32, retry_count: u
     bad_pin_count >= retry_count
 }
 
+pub(crate) fn should_offer_offline_hello_pin(
+    is_remote_service: bool,
+    hello_totp_enabled: bool,
+    allow_remote_hello: bool,
+) -> bool {
+    !is_remote_service || hello_totp_enabled || allow_remote_hello
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum TryUnsealPolicyDenial {
     HelloDisabled,
@@ -577,25 +585,44 @@ macro_rules! load_cached_prt_for_try_unseal_no_op {
 
 #[macro_export]
 macro_rules! impl_himmelblau_offline_auth_init {
-    ($self:ident, $account_id:expr, $no_hello_pin:ident, $keystore:expr, $password_auth:expr) => {{
+    ($self:ident, $account_id:expr, $service:expr, $no_hello_pin:ident, $keystore:expr, $password_auth:expr) => {{
         let hello_key = $self.fetch_hello_key($account_id, $keystore).ok();
-        let (sfa_enabled, hello_pin_retry_count, breakglass_enabled) = {
+        let (
+            sfa_enabled,
+            hello_pin_retry_count,
+            breakglass_enabled,
+            remote_services,
+            hello_totp_enabled,
+            allow_remote_hello,
+        ) = {
             let cfg = $self.config.lock().await;
             (
                 cfg.get_enable_sfa_fallback(),
                 cfg.get_hello_pin_retry_count(),
                 cfg.get_offline_breakglass_enabled(),
+                cfg.get_password_only_remote_services_deny_list(),
+                cfg.get_enable_hello_totp(),
+                cfg.get_allow_remote_hello(),
             )
         };
+        let is_remote_service = $service.starts_with("remote:")
+            || remote_services
+                .iter()
+                .any(|s| !s.is_empty() && $service.contains(s));
         // We only have 2 options when performing an offline auth; Hello PIN,
         // or cached password for SFA users. If neither option is available,
-        // we should respond with a resonable error indicating how to proceed.
+        // we should respond with a reasonable error indicating how to proceed.
         if hello_key.is_some()
             && !$crate::idprovider::common::should_block_hello_pin_attempts(
                 $self.bad_pin_counter.bad_pin_count($account_id).await,
                 hello_pin_retry_count,
             )
             && !$no_hello_pin
+            && $crate::idprovider::common::should_offer_offline_hello_pin(
+                is_remote_service,
+                hello_totp_enabled,
+                allow_remote_hello,
+            )
         {
             Ok((AuthRequest::Pin, AuthCredHandler::None))
         } else if $password_auth && (sfa_enabled || breakglass_enabled) {
@@ -1410,9 +1437,9 @@ macro_rules! impl_setup_hello_totp {
 #[cfg(test)]
 mod tests {
     use super::{
-        should_block_hello_pin_attempts, should_renew_expired_try_unseal_prt,
-        should_warn_last_hello_pin_attempt, try_unseal_policy_denial, KeyType,
-        TryUnsealPolicyDenial,
+        should_block_hello_pin_attempts, should_offer_offline_hello_pin,
+        should_renew_expired_try_unseal_prt, should_warn_last_hello_pin_attempt,
+        try_unseal_policy_denial, KeyType, TryUnsealPolicyDenial,
     };
 
     #[test]
@@ -1434,6 +1461,14 @@ mod tests {
         assert!(!should_warn_last_hello_pin_attempt(0, 0));
         assert!(should_block_hello_pin_attempts(0, 0));
         assert!(should_block_hello_pin_attempts(1, 0));
+    }
+
+    #[test]
+    fn offline_hello_pin_policy_blocks_unprotected_remote_auth() {
+        assert!(!should_offer_offline_hello_pin(true, false, false));
+        assert!(should_offer_offline_hello_pin(false, false, false));
+        assert!(should_offer_offline_hello_pin(true, false, true));
+        assert!(should_offer_offline_hello_pin(true, true, false));
     }
 
     #[test]

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -720,6 +720,7 @@ impl IdProvider for HimmelblauMultiProvider {
         &self,
         account_id: &str,
         token: Option<&UserToken>,
+        service: &str,
         no_hello_pin: bool,
         keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
@@ -729,12 +730,12 @@ impl IdProvider for HimmelblauMultiProvider {
         match provider.as_ref() {
             Providers::Oidc(provider) => {
                 provider
-                    .unix_user_offline_auth_init(account_id, token, no_hello_pin, keystore)
+                    .unix_user_offline_auth_init(account_id, token, service, no_hello_pin, keystore)
                     .await
             }
             Providers::Himmelblau(provider) => {
                 provider
-                    .unix_user_offline_auth_init(account_id, token, no_hello_pin, keystore)
+                    .unix_user_offline_auth_init(account_id, token, service, no_hello_pin, keystore)
                     .await
             }
         }
@@ -4418,10 +4419,11 @@ impl IdProvider for HimmelblauProvider {
         &self,
         account_id: &str,
         _token: Option<&UserToken>,
+        service: &str,
         no_hello_pin: bool,
         keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
-        impl_himmelblau_offline_auth_init!(self, account_id, no_hello_pin, keystore, true)
+        impl_himmelblau_offline_auth_init!(self, account_id, service, no_hello_pin, keystore, true)
     }
 
     #[instrument(skip_all)]

--- a/src/common/src/idprovider/interface.rs
+++ b/src/common/src/idprovider/interface.rs
@@ -350,6 +350,7 @@ pub trait IdProvider {
         &self,
         _account_id: &str,
         _token: Option<&UserToken>,
+        _service: &str,
         _no_hello_pin: bool,
         _keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError>;

--- a/src/common/src/idprovider/openidconnect.rs
+++ b/src/common/src/idprovider/openidconnect.rs
@@ -4100,10 +4100,11 @@ impl IdProvider for OidcProvider {
         &self,
         account_id: &str,
         _token: Option<&UserToken>,
+        service: &str,
         no_hello_pin: bool,
         keystore: &mut D,
     ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
-        impl_himmelblau_offline_auth_init!(self, account_id, no_hello_pin, keystore, false)
+        impl_himmelblau_offline_auth_init!(self, account_id, service, no_hello_pin, keystore, false)
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/src/common/src/resolver.rs
+++ b/src/common/src/resolver.rs
@@ -269,6 +269,7 @@ mod tests {
             &self,
             _account_id: &str,
             _token: Option<&UserToken>,
+            _service: &str,
             _no_hello_pin: bool,
             _keystore: &mut D,
         ) -> Result<(AuthRequest, AuthCredHandler), IdpError> {
@@ -1651,6 +1652,7 @@ where
                                     .unix_user_offline_auth_init(
                                         account_id,
                                         token.as_ref(),
+                                        service,
                                         no_hello_pin,
                                         &mut dbtxn,
                                     )
@@ -1675,7 +1677,13 @@ where
 
             // Can the auth proceed offline?
             self.client
-                .unix_user_offline_auth_init(account_id, token.as_ref(), no_hello_pin, &mut dbtxn)
+                .unix_user_offline_auth_init(
+                    account_id,
+                    token.as_ref(),
+                    service,
+                    no_hello_pin,
+                    &mut dbtxn,
+                )
                 .await
         };
 


### PR DESCRIPTION
### Motivation

- The offline authentication path was service-blind and could offer Hello PIN for remote (SSH) sessions, allowing a PIN-only bypass of the new remote-TOTP requirement during cache/outage fallback.

### Description

- Add a `service: &str` parameter to the provider interface `unix_user_offline_auth_init` and propagate it through the resolver offline-fallback call so providers receive PAM service context.
- Update the shared macro `impl_himmelblau_offline_auth_init!` to accept the `service` argument, compute `is_remote_service` using `get_password_only_remote_services_deny_list()`, and suppress `AuthRequest::Pin` when the session is remote and Hello TOTP is disabled and `allow_remote_hello` is false. 
- Wire the new `service` argument into the Himmelblau and OIDC provider implementations so both provider paths enforce the remote Hello policy during offline initialization. 
- Preserve existing cached-password and offline break-glass fallbacks and avoid changing higher-level behavior other than denying remote PIN-only offline auth where configured.

### Testing

- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran `git diff --check` and a targeted search with `rg` to confirm `unix_user_offline_auth_init` was updated and propagated, both succeeded. 
- Attempted `cargo check -p himmelblau_unix_common` but it failed due to missing system `dbus-1` development files required by `libdbus-sys` in the environment (build error from missing `dbus-1.pc`). 
- Committed the change (message: "Block remote Hello PIN during offline auth") and verified work-tree status was clean after commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a762f6062448326afb66830cc6c57f9)