### PR TITLE
Resolve fedora-cisco-openh264 key import failure

### DIFF
--- a/scripts/gen_dockerfiles.py
+++ b/scripts/gen_dockerfiles.py
@@ -294,7 +294,7 @@ DISTS = {
         "family": "rpm",
         "image": "fedora:rawhide",
         "extra_prep": [
-            "RUN dnf -y --refresh update glibc glibc-common glibc-minimal-langpack systemd-libs systemd-standalone-sysusers rpm-libs rpm && dnf -y --refresh update"
+            "RUN dnf -y --refresh --disablerepo=fedora-cisco-openh264 update glibc glibc-common glibc-minimal-langpack systemd-libs systemd-standalone-sysusers rpm-libs rpm && dnf -y --refresh --disablerepo=fedora-cisco-openh264 update"
         ],
         "tpm": True,
         "selinux": True,


### PR DESCRIPTION
## Summary

The build is failing due to a Rawhide version switch because the key for the fedora-cisco-openh264 repository has changed. We don't need this anyway for the Himmelblau build, so just disable it.

Fixes #1646

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
