### PR TITLE
fix(auth): gate Intune MFA resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "libhimmelblau"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6725d119d79d8b91d8d39fae5d003ad2c053bf2081fcb4ca8320516a3ddb9ae"
+checksum = "b07f89d221f4dfd7d17bc5daae33662fe94ab1a726e96104284639b5f1417991"
 dependencies = [
  "base64 0.23.1",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aad-tool"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "broker-client",
@@ -141,7 +141,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apparmor"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "arbitrary"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "dbus",
  "himmelblau_unix_common",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "broker-client"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde_json",
  "zbus",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-fuzz"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "arbitrary",
  "himmelblau_unix_common",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau-orchestrator"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_policies"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblau_unix_common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "himmelblaud"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "idmap"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "murmur3",
  "unicode-normalization",
@@ -3562,7 +3562,7 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nss_himmelblau"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "o365"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "oauth2"
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "pam_himmelblau"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "himmelblau_unix_common",
  "libc",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "qr-greeter"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "qrcodegen"
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "selinux"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "semver"
@@ -5364,11 +5364,11 @@ dependencies = [
 
 [[package]]
 name = "sshd-config"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "sso"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "broker-client",
  "clap",
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "sso-policies"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -10080,9 +10080,9 @@ rec {
       };
       "libhimmelblau" = rec {
         crateName = "libhimmelblau";
-        version = "0.8.38";
+        version = "0.8.40";
         edition = "2021";
-        sha256 = "1bmrvniic19jm16cn7q8y8xhab5d0g8fbyirilfvkn3rkl8mswmn";
+        sha256 = "14br87qvafa650263s96lyqlms9gcqrsxnn5gg8xgpzl4798jzxh";
         libName = "himmelblau";type = [ "rlib" "cdylib" ];
         authors = [
           "David Mulder <dmulder@suse.com>"

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -253,7 +253,7 @@ rec {
     crates = {
       "aad-tool" = rec {
         crateName = "aad-tool";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -664,7 +664,7 @@ rec {
       };
       "apparmor" = rec {
         crateName = "apparmor";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/apparmor; };
         authors = [
@@ -2415,7 +2415,7 @@ rec {
       };
       "broker" = rec {
         crateName = "broker";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -2475,7 +2475,7 @@ rec {
       };
       "broker-client" = rec {
         crateName = "broker-client";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/broker-client; };
         libName = "broker_client";
@@ -7358,7 +7358,7 @@ rec {
       };
       "himmelblau-fuzz" = rec {
         crateName = "himmelblau-fuzz";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -7407,7 +7407,7 @@ rec {
       };
       "himmelblau-orchestrator" = rec {
         crateName = "himmelblau-orchestrator";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -7484,7 +7484,7 @@ rec {
       };
       "himmelblau_policies" = rec {
         crateName = "himmelblau_policies";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/policies; };
         authors = [
@@ -7555,7 +7555,7 @@ rec {
       };
       "himmelblau_unix_common" = rec {
         crateName = "himmelblau_unix_common";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/common; };
         authors = [
@@ -7747,7 +7747,7 @@ rec {
       };
       "himmelblaud" = rec {
         crateName = "himmelblaud";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -9012,7 +9012,7 @@ rec {
       };
       "idmap" = rec {
         crateName = "idmap";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/idmap; };
         authors = [
@@ -11619,7 +11619,7 @@ rec {
       };
       "nss_himmelblau" = rec {
         crateName = "nss_himmelblau";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/nss; };type = [ "cdylib" ];
         authors = [
@@ -11862,7 +11862,7 @@ rec {
       };
       "o365" = rec {
         crateName = "o365";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/o365; };
         authors = [
@@ -13134,7 +13134,7 @@ rec {
       };
       "pam_himmelblau" = rec {
         crateName = "pam_himmelblau";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         links = "pam";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/pam; };type = [ "cdylib" ];
@@ -14322,7 +14322,7 @@ rec {
       };
       "qr-greeter" = rec {
         crateName = "qr-greeter";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/qr-greeter; };
         libName = "qr_greeter";
@@ -16352,7 +16352,7 @@ rec {
       };
       "selinux" = rec {
         crateName = "selinux";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/selinux; };
         authors = [
@@ -17716,7 +17716,7 @@ rec {
       };
       "sshd-config" = rec {
         crateName = "sshd-config";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/sshd-config; };
         libName = "sshd_config";
@@ -17727,7 +17727,7 @@ rec {
       };
       "sso" = rec {
         crateName = "sso";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         crateBin = [
           {
@@ -17774,7 +17774,7 @@ rec {
       };
       "sso-policies" = rec {
         crateName = "sso-policies";
-        version = "4.0.1";
+        version = "4.0.2";
         edition = "2021";
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./src/sso-policies; };
         libName = "sso_policies";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ winnow-0-7-10 = { package = "winnow", path = "src/overrides/winnow/0.7.10" }
 zerocopy-derive-0-8-25 = { package = "zerocopy-derive", path = "src/overrides/zerocopy-derive/0.8.25" }
 
 [workspace.package]
-version = "4.0.1"
+version = "4.0.2"
 authors = [
     "David Mulder <dmulder@suse.com>"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ serde_json = "^1.0.149"
 tracing-subscriber = "^0.3.23"
 tracing = "^0.1.37"
 himmelblau_unix_common = { path = "src/common" }
-libhimmelblau = { version = "0.8.37", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support", "ipvers", "set_timeout"] }
+libhimmelblau = { version = "0.8.40", features = ["broker", "changepassword", "on_behalf_of", "mfa_method_selection", "optional_mfa", "intune_portal_vers_selection", "redirect_uri", "pop_support", "ipvers", "set_timeout"] }
 clap = { version = "^4.6", features = ["derive", "env"] }
 clap_complete = "^4.6.2"
 reqwest = { version = "^0.13.1", features = ["json"] }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -419,11 +419,17 @@ async fn auth(app: &BrokerClientApplication, account_id: &str) -> Option<UserTok
         .as_ref()
         .map(|c| c.get_enable_passwordless())
         .unwrap_or(true);
-    let auth_options = if enable_passwordless {
-        vec![AuthOption::Passwordless]
-    } else {
-        vec![]
-    };
+    let apply_policy = config
+        .as_ref()
+        .map(|c| c.get_apply_policy())
+        .unwrap_or(false);
+    let mut auth_options = vec![];
+    if enable_passwordless {
+        auth_options.push(AuthOption::Passwordless);
+    }
+    if apply_policy {
+        auth_options.push(AuthOption::IntuneEnable);
+    }
     let auth_init = match app.check_user_exists(account_id, &auth_options).await {
         Ok(auth_init) => auth_init,
         Err(e) => {

--- a/src/common/src/idprovider/himmelblau.rs
+++ b/src/common/src/idprovider/himmelblau.rs
@@ -1473,12 +1473,17 @@ impl IdProvider for HimmelblauProvider {
                     Some(_) => return Ok(UserTokenState::UseCached),
                     // Otherwise, see if we should fake it
                     None => {
+                        let apply_policy = self.config.lock().await.get_apply_policy();
+                        let mut auth_options = vec![];
+                        if apply_policy {
+                            auth_options.push(AuthOption::IntuneEnable);
+                        }
                         // Check if the user exists
                         let auth_init = net_down_check!(
                             self.client
                                 .lock()
                                 .await
-                                .check_user_exists(&account_id, &[])
+                                .check_user_exists(&account_id, &auth_options)
                                 .await,
                             Err(e) => {
                                 error!("Failed checking if the user exists: {:?}", e);
@@ -1917,6 +1922,10 @@ impl IdProvider for HimmelblauProvider {
                 if is_remote_service {
                     auth_options.push(AuthOption::RemoteSession);
                 }
+                let apply_policy = self.config.lock().await.get_apply_policy();
+                if apply_policy {
+                    auth_options.push(AuthOption::IntuneEnable);
+                }
 
                 let mut attempts = 0;
                 let auth_init = loop {
@@ -2252,6 +2261,7 @@ impl IdProvider for HimmelblauProvider {
                                 enable_passwordless_qr_bluetooth,
                                 enable_passwordless,
                                 mfa_method,
+                                apply_policy,
                             ) = {
                                 let cfg = self.config.lock().await;
                                 (
@@ -2262,6 +2272,7 @@ impl IdProvider for HimmelblauProvider {
                                     cfg.get_enable_passwordless_qr_bluetooth(),
                                     cfg.get_enable_passwordless(),
                                     cfg.get_mfa_method(),
+                                    cfg.get_apply_policy(),
                                 )
                             };
                             let is_remote_service = service.starts_with("remote:")
@@ -2290,6 +2301,9 @@ impl IdProvider for HimmelblauProvider {
                                 debug!(
                                     "Forcing MFA for device enrollment despite console password-only mode."
                                 );
+                            }
+                            if apply_policy {
+                                auth_options.push(AuthOption::IntuneEnable);
                             }
 
                             let enrollment_cred: Option<String> = $cred;
@@ -2502,6 +2516,7 @@ impl IdProvider for HimmelblauProvider {
                     enable_passwordless_qr_bluetooth,
                     enable_passwordless,
                     mfa_method,
+                    apply_policy,
                 ) = {
                     let cfg = self.config.lock().await;
                     (
@@ -2513,6 +2528,7 @@ impl IdProvider for HimmelblauProvider {
                         cfg.get_enable_passwordless_qr_bluetooth(),
                         cfg.get_enable_passwordless(),
                         cfg.get_mfa_method(),
+                        cfg.get_apply_policy(),
                     )
                 };
                 let is_remote_service = service.starts_with("remote:")
@@ -2544,6 +2560,9 @@ impl IdProvider for HimmelblauProvider {
                     }
                     if is_remote_service {
                         auth_options.push(AuthOption::RemoteSession);
+                    }
+                    if apply_policy {
+                        auth_options.push(AuthOption::IntuneEnable);
                     }
 
                     let flow = match self
@@ -3969,6 +3988,10 @@ impl IdProvider for HimmelblauProvider {
                 };
                 if sfa_enabled {
                     opts.push(AuthOption::NoDAGFallback);
+                }
+                let apply_policy = self.config.lock().await.get_apply_policy();
+                if apply_policy {
+                    opts.push(AuthOption::IntuneEnable);
                 }
 
                 // Call the appropriate method based on whether mfa_method is configured

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -496,8 +496,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.libhimmelblau]]
-version = "0.8.38"
-when = "2026-09-03"
+version = "0.8.40"
+when = "2026-09-04"
 user-id = 247655
 user-login = "dmulder"
 user-name = "David Mulder"


### PR DESCRIPTION
## Summary

Pass the new Intune auth option only when policy application is enabled. This keeps authentication working for tenants where the Intune service principal is disabled while preserving the policy-enabled behavior.

Fixes #1683

## What Changed

<!-- Brief description of the changes -->

## Testing

- **Distro(s) tested:**
- **Steps performed:**
- **Results observed:**

## Automated Checks

- [ ] I ran `make test` (or explained why not)
- [ ] I ran the distro package build target (or explained why not)
- [ ] I ran `make test-selinux` (if applicable)

## System Integration Impact

<!-- If this change affects systemd, PAM/NSS/authselect, SELinux/AppArmor, filesystem paths, or credentials, describe the impact. Write "N/A" if not applicable. -->

## Checklist

- [ ] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
