### PR TITLE
fix: install Entra SSO policy for Betterbird

### DIFF
--- a/src/sso-policies/scripts/postinst
+++ b/src/sso-policies/scripts/postinst
@@ -70,5 +70,10 @@ EOF
 # Merge Firefox and Thunderbird policies
 merge_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL" "Firefox" "linux_entra_sso-[0-9][0-9.]*\\.xpi$"
 merge_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL" "Thunderbird" "linux_entra_sso-[0-9][0-9.]*\\.thunderbird\\.xpi$"
+# Betterbird is a Thunderbird fork; it does not read /etc/thunderbird/policies.
+merge_mozilla_policy "/etc/betterbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL" "Betterbird" "linux_entra_sso-[0-9][0-9.]*\\.thunderbird\\.xpi$"
+if [ -d /opt/betterbird ]; then
+    merge_mozilla_policy "/opt/betterbird/distribution/policies.json" "$THUNDERBIRD_EXTENSION_URL" "Betterbird" "linux_entra_sso-[0-9][0-9.]*\\.thunderbird\\.xpi$"
+fi
 
 echo "Himmelblau SSO Mozilla policy configuration complete"

--- a/src/sso-policies/scripts/postrm
+++ b/src/sso-policies/scripts/postrm
@@ -53,6 +53,8 @@ case "$1" in
         # Remove Firefox and Thunderbird policies
         remove_mozilla_policy "/etc/firefox/policies/policies.json" "$FIREFOX_EXTENSION_URL"
         remove_mozilla_policy "/etc/thunderbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"
+        remove_mozilla_policy "/etc/betterbird/policies/policies.json" "$THUNDERBIRD_EXTENSION_URL"
+        remove_mozilla_policy "/opt/betterbird/distribution/policies.json" "$THUNDERBIRD_EXTENSION_URL"
 
         echo "Himmelblau SSO Mozilla policy configuration removed"
         ;;


### PR DESCRIPTION
## Summary

Write the linux-entra-sso Thunderbird XPI into Betterbird policy paths. Betterbird does not read `/etc/thunderbird/policies/`, so mail SSO never got the managed extension.

## What Changed

`himmelblau-sso-policies` postinst already merges the Siemens Entra SSO XPI into Firefox and Thunderbird policy files. Betterbird is a Thunderbird fork that looks at `/etc/betterbird/policies/` and, for tarball installs, `<installdir>/distribution/policies.json`.

postinst now merges the same Thunderbird XPI URL into `/etc/betterbird/policies/policies.json`, and into `/opt/betterbird/distribution/policies.json` when `/opt/betterbird` exists. postrm removes both.

Native messaging already allows `@linux-entra-sso.tb`. This only adds the missing policy files.

## Testing

- **Distro(s) tested:** none (no VM run)
- **Steps performed:** inspected postinst/postrm paths against a host with Betterbird at `/opt/betterbird` and a working Thunderbird policy at `/etc/thunderbird/policies/policies.json`.
- **Results observed:** not installed from this branch.

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

Shell maintainer scripts only; `make test` would not exercise them. Did not run a package build.

## System Integration Impact

**SSO policies:** new files under `/etc/betterbird/policies/` and, if present, `/opt/betterbird/distribution/`. If Betterbird is installed *after* this package, reinstall or reconfigure `himmelblau-sso-policies` so the `/opt/betterbird` path is written.

## Checklist

- [ ] I manually tested this change on a test VM
- [x] PR scope is focused and linked to an issue/enhancement/discussion