### PR TITLE
fix(selinux): label the Intune policy cache directory

### DIFF
--- a/src/selinux/scripts/postinst
+++ b/src/selinux/scripts/postinst
@@ -58,6 +58,7 @@ if selinux_configured; then
         [ -d /var/cache/private/himmelblaud ] && restorecon -RFv /var/cache/private/himmelblaud || :
         [ -d /var/cache/himmelblaud ]         && restorecon -RFv /var/cache/himmelblaud || :
         [ -d /var/cache/nss-himmelblau ]      && restorecon -RFv /var/cache/nss-himmelblau || :
+        [ -d /var/cache/himmelblau-policies ] && restorecon -RFv /var/cache/himmelblau-policies || :
         [ -d /var/lib/private/himmelblaud ]   && restorecon -RFv /var/lib/private/himmelblaud || :
         [ -d /var/lib/himmelblaud ]           && restorecon -RFv /var/lib/himmelblaud || :
 

--- a/src/selinux/src/himmelblaud.fc
+++ b/src/selinux/src/himmelblaud.fc
@@ -20,6 +20,9 @@
 # compatibility symlink target (if present)
 /var/cache/himmelblaud(/.*)?            gen_context(system_u:object_r:himmelblau_var_cache_t,s0)
 
+# Intune policy cache (policies_db_path, written by himmelblaud_tasks).
+/var/cache/himmelblau-policies(/.*)?    gen_context(system_u:object_r:himmelblau_var_cache_t,s0)
+
 # NSS side cache (separate type so we can grant `init_t` narrowly)
 /var/cache/nss-himmelblau(/.*)?         gen_context(system_u:object_r:himmelblau_nss_cache_t,s0)
 


### PR DESCRIPTION
## Summary

Fixes missing SELinux context on the himmelblau-policies cache directory.

## What Changed

Added the missing path to `himmelblaud.fc` and to the `restorecon` list in `postinst`.

`policies_db_path`, where himmelblau-tasks' ScriptsCSE saves its policy cache and
downloads custom config scripts to. The existing rule only did `/var/cache/himmelblaud/*`, this now adds `/var/cache/himmelblau-policies/*` as well.

## Testing

- **Distro(s) tested:** Fedora 44
- **Steps performed:** Ran a compliance check before and after installing the rebuilt himmelblau-selinux package
- **Results observed:** Denial is gone, compliance check now works

## Automated Checks

- [x] I ran `make test` (or explained why not)
- [x] I ran the distro package build target (or explained why not) — `make fedora44`
- [x] I ran `make test-selinux` (if applicable) — passed on rocky8, rocky9, rocky10, fedora43, fedora44

## System Integration Impact

SELinux only. Fixes missing context

## Checklist

- [x] I manually tested this change on a test VM
- [ ] PR scope is focused and linked to an issue/enhancement/discussion
